### PR TITLE
docs: Update cargo install to use Git repository instead of crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Claudius is a powerful configuration management tool that helps developers maint
 
 ## Installation
 
-### Using Cargo
+### Using Cargo (from Git)
 
 ```bash
-cargo install claudius
+cargo install --git https://github.com/cariandrum22/claudius
 ```
 
 ### Using Nix Flake


### PR DESCRIPTION
## Summary
- fix cargo install instructions

## Testing
- `cargo fmt --all -- --check`
- `cargo test --quiet` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6884472cdd208326ba9950c476e195dd