### PR TITLE
fix: Remove deprecated darwin.apple_sdk.frameworks dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -342,16 +342,13 @@
               allowBuiltinFetchGit = true;
             };
 
-            buildInputs =
-              with pkgs;
-              [
-                pkg-config
-                openssl
-              ]
-              ++ lib.optionals stdenv.isDarwin [
-                darwin.apple_sdk.frameworks.Security
-                darwin.apple_sdk.frameworks.SystemConfiguration
-              ];
+            # Note: On Darwin, Security and SystemConfiguration frameworks are now
+            # provided automatically by the Darwin stdenv (nixpkgs 25.05+).
+            # See: https://discourse.nixos.org/t/the-darwin-sdks-have-been-updated/55295
+            buildInputs = with pkgs; [
+              pkg-config
+              openssl
+            ];
 
             nativeBuildInputs = [ pkgs.pkg-config ];
 


### PR DESCRIPTION
The darwin.apple_sdk_11_0 and darwin.apple_sdk.frameworks have been removed from nixpkgs unstable (25.05+). Security and SystemConfiguration frameworks are now provided automatically by the Darwin stdenv.

See: https://discourse.nixos.org/t/the-darwin-sdks-have-been-updated/55295
Ref: https://github.com/NixOS/nixpkgs/issues/354146