### PR TITLE
feat: add prune support for synced assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,15 @@ claudius config sync --global
 # Preview changes without writing
 claudius config sync --dry-run
 
+# Preview config and auxiliary file deletions
+claudius config sync --dry-run --prune
+
 # Create backup before syncing
 claudius config sync --backup
+
+# Remove stale skills, Gemini commands, and Claude Code subagents that
+# Claudius previously deployed
+claudius config sync --prune
 
 # Use custom configuration paths
 claudius config sync --config /path/to/servers.json --target-config /path/to/target.json
@@ -307,6 +314,12 @@ claudius skills sync --global
 
 # Sync skills to global ~/.gemini/skills/
 claudius skills sync --global --agent gemini
+
+# Preview skill changes and stale-file removals
+claudius skills sync --dry-run --prune
+
+# Remove stale deployed skill files that Claudius previously published
+claudius skills sync --prune
 
 # Codex skills are experimental and must be explicitly enabled
 # (synced to both .codex/skills and .agents/skills for compatibility)
@@ -554,6 +567,10 @@ Skills are deployed to `~/.claude/skills/` (Claude / Claude Code) or `~/.gemini/
 explicit opt-in; when enabled they are synced to both `~/.codex/skills/` and
 `~/.agents/skills/` for compatibility.
 
+By default, skill and auxiliary file sync is non-destructive. Use `--prune` to remove
+stale files that Claudius previously deployed. Pruning only touches files tracked in
+Claudius-managed target trees and leaves unrelated files alone.
+
 To override a shared skill for a specific agent, place it under
 `~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude, claude-code, gemini, codex).
 
@@ -655,7 +672,8 @@ Features:
 ### Skills
 - All skill directories are synced
 - Existing skills are overwritten
-- Removed source files don't delete deployed skills
+- Removed source files stay deployed unless `--prune` is used
+- `--prune` removes only files previously deployed by Claudius
 
 ## Code Coverage
 

--- a/src/asset_sync.rs
+++ b/src/asset_sync.rs
@@ -1,0 +1,337 @@
+#![allow(missing_docs)]
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MANIFEST_FILE_NAME: &str = ".claudius-managed-files.json";
+const MANIFEST_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceFileMapping {
+    pub source_path: PathBuf,
+    pub relative_path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyncBehavior {
+    pub dry_run: bool,
+    pub prune: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedTreeSyncReport {
+    pub target_dir: PathBuf,
+    pub synced_files: Vec<String>,
+    pub pruned_files: Vec<String>,
+}
+
+impl ManagedTreeSyncReport {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.synced_files.is_empty() && self.pruned_files.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ManagedTreeManifest {
+    #[serde(default = "manifest_version")]
+    version: u8,
+    #[serde(default)]
+    managed_files: BTreeSet<String>,
+}
+
+const fn manifest_version() -> u8 {
+    MANIFEST_VERSION
+}
+
+/// Collect source-to-target mappings for a managed directory tree.
+///
+/// # Errors
+///
+/// Returns an error if the source tree cannot be read or relative paths cannot
+/// be computed.
+pub fn collect_directory_tree_mappings(source_dir: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !source_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut mappings = Vec::new();
+    collect_directory_tree_mappings_recursive(source_dir, source_dir, &mut mappings)?;
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+/// Synchronize a Claudius-managed target tree and optionally prune stale files.
+///
+/// # Errors
+///
+/// Returns an error if files cannot be copied, deleted, or if the manifest
+/// cannot be read or written.
+pub fn sync_managed_tree(
+    target_dir: &Path,
+    mappings: &[SourceFileMapping],
+    behavior: SyncBehavior,
+) -> Result<ManagedTreeSyncReport> {
+    let manifest_path = manifest_path(target_dir);
+    let previous_manifest = read_manifest(&manifest_path)?;
+
+    let synced_files =
+        mappings.iter().map(|mapping| mapping.relative_path.clone()).collect::<Vec<_>>();
+
+    let current_files = synced_files.iter().cloned().collect::<BTreeSet<_>>();
+    let pruned_files = if behavior.prune {
+        previous_manifest
+            .managed_files
+            .difference(&current_files)
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    if !behavior.dry_run {
+        let should_prepare_target =
+            !mappings.is_empty() || !previous_manifest.managed_files.is_empty();
+        if should_prepare_target {
+            fs::create_dir_all(target_dir).with_context(|| {
+                format!("Failed to create target directory: {}", target_dir.display())
+            })?;
+        }
+
+        for mapping in mappings {
+            copy_mapping(target_dir, mapping)?;
+        }
+
+        if behavior.prune {
+            for relative_path in &pruned_files {
+                delete_managed_file(target_dir, relative_path)?;
+            }
+        }
+
+        let next_managed_files = if behavior.prune {
+            current_files
+        } else {
+            previous_manifest.managed_files.union(&current_files).cloned().collect()
+        };
+        write_manifest(&manifest_path, &next_managed_files)?;
+    }
+
+    Ok(ManagedTreeSyncReport { target_dir: target_dir.to_path_buf(), synced_files, pruned_files })
+}
+
+fn collect_directory_tree_mappings_recursive(
+    root_dir: &Path,
+    current_dir: &Path,
+    mappings: &mut Vec<SourceFileMapping>,
+) -> Result<()> {
+    let mut entries = fs::read_dir(current_dir)
+        .with_context(|| format!("Failed to read directory: {}", current_dir.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_directory_tree_mappings_recursive(root_dir, &path, mappings)?;
+            continue;
+        }
+
+        if !path.is_file() {
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root_dir)
+            .with_context(|| format!("Failed to compute relative path for {}", path.display()))?;
+        let relative_path = normalize_relative_path(relative);
+        mappings.push(SourceFileMapping { source_path: path, relative_path });
+    }
+
+    Ok(())
+}
+
+fn copy_mapping(target_dir: &Path, mapping: &SourceFileMapping) -> Result<()> {
+    let destination = target_dir.join(&mapping.relative_path);
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    fs::copy(&mapping.source_path, &destination).with_context(|| {
+        format!(
+            "Failed to copy file from {} to {}",
+            mapping.source_path.display(),
+            destination.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+fn delete_managed_file(target_dir: &Path, relative_path: &str) -> Result<()> {
+    let file_path = target_dir.join(relative_path);
+    match fs::remove_file(&file_path) {
+        Ok(()) => remove_empty_parent_directories(target_dir, &file_path)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+        Err(error) => {
+            return Err(error).with_context(|| format!("Failed to remove {}", file_path.display()));
+        },
+    }
+
+    Ok(())
+}
+
+fn remove_empty_parent_directories(root_dir: &Path, file_path: &Path) -> Result<()> {
+    let mut current = file_path.parent();
+    while let Some(dir) = current {
+        if dir == root_dir {
+            break;
+        }
+
+        match fs::remove_dir(dir) {
+            Ok(()) => current = dir.parent(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => current = dir.parent(),
+            Err(error) if error.kind() == std::io::ErrorKind::DirectoryNotEmpty => break,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to remove directory {}", dir.display()));
+            },
+        }
+    }
+
+    Ok(())
+}
+
+fn read_manifest(manifest_path: &Path) -> Result<ManagedTreeManifest> {
+    if !manifest_path.exists() {
+        return Ok(ManagedTreeManifest::default());
+    }
+
+    let content = fs::read_to_string(manifest_path)
+        .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+    let manifest: ManagedTreeManifest = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+
+    Ok(manifest)
+}
+
+fn write_manifest(manifest_path: &Path, managed_files: &BTreeSet<String>) -> Result<()> {
+    if managed_files.is_empty() {
+        match fs::remove_file(manifest_path) {
+            Ok(()) => {},
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to remove {}", manifest_path.display()));
+            },
+        }
+        return Ok(());
+    }
+
+    if let Some(parent) = manifest_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    let manifest =
+        ManagedTreeManifest { version: MANIFEST_VERSION, managed_files: managed_files.clone() };
+    let content =
+        serde_json::to_string_pretty(&manifest).context("Failed to serialize sync manifest")?;
+    fs::write(manifest_path, format!("{content}\n"))
+        .with_context(|| format!("Failed to write {}", manifest_path.display()))?;
+
+    Ok(())
+}
+
+fn manifest_path(target_dir: &Path) -> PathBuf {
+    target_dir.join(MANIFEST_FILE_NAME)
+}
+
+fn normalize_relative_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sync_managed_tree_records_manifest_without_pruning() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::write(source_dir.join("a.txt"), "alpha").expect("write source file");
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        let report = sync_managed_tree(
+            &target_dir,
+            &mappings,
+            SyncBehavior { dry_run: false, prune: false },
+        )
+        .expect("sync should succeed");
+
+        assert_eq!(report.synced_files, vec!["a.txt".to_string()]);
+        assert!(report.pruned_files.is_empty());
+        assert!(target_dir.join("a.txt").exists());
+        assert!(target_dir.join(MANIFEST_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn sync_managed_tree_prunes_only_manifested_files() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::create_dir_all(target_dir.join("manual")).expect("create manual dir");
+        fs::write(source_dir.join("keep.txt"), "keep").expect("write source file");
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: false })
+            .expect("initial sync should succeed");
+
+        fs::write(target_dir.join("old.txt"), "old").expect("write old file");
+        fs::write(target_dir.join("manual").join("note.txt"), "manual").expect("write note");
+        write_manifest(
+            &manifest_path(&target_dir),
+            &BTreeSet::from(["keep.txt".to_string(), "old.txt".to_string()]),
+        )
+        .expect("write manifest");
+
+        let report =
+            sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: true })
+                .expect("prune sync should succeed");
+
+        assert_eq!(report.pruned_files, vec!["old.txt".to_string()]);
+        assert!(target_dir.join("keep.txt").exists());
+        assert!(!target_dir.join("old.txt").exists());
+        assert!(target_dir.join("manual").join("note.txt").exists());
+    }
+
+    #[test]
+    fn sync_managed_tree_dry_run_does_not_modify_target() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::write(source_dir.join("new.txt"), "new").expect("write source file");
+        fs::create_dir_all(&target_dir).expect("create target");
+        fs::write(target_dir.join("old.txt"), "old").expect("write target file");
+        write_manifest(&manifest_path(&target_dir), &BTreeSet::from(["old.txt".to_string()]))
+            .expect("write manifest");
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        let report =
+            sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: true, prune: true })
+                .expect("dry-run sync should succeed");
+
+        assert_eq!(report.synced_files, vec!["new.txt".to_string()]);
+        assert_eq!(report.pruned_files, vec!["old.txt".to_string()]);
+        assert!(target_dir.join("old.txt").exists());
+        assert!(!target_dir.join("new.txt").exists());
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,6 +329,13 @@ pub struct ConfigSyncArgs {
     )]
     pub backup: bool,
 
+    /// Remove stale auxiliary files that Claudius previously deployed
+    #[arg(
+        long,
+        help = "Remove stale skills, commands, and subagents previously deployed by Claudius"
+    )]
+    pub prune: bool,
+
     /// Override target configuration file path
     #[arg(short = 'T', long, env = "TARGET_CONFIG_PATH", value_hint = clap::ValueHint::FilePath)]
     pub target_config: Option<PathBuf>,
@@ -396,6 +403,14 @@ pub struct SkillsSyncArgs {
         help = "Target system-wide skills directory instead of project-local skills directory"
     )]
     pub global: bool,
+
+    /// Preview skill sync changes without writing them
+    #[arg(short, long, help = "Preview skill sync changes without writing them")]
+    pub dry_run: bool,
+
+    /// Remove stale deployed skill files that Claudius previously published
+    #[arg(long, help = "Remove stale deployed skill files previously published by Claudius")]
+    pub prune: bool,
 
     /// Specify the agent (defaults to Claude)
     #[arg(short, long, value_enum, help = "Agent to use: claude, claude-code, codex, or gemini")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,23 +253,21 @@ impl Config {
         fs::read_dir(path).map(|mut entries| entries.next().is_some()).unwrap_or(false)
     }
 
-    fn agent_skills_subdir(agent: crate::app_config::Agent) -> Option<&'static str> {
+    fn agent_skills_subdir(agent: crate::app_config::Agent) -> &'static str {
         match agent {
-            crate::app_config::Agent::Claude => Some("claude"),
-            crate::app_config::Agent::ClaudeCode => Some("claude-code"),
-            crate::app_config::Agent::Codex => Some("codex"),
-            crate::app_config::Agent::Gemini => Some("gemini"),
+            crate::app_config::Agent::Claude => "claude",
+            crate::app_config::Agent::ClaudeCode => "claude-code",
+            crate::app_config::Agent::Codex => "codex",
+            crate::app_config::Agent::Gemini => "gemini",
         }
     }
 
     #[must_use]
     pub fn resolve_skills_source_dir(&self) -> Option<PathBuf> {
         if let Some(agent) = self.agent {
-            if let Some(subdir) = Self::agent_skills_subdir(agent) {
-                let candidate = self.skills_dir.join(subdir);
-                if candidate.exists() && Self::skills_dir_has_entries(&candidate) {
-                    return Some(candidate);
-                }
+            let candidate = self.skills_dir.join(Self::agent_skills_subdir(agent));
+            if candidate.exists() && Self::skills_dir_has_entries(&candidate) {
+                return Some(candidate);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod agent_paths;
 pub mod app_config;
+pub mod asset_sync;
 pub mod bootstrap;
 pub mod cli;
 pub mod codex_settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,15 +7,16 @@ use claudius::profiling::profile_flamegraph;
 use claudius::{
     agent_paths,
     app_config::AppConfig,
+    asset_sync::SyncBehavior,
     bootstrap,
     cli::{self, Cli},
     config::{reader, Config},
     secrets::SecretResolver,
     skills,
     sync_operations::{
-        determine_agent, handle_backup, handle_dry_run, merge_all_configs, read_configurations,
-        sync_supporting_assets_if_exists, write_configurations, AgentContext,
-        CodexGlobalSyncOptions,
+        determine_agent, handle_backup, handle_dry_run, merge_all_configs,
+        print_supporting_assets_dry_run, read_configurations, sync_supporting_assets,
+        write_configurations, AgentContext, CodexGlobalSyncOptions,
     },
     template::{
         append_rules_to_context_file, append_template_to_context_file, ensure_rules_directory,
@@ -205,7 +206,7 @@ fn run_init(force: bool, app_config: Option<&AppConfig>) -> Result<()> {
 }
 
 fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) -> Result<()> {
-    let cli::SkillsSyncArgs { global, agent, enable_codex_skills } = args;
+    let cli::SkillsSyncArgs { global, agent, enable_codex_skills, dry_run, prune } = args;
 
     let effective_agent = determine_agent(agent, app_config);
 
@@ -216,7 +217,14 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
 
     let config = Config::new_with_agent(global, effective_agent)?;
     let Some(source_dir) = config.resolve_skills_source_dir() else {
-        println!("No skills to sync");
+        let skill_targets = determine_skill_sync_targets(&config)?;
+        let reports = skill_targets
+            .iter()
+            .map(|target_dir| {
+                skills::sync_skills_with_options(None, target_dir, SyncBehavior { dry_run, prune })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        print_skill_sync_result(&reports, dry_run);
         return Ok(());
     };
 
@@ -228,37 +236,19 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
     }
 
     let skill_targets = determine_skill_sync_targets(&config)?;
-    let mut synced_skills = Vec::new();
-    for (index, target_dir) in skill_targets.iter().enumerate() {
-        match skills::sync_skills(&source_dir, target_dir) {
-            Ok(synced) if index == 0 => synced_skills = synced,
-            Ok(_) => {},
-            Err(e) => {
-                error!("Failed to sync skills: {e:#}");
-                std::process::exit(1);
-            },
-        }
-    }
+    let reports = skill_targets
+        .iter()
+        .map(|target_dir| {
+            skills::sync_skills_with_options(
+                Some(&source_dir),
+                target_dir,
+                SyncBehavior { dry_run, prune },
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
 
-    match synced_skills.is_empty() {
-        true => {
-            println!("No skills to sync");
-            Ok(())
-        },
-        false => {
-            println!("Successfully synced {} skill(s):", synced_skills.len());
-            for skill in &synced_skills {
-                println!("  - {skill}");
-            }
-            if skill_targets.len() > 1 {
-                println!("Published to:");
-                for target_dir in &skill_targets {
-                    println!("  - {}", target_dir.display());
-                }
-            }
-            Ok(())
-        },
-    }
+    print_skill_sync_result(&reports, dry_run);
+    Ok(())
 }
 
 fn determine_skill_sync_targets(config: &Config) -> Result<Vec<std::path::PathBuf>> {
@@ -286,6 +276,7 @@ fn build_sync_options(
         config,
         dry_run,
         backup,
+        prune,
         target_config,
         global,
         agent,
@@ -329,6 +320,7 @@ fn build_sync_options(
         target_config_path: effective_target_config,
         dry_run,
         backup,
+        prune,
         global: effective_global,
         agent_override: agent,
         claude_code_scope: scope,
@@ -851,6 +843,7 @@ struct SyncOptions {
     target_config_path: Option<std::path::PathBuf>,
     dry_run: bool,
     backup: bool,
+    prune: bool,
     global: bool,
     agent_override: Option<claudius::app_config::Agent>,
     claude_code_scope: Option<claudius::app_config::ClaudeCodeScope>,
@@ -890,6 +883,7 @@ fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()>
         let flags = SyncExecutionFlags {
             backup: options.backup,
             dry_run: options.dry_run,
+            prune: options.prune,
             codex_global: CodexGlobalSyncOptions {
                 requirements: options.codex_requirements,
                 managed_config: options.codex_managed_config,
@@ -909,7 +903,11 @@ fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfi
         warn!("No agent configuration files found in config directory");
         // Still sync skills if they exist
         let config = Config::new_with_agent(true, None)?;
-        sync_supporting_assets_if_exists(&config, AgentContext::new(None, None));
+        let _ = sync_supporting_assets(
+            &config,
+            AgentContext::new(None, None),
+            SyncBehavior { dry_run: options.dry_run, prune: options.prune },
+        );
         return Ok(());
     }
 
@@ -946,6 +944,7 @@ fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfi
         let flags = SyncExecutionFlags {
             backup: options.backup,
             dry_run: options.dry_run,
+            prune: options.prune,
             codex_global: CodexGlobalSyncOptions::default(),
         };
 
@@ -1022,6 +1021,7 @@ fn log_sync_paths(paths: &SyncPaths, global: bool, config: &Config) {
 struct SyncExecutionFlags {
     backup: bool,
     dry_run: bool,
+    prune: bool,
     codex_global: CodexGlobalSyncOptions,
 }
 
@@ -1058,6 +1058,11 @@ fn execute_sync_operation(
 
     // Output results
     if flags.dry_run {
+        let supporting_assets = sync_supporting_assets(
+            config,
+            agent_context,
+            SyncBehavior { dry_run: true, prune: flags.prune },
+        );
         handle_dry_run(
             config,
             &paths.target_config,
@@ -1065,7 +1070,8 @@ fn execute_sync_operation(
             &read_result,
             agent_context,
             flags.codex_global,
-        )
+        )?;
+        print_supporting_assets_dry_run(&supporting_assets);
     } else {
         write_configurations(
             config,
@@ -1075,8 +1081,79 @@ fn execute_sync_operation(
             agent_context,
             flags.codex_global,
         )?;
-        sync_supporting_assets_if_exists(config, agent_context);
-        Ok(())
+        let _ = sync_supporting_assets(
+            config,
+            agent_context,
+            SyncBehavior { dry_run: false, prune: flags.prune },
+        );
+    }
+
+    Ok(())
+}
+
+fn print_skill_sync_result(reports: &[skills::SkillSyncReport], dry_run: bool) {
+    if reports.iter().all(skills::SkillSyncReport::is_empty) {
+        println!("No skills to sync");
+        return;
+    }
+
+    if dry_run {
+        print_skill_sync_dry_run(reports);
+        return;
+    }
+
+    print_skill_sync_summary(reports);
+}
+
+fn print_skill_sync_dry_run(reports: &[skills::SkillSyncReport]) {
+    println!("Dry run mode - not writing changes");
+    for report in reports {
+        if report.is_empty() {
+            continue;
+        }
+
+        println!("\n--- Skills ({}) ---", report.target_dir.display());
+        if !report.synced_skills.is_empty() {
+            println!("Would sync {} skill(s):", report.synced_skills.len());
+            for skill in &report.synced_skills {
+                println!("  + {skill}");
+            }
+        }
+        if !report.pruned_files.is_empty() {
+            println!("Would prune {} stale file(s):", report.pruned_files.len());
+            for path in &report.pruned_files {
+                println!("  - {path}");
+            }
+        }
+    }
+}
+
+fn print_skill_sync_summary(reports: &[skills::SkillSyncReport]) {
+    let synced_skills =
+        reports.first().map_or_else(Vec::new, |report| report.synced_skills.clone());
+    if !synced_skills.is_empty() {
+        println!("Successfully synced {} skill(s):", synced_skills.len());
+        for skill in &synced_skills {
+            println!("  - {skill}");
+        }
+    }
+
+    for report in reports.iter().filter(|report| !report.pruned_files.is_empty()) {
+        println!(
+            "Pruned {} stale skill file(s) from {}:",
+            report.pruned_files.len(),
+            report.target_dir.display()
+        );
+        for path in &report.pruned_files {
+            println!("  - {path}");
+        }
+    }
+
+    if reports.len() > 1 {
+        println!("Published to:");
+        for report in reports {
+            println!("  - {}", report.target_dir.display());
+        }
     }
 }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -82,12 +82,14 @@ impl SecretResolver {
     fn extract_first_op_reference(value: &str) -> Option<String> {
         if let Some(start_pos) = value.find("{{op://") {
             let op_ref_start = start_pos.saturating_add(2);
-            if let Some(search_area) = value.get(op_ref_start..) {
-                if let Some(end_pos) = search_area.find("}}") {
-                    if let Some(op_ref) = search_area.get(..end_pos) {
-                        return Some(op_ref.to_string());
-                    }
-                }
+            let inline_reference = value
+                .get(op_ref_start..)
+                .and_then(|search_area| {
+                    search_area.find("}}").and_then(|end_pos| search_area.get(..end_pos))
+                })
+                .map(str::to_string);
+            if inline_reference.is_some() {
+                return inline_reference;
             }
         }
 
@@ -314,17 +316,19 @@ impl SecretResolver {
         }
 
         let op_ref_lock = {
-            let mut locks = self.op_ref_locks.lock().unwrap_or_else(|e| e.into_inner());
+            let mut locks =
+                self.op_ref_locks.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             locks
                 .entry(op_ref.to_string())
                 .or_insert_with(|| Arc::new(Mutex::new(())))
                 .clone()
         };
-        let _guard = op_ref_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = op_ref_lock.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
 
         // Re-check cache after waiting for any in-flight resolution of the same reference.
-        let cached = cache.lock().map_or(None, |cache_guard| cache_guard.get(op_ref).cloned());
-        if let Some(cached_value) = cached {
+        let cached_after_wait =
+            cache.lock().map_or(None, |cache_guard| cache_guard.get(op_ref).cloned());
+        if let Some(cached_value) = cached_after_wait {
             debug!("Using cached value for {}", op_ref);
             return cached_value;
         }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,9 +1,25 @@
+use crate::asset_sync::{self, ManagedTreeSyncReport, SourceFileMapping, SyncBehavior};
 use anyhow::{Context, Result};
 use std::collections::BTreeSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const SKILL_FILE_NAME: &str = "SKILL.md";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillSyncReport {
+    pub target_dir: PathBuf,
+    pub synced_skills: Vec<String>,
+    pub synced_files: Vec<String>,
+    pub pruned_files: Vec<String>,
+}
+
+impl SkillSyncReport {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.synced_files.is_empty() && self.pruned_files.is_empty()
+    }
+}
 
 /// Sync skills from source to target directory.
 ///
@@ -18,57 +34,35 @@ const SKILL_FILE_NAME: &str = "SKILL.md";
 /// - Unable to read the source directory
 /// - Unable to copy skill files
 pub fn sync_skills(source_dir: &Path, target_dir: &Path) -> Result<Vec<String>> {
-    // Ensure target directory exists
     fs::create_dir_all(target_dir)
         .with_context(|| format!("Failed to create target directory: {}", target_dir.display()))?;
 
-    if !source_dir.exists() {
-        return Ok(Vec::new());
-    }
+    let report = sync_skills_with_options(
+        Some(source_dir),
+        target_dir,
+        SyncBehavior { dry_run: false, prune: false },
+    )?;
 
-    let entries = fs::read_dir(source_dir)
-        .with_context(|| format!("Failed to read skills directory: {}", source_dir.display()))?;
+    Ok(report.synced_skills)
+}
 
-    let mut synced_skills = BTreeSet::new();
+/// Sync skills with optional dry-run and pruning behavior.
+///
+/// # Errors
+///
+/// Returns an error if the source tree cannot be read, files cannot be copied,
+/// or the managed-file manifest cannot be updated.
+pub fn sync_skills_with_options(
+    source_dir_opt: Option<&Path>,
+    target_dir: &Path,
+    behavior: SyncBehavior,
+) -> Result<SkillSyncReport> {
+    let mappings = collect_skill_mappings(source_dir_opt)?;
+    let synced_skills = skill_names_from_mappings(&mappings);
+    let ManagedTreeSyncReport { target_dir: synced_target_dir, synced_files, pruned_files } =
+        asset_sync::sync_managed_tree(target_dir, &mappings, behavior)?;
 
-    for entry in entries {
-        let dir_entry = entry?;
-        let path = dir_entry.path();
-
-        if path.is_dir() {
-            let skill_name = dir_entry
-                .file_name()
-                .to_str()
-                .ok_or_else(|| anyhow::anyhow!("Invalid skill directory name"))?
-                .to_string();
-
-            let target_skill_dir = target_dir.join(&skill_name);
-            copy_dir_recursive(&path, &target_skill_dir)?;
-            synced_skills.insert(skill_name);
-            continue;
-        }
-
-        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("md") {
-            let skill_name = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?;
-
-            let target_skill_dir = target_dir.join(skill_name);
-            fs::create_dir_all(&target_skill_dir).with_context(|| {
-                format!("Failed to create skill directory: {}", target_skill_dir.display())
-            })?;
-
-            let target_path = target_skill_dir.join(SKILL_FILE_NAME);
-            fs::copy(&path, &target_path).with_context(|| {
-                format!("Failed to copy skill from {} to {}", path.display(), target_path.display())
-            })?;
-
-            synced_skills.insert(skill_name.to_string());
-        }
-    }
-
-    Ok(synced_skills.into_iter().collect())
+    Ok(SkillSyncReport { target_dir: synced_target_dir, synced_skills, synced_files, pruned_files })
 }
 
 /// List all skills in a directory.
@@ -122,27 +116,71 @@ pub fn ensure_skills_directory(skills_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
-    fs::create_dir_all(target)
-        .with_context(|| format!("Failed to create directory: {}", target.display()))?;
+/// Collect source-to-target mappings for skill deployment.
+///
+/// # Errors
+///
+/// Returns an error if the source tree cannot be read or if a skill name cannot
+/// be derived from the source path.
+pub fn collect_skill_mappings(source_dir_opt: Option<&Path>) -> Result<Vec<SourceFileMapping>> {
+    let Some(source_dir) = source_dir_opt else {
+        return Ok(Vec::new());
+    };
 
-    for entry in fs::read_dir(source)
-        .with_context(|| format!("Failed to read directory: {}", source.display()))?
-    {
-        let dir_entry = entry?;
-        let path = dir_entry.path();
-        let target_path = target.join(dir_entry.file_name());
+    if !source_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = fs::read_dir(source_dir)
+        .with_context(|| format!("Failed to read skills directory: {}", source_dir.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut mappings = Vec::new();
+
+    for entry in entries {
+        let path = entry.path();
 
         if path.is_dir() {
-            copy_dir_recursive(&path, &target_path)?;
-        } else if path.is_file() {
-            fs::copy(&path, &target_path).with_context(|| {
-                format!("Failed to copy file from {} to {}", path.display(), target_path.display())
-            })?;
+            let skill_name = entry
+                .file_name()
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid skill directory name"))?
+                .to_string();
+            let skill_files = asset_sync::collect_directory_tree_mappings(&path)?;
+            mappings.extend(skill_files.into_iter().map(|mapping| SourceFileMapping {
+                source_path: mapping.source_path,
+                relative_path: normalize_skill_relative_path(&skill_name, &mapping.relative_path),
+            }));
+            continue;
+        }
+
+        if path.is_file() && path.extension().and_then(|value| value.to_str()) == Some("md") {
+            let skill_name = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?;
+            let relative_path = normalize_skill_relative_path(skill_name, SKILL_FILE_NAME);
+
+            mappings.push(SourceFileMapping { source_path: path, relative_path });
         }
     }
 
-    Ok(())
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+fn skill_names_from_mappings(mappings: &[SourceFileMapping]) -> Vec<String> {
+    mappings
+        .iter()
+        .filter_map(|mapping| mapping.relative_path.split('/').next().map(str::to_string))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn normalize_skill_relative_path(skill_name: &str, suffix: &str) -> String {
+    format!("{skill_name}/{}", suffix.replace('\\', "/"))
 }
 
 #[cfg(test)]
@@ -203,6 +241,61 @@ mod tests {
         let content = fs::read_to_string(target_skill.join(SKILL_FILE_NAME))
             .expect("Failed to read SKILL.md");
         assert_eq!(content, "# Command 1");
+    }
+
+    #[test]
+    fn test_collect_skill_mappings_supports_directory_and_legacy_sources() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let source_dir = temp_dir.path().join("source");
+        let skill_dir = source_dir.join("review");
+        fs::create_dir_all(skill_dir.join("prompts")).expect("Failed to create prompts dir");
+        fs::write(skill_dir.join(SKILL_FILE_NAME), "# Review Skill")
+            .expect("Failed to write SKILL.md");
+        fs::write(skill_dir.join("prompts").join("summary.txt"), "Summarize")
+            .expect("Failed to write summary.txt");
+        fs::write(source_dir.join("legacy.md"), "# Legacy Skill").expect("Failed to write legacy");
+
+        let mappings = collect_skill_mappings(Some(&source_dir)).expect("collect mappings");
+        let relative_paths =
+            mappings.iter().map(|mapping| mapping.relative_path.clone()).collect::<Vec<_>>();
+
+        assert_eq!(
+            relative_paths,
+            vec![
+                "legacy/SKILL.md".to_string(),
+                "review/SKILL.md".to_string(),
+                "review/prompts/summary.txt".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_sync_skills_with_options_prunes_removed_skill_files() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        let review_dir = source_dir.join("review");
+        fs::create_dir_all(&review_dir).expect("Failed to create review dir");
+        fs::write(review_dir.join(SKILL_FILE_NAME), "# Review Skill")
+            .expect("Failed to write SKILL.md");
+
+        sync_skills_with_options(
+            Some(&source_dir),
+            &target_dir,
+            SyncBehavior { dry_run: false, prune: false },
+        )
+        .expect("initial sync should succeed");
+
+        fs::remove_dir_all(&review_dir).expect("Failed to remove review dir");
+        let report = sync_skills_with_options(
+            Some(&source_dir),
+            &target_dir,
+            SyncBehavior { dry_run: false, prune: true },
+        )
+        .expect("prune sync should succeed");
+
+        assert_eq!(report.pruned_files, vec!["review/SKILL.md".to_string()]);
+        assert!(!target_dir.join("review").exists());
     }
 
     #[test]

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -2,6 +2,7 @@
 
 use crate::agent_paths;
 use crate::app_config::{Agent, AppConfig, ClaudeCodeScope};
+use crate::asset_sync::{self, SyncBehavior};
 use crate::codex_settings::{convert_mcp_to_toml, CodexSettings, ModelProvider};
 use crate::config::{reader, writer, ClaudeConfig, Config, McpServersConfig, Settings};
 use crate::json_merge::deep_merge_json_maps;
@@ -11,7 +12,6 @@ use crate::validation::{pre_validate_settings, prompt_continue};
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 use toml::Value as TomlValue;
 use tracing::{debug, info, warn};
@@ -41,6 +41,39 @@ pub struct ReadConfigResult {
 pub struct CodexGlobalSyncOptions {
     pub requirements: bool,
     pub managed_config: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SupportingAssetSyncReport {
+    pub assets: Vec<SupportingAssetReport>,
+}
+
+impl SupportingAssetSyncReport {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.assets.is_empty()
+    }
+
+    fn push(&mut self, asset: SupportingAssetReport) {
+        if !asset.is_empty() {
+            self.assets.push(asset);
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SupportingAssetReport {
+    pub label: &'static str,
+    pub target_dir: PathBuf,
+    pub synced_files: Vec<String>,
+    pub pruned_files: Vec<String>,
+}
+
+impl SupportingAssetReport {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.synced_files.is_empty() && self.pruned_files.is_empty()
+    }
 }
 
 /// Agent context for sync operation
@@ -570,6 +603,30 @@ fn print_gemini_dry_run(claude_config: &ClaudeConfig) -> Result<()> {
     println!("\n--- Gemini settings (.gemini/settings.json) ---");
     println!("{}", serde_json::to_string_pretty(&claude_config)?);
     Ok(())
+}
+
+pub fn print_supporting_assets_dry_run(report: &SupportingAssetSyncReport) {
+    if report.is_empty() {
+        return;
+    }
+
+    for asset in &report.assets {
+        println!("\n--- {} ({}) ---", asset.label, asset.target_dir.display());
+
+        if !asset.synced_files.is_empty() {
+            println!("Would sync {} file(s):", asset.synced_files.len());
+            for path in &asset.synced_files {
+                println!("  + {path}");
+            }
+        }
+
+        if !asset.pruned_files.is_empty() {
+            println!("Would prune {} stale file(s):", asset.pruned_files.len());
+            for path in &asset.pruned_files {
+                println!("  - {path}");
+            }
+        }
+    }
 }
 
 fn print_claude_code_global_dry_run(
@@ -1391,16 +1448,35 @@ fn deep_merge_toml_value(target: &mut TomlValue, overlay: &TomlValue) {
 }
 
 /// Sync skills and other agent-specific auxiliary content.
-pub fn sync_supporting_assets_if_exists(config: &Config, agent_context: AgentContext) {
-    sync_skills_if_exists(config, agent_context);
-    sync_gemini_commands_if_exists(config);
-    sync_claude_code_agents_if_exists(config, agent_context);
+#[must_use]
+pub fn sync_supporting_assets(
+    config: &Config,
+    agent_context: AgentContext,
+    behavior: SyncBehavior,
+) -> SupportingAssetSyncReport {
+    let mut report = SupportingAssetSyncReport::default();
+
+    if let Some(asset) = sync_skills_if_exists(config, agent_context, behavior) {
+        report.push(asset);
+    }
+    if let Some(asset) = sync_gemini_commands_if_exists(config, behavior) {
+        report.push(asset);
+    }
+    if let Some(asset) = sync_claude_code_agents_if_exists(config, agent_context, behavior) {
+        report.push(asset);
+    }
+
+    report
 }
 
-fn sync_skills_if_exists(config: &Config, agent_context: AgentContext) {
+fn sync_skills_if_exists(
+    config: &Config,
+    agent_context: AgentContext,
+    behavior: SyncBehavior,
+) -> Option<SupportingAssetReport> {
     if config.agent == Some(Agent::Codex) {
         debug!("Skipping Codex skills sync (experimental; use `claudius skills sync --enable-codex-skills`)");
-        return;
+        return None;
     }
 
     if agent_context.is_claude_code
@@ -1410,145 +1486,169 @@ fn sync_skills_if_exists(config: &Config, agent_context: AgentContext) {
         )
     {
         debug!("Skipping Claude Code skills sync for managed/local scope");
-        return;
+        return None;
     }
 
-    let Some(source_dir) = config.resolve_skills_source_dir() else {
-        return;
-    };
+    let source_dir = config.resolve_skills_source_dir();
 
-    if source_dir != config.skills_dir {
-        warn!("Legacy commands directory detected; syncing skills from {}", source_dir.display());
+    if let Some(path) = source_dir.as_ref().filter(|path| **path != config.skills_dir) {
+        warn!("Legacy commands directory detected; syncing skills from {}", path.display());
     }
 
     debug!("Syncing skills");
-    debug!("Source: {}", source_dir.display());
+    if let Some(path) = &source_dir {
+        debug!("Source: {}", path.display());
+    }
     debug!("Target: {}", config.skills_target_dir.display());
 
-    match skills::sync_skills(&source_dir, &config.skills_target_dir) {
-        Ok(synced) => {
-            if !synced.is_empty() {
-                info!("Synced {} skill(s)", synced.len());
-                for skill in &synced {
-                    debug!("  - {}", skill);
-                }
-            }
+    match skills::sync_skills_with_options(
+        source_dir.as_deref(),
+        &config.skills_target_dir,
+        behavior,
+    ) {
+        Ok(sync_report) => {
+            log_supporting_asset_result(
+                "skill",
+                &sync_report.synced_files,
+                &sync_report.pruned_files,
+                behavior.dry_run,
+            );
+            Some(SupportingAssetReport {
+                label: "Skills",
+                target_dir: sync_report.target_dir,
+                synced_files: sync_report.synced_files,
+                pruned_files: sync_report.pruned_files,
+            })
         },
         Err(e) => {
             warn!("Failed to sync skills: {}", e);
+            None
         },
     }
 }
 
-fn sync_gemini_commands_if_exists(config: &Config) {
-    let Some(source_dir) = config.resolve_gemini_commands_source_dir() else {
-        return;
-    };
-
+fn sync_gemini_commands_if_exists(
+    config: &Config,
+    behavior: SyncBehavior,
+) -> Option<SupportingAssetReport> {
+    let source_dir = config.resolve_gemini_commands_source_dir();
     let target_dir = match config.gemini_commands_target_dir() {
         Ok(Some(path)) => path,
-        Ok(None) => return,
+        Ok(None) => return None,
         Err(e) => {
             warn!("Failed to determine Gemini commands target directory: {}", e);
-            return;
+            return None;
         },
     };
 
-    sync_directory_tree_if_exists("Gemini command", &source_dir, &target_dir);
+    sync_directory_tree_if_exists(
+        "Gemini command",
+        "Gemini commands",
+        source_dir.as_deref(),
+        &target_dir,
+        behavior,
+    )
 }
 
-fn sync_claude_code_agents_if_exists(config: &Config, agent_context: AgentContext) {
+fn sync_claude_code_agents_if_exists(
+    config: &Config,
+    agent_context: AgentContext,
+    behavior: SyncBehavior,
+) -> Option<SupportingAssetReport> {
     if !agent_context.is_claude_code
         || matches!(
             agent_context.claude_code_scope,
             Some(ClaudeCodeScope::Managed | ClaudeCodeScope::Local)
         )
     {
-        return;
+        return None;
     }
 
-    let Some(source_dir) = config.resolve_claude_code_agents_source_dir() else {
-        return;
-    };
-
+    let source_dir = config.resolve_claude_code_agents_source_dir();
     let target_dir = match config.claude_code_agents_target_dir() {
         Ok(Some(path)) => path,
-        Ok(None) => return,
+        Ok(None) => return None,
         Err(e) => {
             warn!("Failed to determine Claude Code agents target directory: {}", e);
-            return;
+            return None;
         },
     };
 
-    sync_directory_tree_if_exists("Claude Code subagent", &source_dir, &target_dir);
+    sync_directory_tree_if_exists(
+        "Claude Code subagent",
+        "Claude Code subagents",
+        source_dir.as_deref(),
+        &target_dir,
+        behavior,
+    )
 }
 
-fn sync_directory_tree_if_exists(label: &str, source_dir: &Path, target_dir: &Path) {
-    debug!("Syncing {label}s");
-    debug!("Source: {}", source_dir.display());
+fn sync_directory_tree_if_exists(
+    log_label: &str,
+    report_label: &'static str,
+    source_dir: Option<&Path>,
+    target_dir: &Path,
+    behavior: SyncBehavior,
+) -> Option<SupportingAssetReport> {
+    debug!("Syncing {log_label}s");
+    if let Some(path) = source_dir {
+        debug!("Source: {}", path.display());
+    }
     debug!("Target: {}", target_dir.display());
 
-    match sync_directory_tree(source_dir, target_dir) {
-        Ok(synced) => {
-            if !synced.is_empty() {
-                info!("Synced {} {} file(s)", synced.len(), label);
-                for entry in &synced {
-                    debug!("  - {}", entry);
-                }
-            }
+    match sync_directory_tree(source_dir, target_dir, behavior) {
+        Ok(sync_report) => {
+            log_supporting_asset_result(
+                log_label,
+                &sync_report.synced_files,
+                &sync_report.pruned_files,
+                behavior.dry_run,
+            );
+            Some(SupportingAssetReport {
+                label: report_label,
+                target_dir: sync_report.target_dir,
+                synced_files: sync_report.synced_files,
+                pruned_files: sync_report.pruned_files,
+            })
         },
-        Err(e) => warn!("Failed to sync {label}s: {}", e),
+        Err(e) => {
+            warn!("Failed to sync {log_label}s: {}", e);
+            None
+        },
     }
 }
 
-fn sync_directory_tree(source_dir: &Path, target_dir: &Path) -> Result<Vec<String>> {
-    fs::create_dir_all(target_dir)
-        .with_context(|| format!("Failed to create target directory: {}", target_dir.display()))?;
-
-    if !source_dir.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut synced = Vec::new();
-    sync_directory_tree_recursive(source_dir, source_dir, target_dir, &mut synced)?;
-    synced.sort();
-    Ok(synced)
-}
-
-fn sync_directory_tree_recursive(
-    root_dir: &Path,
-    current_dir: &Path,
+fn sync_directory_tree(
+    source_dir: Option<&Path>,
     target_dir: &Path,
-    synced: &mut Vec<String>,
-) -> Result<()> {
-    for entry in fs::read_dir(current_dir)
-        .with_context(|| format!("Failed to read directory: {}", current_dir.display()))?
-    {
-        let dir_entry = entry?;
-        let path = dir_entry.path();
-        let relative = path
-            .strip_prefix(root_dir)
-            .with_context(|| format!("Failed to compute relative path for {}", path.display()))?;
-        let destination = target_dir.join(relative);
+    behavior: SyncBehavior,
+) -> Result<asset_sync::ManagedTreeSyncReport> {
+    let mappings =
+        source_dir.map_or_else(|| Ok(Vec::new()), asset_sync::collect_directory_tree_mappings)?;
+    asset_sync::sync_managed_tree(target_dir, &mappings, behavior)
+}
 
-        if path.is_dir() {
-            fs::create_dir_all(&destination).with_context(|| {
-                format!("Failed to create directory: {}", destination.display())
-            })?;
-            sync_directory_tree_recursive(root_dir, &path, target_dir, synced)?;
-            continue;
-        }
-
-        if let Some(parent) = destination.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
-        }
-
-        fs::copy(&path, &destination).with_context(|| {
-            format!("Failed to copy file from {} to {}", path.display(), destination.display())
-        })?;
-        synced.push(relative.to_string_lossy().replace('\\', "/"));
+fn log_supporting_asset_result(
+    label: &str,
+    synced_files: &[String],
+    pruned_files: &[String],
+    dry_run: bool,
+) {
+    if dry_run {
+        return;
     }
 
-    Ok(())
+    if !synced_files.is_empty() {
+        info!("Synced {} {} file(s)", synced_files.len(), label);
+        for entry in synced_files {
+            debug!("  + {}", entry);
+        }
+    }
+
+    if !pruned_files.is_empty() {
+        info!("Pruned {} stale {} file(s)", pruned_files.len(), label);
+        for entry in pruned_files {
+            debug!("  - {}", entry);
+        }
+    }
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -70,10 +70,10 @@ impl TestFixture {
 
     /// Create a test skill directory with SKILL.md
     pub fn with_skill(&self, name: &str, content: &str) -> std::io::Result<&Self> {
-        let skills_dir = self.config.join("skills");
-        let skill_dir = skills_dir.join(name);
-        fs::create_dir_all(&skill_dir)?;
-        let path = skill_dir.join("SKILL.md");
+        let skills_root = self.config.join("skills");
+        let skill_path = skills_root.join(name);
+        fs::create_dir_all(&skill_path)?;
+        let path = skill_path.join("SKILL.md");
         fs::write(path, content)?;
         Ok(self)
     }

--- a/tests/integration/agent_assets_test.rs
+++ b/tests/integration/agent_assets_test.rs
@@ -1,6 +1,8 @@
 use crate::fixtures::TestFixture;
 use assert_cmd::Command;
+use predicates::prelude::*;
 use serial_test::serial;
+use std::fs;
 
 #[cfg(test)]
 mod tests {
@@ -96,5 +98,91 @@ mod tests {
             .read_project_file(".claude/agents/reviewer.md")
             .expect("Claude Code subagent should be readable");
         assert!(agent.contains("Focus on regressions."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_sync_gemini_dry_run_prune_reports_stale_commands() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture
+            .with_gemini_command(
+                "review",
+                "description = \"Review the current diff\"\nprompt = \"Review this change set.\"",
+            )
+            .unwrap();
+
+        let mut initial_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        initial_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success();
+
+        fs::remove_file(fixture.config.join("commands").join("gemini").join("review.toml"))
+            .unwrap();
+
+        let mut dry_run = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        dry_run
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini", "--dry-run", "--prune"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Would prune 1 stale file(s):"))
+            .stdout(predicate::str::contains("review.toml"));
+
+        assert!(fixture.project_file_exists(".gemini/commands/review.toml"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_sync_claude_code_prune_removes_only_managed_subagents() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_claude_settings(r#"{"permissions":{"allow":[],"deny":[]}}"#)
+            .unwrap();
+        fixture
+            .with_claude_code_agent(
+                "reviewer",
+                "---\nname: reviewer\ndescription: Review code changes\n---\nFocus on regressions.",
+            )
+            .unwrap();
+
+        let mut initial_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        initial_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "claude-code"])
+            .assert()
+            .success();
+
+        fs::remove_file(fixture.config.join("agents").join("claude-code").join("reviewer.md"))
+            .unwrap();
+        fs::create_dir_all(fixture.project.join(".claude").join("agents")).unwrap();
+        fs::write(fixture.project.join(".claude").join("agents").join("manual.md"), "manual")
+            .unwrap();
+
+        let mut prune_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        prune_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "claude-code", "--prune"])
+            .assert()
+            .success();
+
+        assert!(!fixture.project_file_exists(".claude/agents/reviewer.md"));
+        assert!(fixture.project_file_exists(".claude/agents/manual.md"));
     }
 }

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -2,6 +2,7 @@ use crate::fixtures::TestFixture;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serial_test::serial;
+use std::fs;
 
 #[cfg(test)]
 mod tests {
@@ -180,5 +181,55 @@ mod tests {
 
         // But skills should exist
         assert!(fixture.project_file_exists(".claude/skills/cmd/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_prune_updates_and_removes_only_managed_files() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_skill("keep", "# Keep Skill\nVersion 1").unwrap();
+        fixture.with_skill("remove", "# Remove Skill").unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut initial_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        initial_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync"])
+            .assert()
+            .success();
+
+        fs::write(
+            fixture.config.join("skills").join("keep").join("SKILL.md"),
+            "# Keep Skill\nVersion 2",
+        )
+        .unwrap();
+        fs::remove_dir_all(fixture.config.join("skills").join("remove")).unwrap();
+        fs::create_dir_all(fixture.project.join(".claude").join("skills").join("manual")).unwrap();
+        fs::write(
+            fixture.project.join(".claude").join("skills").join("manual").join("notes.txt"),
+            "manual",
+        )
+        .unwrap();
+
+        let mut prune_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        prune_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--prune"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Successfully synced 1 skill(s):"))
+            .stdout(predicate::str::contains("Pruned 1 stale skill file(s)"));
+
+        assert_eq!(
+            fixture.read_project_file(".claude/skills/keep/SKILL.md").unwrap(),
+            "# Keep Skill\nVersion 2"
+        );
+        assert!(!fixture.project_file_exists(".claude/skills/remove/SKILL.md"));
+        assert!(fixture.project_file_exists(".claude/skills/manual/notes.txt"));
     }
 }


### PR DESCRIPTION
## Summary
- add manifest-based tracking for Claudius-managed auxiliary trees so prune only removes files that Claudius previously deployed
- add `--prune` to `config sync` and `skills sync`, plus `--dry-run` support for `skills sync`
- report pending/pruned stale files for skills, Gemini commands, and Claude Code subagents, and document the new behavior

## Testing
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test`
- `nix develop -c just build`

Closes #68