### PR TITLE
feat: add config doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,29 @@ claudius config validate --agent gemini
 claudius config validate --strict
 ```
 
+### `claudius config doctor`
+
+Inspect Claudius configuration health across source files and deployed targets.
+
+This command highlights:
+- `supported` managed surfaces currently in use
+- `best-effort` legacy compatibility targets such as Claude Desktop JSON sync
+- `legacy` source layouts such as `settings.json` and `commands/*.md`
+- `unmanaged` surfaces such as Gemini extensions
+- `experimental` Codex skill sync surfaces
+- stale deployed assets tracked by Claudius manifests
+
+```bash
+# Inspect the current project-local deployment context
+claudius config doctor
+
+# Focus on a single agent surface
+claudius config doctor --agent gemini
+
+# Inspect global deployment targets under $HOME
+claudius config doctor --global
+```
+
 ### `claudius skills sync`
 
 Synchronize skills into the selected agent's skills directory.

--- a/src/asset_sync.rs
+++ b/src/asset_sync.rs
@@ -35,6 +35,13 @@ impl ManagedTreeSyncReport {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedTreeInspection {
+    pub target_dir: PathBuf,
+    pub managed_files: Vec<String>,
+    pub stale_files: Vec<String>,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct ManagedTreeManifest {
     #[serde(default = "manifest_version")]
@@ -62,6 +69,27 @@ pub fn collect_directory_tree_mappings(source_dir: &Path) -> Result<Vec<SourceFi
     collect_directory_tree_mappings_recursive(source_dir, source_dir, &mut mappings)?;
     mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
     Ok(mappings)
+}
+
+/// Inspect a Claudius-managed target tree without changing it.
+///
+/// # Errors
+///
+/// Returns an error if the manifest cannot be read or parsed.
+pub fn inspect_managed_tree(
+    target_dir: &Path,
+    mappings: &[SourceFileMapping],
+) -> Result<ManagedTreeInspection> {
+    let manifest = read_manifest(&manifest_path(target_dir))?;
+    let current_files = mappings
+        .iter()
+        .map(|mapping| mapping.relative_path.clone())
+        .collect::<BTreeSet<_>>();
+    let managed_files = manifest.managed_files.iter().cloned().collect::<Vec<_>>();
+    let stale_files =
+        manifest.managed_files.difference(&current_files).cloned().collect::<Vec<_>>();
+
+    Ok(ManagedTreeInspection { target_dir: target_dir.to_path_buf(), managed_files, stale_files })
 }
 
 /// Synchronize a Claudius-managed target tree and optionally prune stale files.
@@ -333,5 +361,25 @@ mod tests {
         assert_eq!(report.pruned_files, vec!["old.txt".to_string()]);
         assert!(target_dir.join("old.txt").exists());
         assert!(!target_dir.join("new.txt").exists());
+    }
+
+    #[test]
+    fn inspect_managed_tree_reports_stale_files() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::write(source_dir.join("keep.txt"), "keep").expect("write source file");
+        write_manifest(
+            &manifest_path(&target_dir),
+            &BTreeSet::from(["keep.txt".to_string(), "old.txt".to_string()]),
+        )
+        .expect("write manifest");
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        let inspection = inspect_managed_tree(&target_dir, &mappings).expect("inspect tree");
+
+        assert_eq!(inspection.managed_files, vec!["keep.txt".to_string(), "old.txt".to_string()]);
+        assert_eq!(inspection.stale_files, vec!["old.txt".to_string()]);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -183,6 +183,24 @@ Use --agent to validate a specific agent's settings.
 Use --strict to fail on warnings."
     )]
     Validate(ConfigValidateArgs),
+
+    /// Inspect configuration health, lifecycle risks, and unmanaged surfaces
+    #[command(
+        long_about = "Inspect Claudius configuration health, lifecycle risks, and unmanaged surfaces.
+
+This command scans the Claudius source tree and the current deployment context
+to report situations such as:
+  • legacy settings.json still in use
+  • legacy commands/*.md fallback still present
+  • Claude Desktop JSON targets being used as legacy / best-effort surfaces
+  • unmanaged Gemini extensions in the selected deployment context
+  • experimental Codex skill sync surfaces
+  • stale deployed assets that no longer exist in the source tree
+
+Use --global to inspect global deployment targets under $HOME.
+Use --agent to focus on a single agent surface."
+    )]
+    Doctor(ConfigDoctorArgs),
 }
 
 #[derive(Subcommand, Debug, Clone, Copy)]
@@ -392,6 +410,17 @@ pub struct ConfigValidateArgs {
     /// Treat warnings as errors (exit non-zero)
     #[arg(long)]
     pub strict: bool,
+}
+
+#[derive(Args, Debug, Clone, Copy)]
+pub struct ConfigDoctorArgs {
+    /// Inspect global deployment targets under $HOME instead of the current project
+    #[arg(short, long)]
+    pub global: bool,
+
+    /// Focus diagnostics on a specific agent
+    #[arg(short, long, value_enum)]
+    pub agent: Option<crate::app_config::Agent>,
 }
 
 #[derive(Args, Debug, Clone, Copy)]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,848 @@
+#![allow(missing_docs)]
+
+use crate::app_config::Agent;
+use crate::asset_sync::{inspect_managed_tree, ManagedTreeInspection, SourceFileMapping};
+use crate::config::Config;
+use crate::skills;
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DoctorStatus {
+    Supported,
+    BestEffort,
+    Legacy,
+    Unmanaged,
+    Experimental,
+    Stale,
+}
+
+impl DoctorStatus {
+    #[must_use]
+    pub const fn heading(self) -> &'static str {
+        match self {
+            Self::Supported => "SUPPORTED",
+            Self::BestEffort => "BEST-EFFORT",
+            Self::Legacy => "LEGACY",
+            Self::Unmanaged => "UNMANAGED",
+            Self::Experimental => "EXPERIMENTAL",
+            Self::Stale => "STALE",
+        }
+    }
+
+    #[must_use]
+    pub const fn ordered() -> [Self; 6] {
+        [
+            Self::Supported,
+            Self::BestEffort,
+            Self::Legacy,
+            Self::Unmanaged,
+            Self::Experimental,
+            Self::Stale,
+        ]
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DoctorFinding {
+    pub status: DoctorStatus,
+    pub summary: String,
+    pub path: Option<PathBuf>,
+    pub detail: Option<String>,
+    pub recommendation: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DoctorReport {
+    pub global: bool,
+    pub agent_filter: Option<Agent>,
+    pub config_dir: PathBuf,
+    pub deployment_base_dir: PathBuf,
+    pub findings: Vec<DoctorFinding>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DoctorOptions {
+    pub global: bool,
+    pub agent_filter: Option<Agent>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceSurfaceState {
+    shared_skills: Vec<SourceFileMapping>,
+    legacy_commands: Vec<SourceFileMapping>,
+    claude_skills: Vec<SourceFileMapping>,
+    claude_code_skills: Vec<SourceFileMapping>,
+    gemini_skills: Vec<SourceFileMapping>,
+    codex_skills: Vec<SourceFileMapping>,
+    gemini_commands: Vec<SourceFileMapping>,
+    claude_code_agents: Vec<SourceFileMapping>,
+}
+
+/// Build a configuration health report for the selected deployment context.
+///
+/// # Errors
+///
+/// Returns an error if Claudius paths cannot be resolved or if source/manifest
+/// inspection fails.
+pub fn run_doctor(options: DoctorOptions) -> Result<DoctorReport> {
+    let config_dir = Config::get_config_dir().context("Failed to determine Claudius config dir")?;
+    let config = Config::new_with_agent(options.global, options.agent_filter)
+        .context("Failed to resolve diagnostic context")?;
+    let source_state = load_source_surface_state(&config_dir)?;
+    let deployment_base_dir = config
+        .deployment_base_dir()
+        .context("Failed to determine deployment base dir")?;
+    let findings = collect_findings(options, &config_dir, &deployment_base_dir, &source_state)?;
+
+    Ok(DoctorReport {
+        global: options.global,
+        agent_filter: options.agent_filter,
+        config_dir,
+        deployment_base_dir,
+        findings,
+    })
+}
+
+pub fn render_report(report: &DoctorReport) -> String {
+    let mut lines = vec![
+        "Configuration doctor report".to_string(),
+        format!("Context: {}", if report.global { "global" } else { "project-local" }),
+        format!("Agent filter: {}", agent_filter_label(report.agent_filter)),
+        format!("Config directory: {}", report.config_dir.display()),
+        format!("Deployment base: {}", report.deployment_base_dir.display()),
+    ];
+
+    let mut groups = BTreeMap::<DoctorStatus, Vec<&DoctorFinding>>::new();
+    for finding in &report.findings {
+        groups.entry(finding.status).or_default().push(finding);
+    }
+
+    if report.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("No managed surfaces or lifecycle risks were detected.".to_string());
+        return lines.join("\n");
+    }
+
+    for status in DoctorStatus::ordered() {
+        let Some(findings) = groups.get(&status) else {
+            continue;
+        };
+
+        lines.push(String::new());
+        lines.push(format!("{} ({})", status.heading(), findings.len()));
+        for finding in findings {
+            lines.push(format!("- {}", finding.summary));
+            if let Some(path) = &finding.path {
+                lines.push(format!("  Path: {}", path.display()));
+            }
+            if let Some(detail) = &finding.detail {
+                lines.push(format!("  Detail: {detail}"));
+            }
+            lines.push(format!("  Next: {}", finding.recommendation));
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn load_source_surface_state(config_dir: &Path) -> Result<SourceSurfaceState> {
+    Ok(SourceSurfaceState {
+        shared_skills: collect_shared_skill_mappings(&config_dir.join("skills"))?,
+        legacy_commands: collect_legacy_command_mappings(&config_dir.join("commands"))?,
+        claude_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("claude"))?,
+        claude_code_skills: collect_agent_skill_mappings(
+            &config_dir.join("skills").join("claude-code"),
+        )?,
+        gemini_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("gemini"))?,
+        codex_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("codex"))?,
+        gemini_commands: collect_tree_if_exists(&config_dir.join("commands").join("gemini"))?,
+        claude_code_agents: collect_tree_if_exists(&config_dir.join("agents").join("claude-code"))?,
+    })
+}
+
+fn collect_findings(
+    options: DoctorOptions,
+    config_dir: &Path,
+    deployment_base_dir: &Path,
+    source_state: &SourceSurfaceState,
+) -> Result<Vec<DoctorFinding>> {
+    let mut findings = Vec::new();
+
+    inspect_claude_sources(config_dir, options.agent_filter, &mut findings);
+    inspect_codex_sources(config_dir, options.agent_filter, &mut findings);
+    inspect_gemini_sources(config_dir, options.agent_filter, &mut findings);
+    inspect_skill_sources(
+        config_dir,
+        options.agent_filter,
+        &source_state.shared_skills,
+        &source_state.claude_skills,
+        &source_state.claude_code_skills,
+        &source_state.gemini_skills,
+        &source_state.codex_skills,
+        &source_state.legacy_commands,
+        &mut findings,
+    );
+    inspect_auxiliary_sources(
+        config_dir,
+        options.agent_filter,
+        &source_state.gemini_commands,
+        &source_state.claude_code_agents,
+        &mut findings,
+    );
+    inspect_target_surfaces(options, deployment_base_dir, source_state, &mut findings)?;
+
+    Ok(findings)
+}
+
+fn inspect_claude_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if !matches_filter(agent_filter, Agent::Claude)
+        && !matches_filter(agent_filter, Agent::ClaudeCode)
+    {
+        return;
+    }
+
+    let preferred = config_dir.join("claude.settings.json");
+    let legacy = config_dir.join("settings.json");
+
+    if preferred.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Claude / Claude Code settings source is using the preferred layout."
+                .to_string(),
+            path: Some(preferred),
+            detail: None,
+            recommendation: "Keep using claude.settings.json for Claude and Claude Code settings."
+                .to_string(),
+        });
+    } else if legacy.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Legacy,
+            summary: "Legacy settings.json is still active for Claude / Claude Code settings."
+                .to_string(),
+            path: Some(legacy),
+            detail: None,
+            recommendation: "Rename or migrate settings.json to claude.settings.json.".to_string(),
+        });
+    }
+}
+
+fn inspect_codex_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if !matches_filter(agent_filter, Agent::Codex) {
+        return;
+    }
+
+    let settings = config_dir.join("codex.settings.toml");
+    if settings.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Codex settings source is present.".to_string(),
+            path: Some(settings),
+            detail: None,
+            recommendation: "Keep this in sync with `claudius config sync --agent codex`."
+                .to_string(),
+        });
+    }
+
+    let requirements = config_dir.join("codex.requirements.toml");
+    if requirements.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Codex admin-enforced requirements source is present.".to_string(),
+            path: Some(requirements),
+            detail: None,
+            recommendation:
+                "Sync it with `claudius config sync --global --agent codex --codex-requirements` when admin requirements change."
+                    .to_string(),
+        });
+    }
+
+    let managed = config_dir.join("codex.managed_config.toml");
+    let legacy_managed = config_dir.join("managed_config.toml");
+    if managed.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Codex managed defaults source is present.".to_string(),
+            path: Some(managed),
+            detail: None,
+            recommendation:
+                "Sync it with `claudius config sync --global --agent codex --codex-managed-config` when managed defaults change."
+                    .to_string(),
+        });
+    } else if legacy_managed.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Legacy,
+            summary: "Legacy managed_config.toml is still active for Codex managed defaults."
+                .to_string(),
+            path: Some(legacy_managed),
+            detail: None,
+            recommendation: "Rename or migrate managed_config.toml to codex.managed_config.toml."
+                .to_string(),
+        });
+    }
+}
+
+fn inspect_gemini_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if !matches_filter(agent_filter, Agent::Gemini) {
+        return;
+    }
+
+    let settings = config_dir.join("gemini.settings.json");
+    if settings.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Gemini settings source is present.".to_string(),
+            path: Some(settings),
+            detail: None,
+            recommendation: "Keep it in sync with `claudius config sync --agent gemini`."
+                .to_string(),
+        });
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect_skill_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    shared_skill_mappings: &[SourceFileMapping],
+    claude_skill_mappings: &[SourceFileMapping],
+    claude_code_skill_mappings: &[SourceFileMapping],
+    gemini_skill_mappings: &[SourceFileMapping],
+    codex_skill_mappings: &[SourceFileMapping],
+    legacy_command_mappings: &[SourceFileMapping],
+    findings: &mut Vec<DoctorFinding>,
+) {
+    let shared_skills_path = config_dir.join("skills");
+    if !shared_skill_mappings.is_empty() && agent_filter != Some(Agent::Codex) {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Shared skills source is present.".to_string(),
+            path: Some(shared_skills_path),
+            detail: Some(format!(
+                "{} shared skill file(s) are available for managed skill sync.",
+                shared_skill_mappings.len()
+            )),
+            recommendation: "Sync them with `claudius skills sync` or the relevant `claudius config sync` command.".to_string(),
+        });
+    }
+
+    push_agent_skill_finding(
+        findings,
+        agent_filter,
+        Agent::Claude,
+        config_dir.join("skills").join("claude"),
+        claude_skill_mappings,
+        "Claude-specific skills source is present.",
+    );
+    push_agent_skill_finding(
+        findings,
+        agent_filter,
+        Agent::ClaudeCode,
+        config_dir.join("skills").join("claude-code"),
+        claude_code_skill_mappings,
+        "Claude Code-specific skills source is present.",
+    );
+    push_agent_skill_finding(
+        findings,
+        agent_filter,
+        Agent::Gemini,
+        config_dir.join("skills").join("gemini"),
+        gemini_skill_mappings,
+        "Gemini-specific skills source is present.",
+    );
+
+    if !legacy_command_mappings.is_empty() && agent_filter != Some(Agent::Gemini) {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Legacy,
+            summary: "Legacy commands/*.md skill fallback is still in use.".to_string(),
+            path: Some(config_dir.join("commands")),
+            detail: Some(format!(
+                "{} legacy command file(s) still rely on commands/*.md fallback.",
+                legacy_command_mappings.len()
+            )),
+            recommendation: "Move each commands/*.md file into skills/<name>/SKILL.md.".to_string(),
+        });
+    }
+
+    if should_report_codex_experimental(
+        agent_filter,
+        shared_skill_mappings,
+        codex_skill_mappings,
+        legacy_command_mappings,
+    ) {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Experimental,
+            summary: "Codex skill sync remains in experimental compatibility mode.".to_string(),
+            path: Some(config_dir.join("skills").join("codex")),
+            detail: Some(
+                "Codex skill sync still uses opt-in publishing and compatibility targets."
+                    .to_string(),
+            ),
+            recommendation:
+                "Use `claudius skills sync --agent codex --enable-codex-skills` only when you need Codex skills."
+                    .to_string(),
+        });
+    }
+}
+
+fn inspect_auxiliary_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    gemini_command_mappings: &[SourceFileMapping],
+    claude_code_agent_mappings: &[SourceFileMapping],
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if matches_filter(agent_filter, Agent::Gemini) && !gemini_command_mappings.is_empty() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Gemini custom command source is present.".to_string(),
+            path: Some(config_dir.join("commands").join("gemini")),
+            detail: Some(format!(
+                "{} Gemini command file(s) are ready to sync.",
+                gemini_command_mappings.len()
+            )),
+            recommendation: "Deploy them with `claudius config sync --agent gemini`.".to_string(),
+        });
+    }
+
+    if matches_filter(agent_filter, Agent::ClaudeCode) && !claude_code_agent_mappings.is_empty() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Claude Code subagent source is present.".to_string(),
+            path: Some(config_dir.join("agents").join("claude-code")),
+            detail: Some(format!(
+                "{} Claude Code subagent file(s) are ready to sync.",
+                claude_code_agent_mappings.len()
+            )),
+            recommendation: "Deploy them with `claudius config sync --agent claude-code`."
+                .to_string(),
+        });
+    }
+}
+
+fn inspect_target_surfaces(
+    options: DoctorOptions,
+    deployment_base_dir: &Path,
+    source_state: &SourceSurfaceState,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    inspect_best_effort_targets(options, findings)?;
+    inspect_unmanaged_targets(options.agent_filter, deployment_base_dir, findings);
+    inspect_claude_skill_targets(options, source_state, findings)?;
+    inspect_gemini_targets(options, deployment_base_dir, source_state, findings)?;
+    inspect_claude_code_targets(options, deployment_base_dir, source_state, findings)?;
+    inspect_codex_targets(options, source_state, findings)?;
+
+    Ok(())
+}
+
+fn inspect_best_effort_targets(
+    options: DoctorOptions,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    if !(options.global && matches_filter(options.agent_filter, Agent::Claude)) {
+        return Ok(());
+    }
+
+    let claude_config = Config::new_with_agent(true, Some(Agent::Claude))?;
+    if claude_config.target_config_path.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::BestEffort,
+            summary: "Claude Desktop JSON target is present as a legacy / best-effort surface."
+                .to_string(),
+            path: Some(claude_config.target_config_path),
+            detail: Some(
+                "Claudius can sync this JSON file, but it does not manage Claude Desktop Extensions or Connectors."
+                    .to_string(),
+            ),
+            recommendation:
+                "Prefer Claude Code, Codex, or Gemini when you need actively managed surfaces."
+                    .to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn inspect_unmanaged_targets(
+    agent_filter: Option<Agent>,
+    deployment_base_dir: &Path,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if matches_filter(agent_filter, Agent::Gemini) {
+        let extensions_dir = deployment_base_dir.join(".gemini").join("extensions");
+        if directory_has_entries(&extensions_dir) {
+            findings.push(DoctorFinding {
+                status: DoctorStatus::Unmanaged,
+                summary: "Gemini extensions are present in an unmanaged target directory."
+                    .to_string(),
+                path: Some(extensions_dir),
+                detail: None,
+                recommendation:
+                    "Install and update Gemini extensions through the Gemini CLI workflow; Claudius does not sync them."
+                        .to_string(),
+            });
+        }
+    }
+}
+
+fn inspect_claude_skill_targets(
+    options: DoctorOptions,
+    source_state: &SourceSurfaceState,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    if !(matches_filter(options.agent_filter, Agent::Claude)
+        || matches_filter(options.agent_filter, Agent::ClaudeCode))
+    {
+        return Ok(());
+    }
+
+    let source_mappings = combine_mappings(&[
+        &source_state.shared_skills,
+        &source_state.claude_skills,
+        &source_state.claude_code_skills,
+        &source_state.legacy_commands,
+    ]);
+    let target_dir =
+        Config::new_with_agent(options.global, Some(Agent::ClaudeCode))?.skills_target_dir;
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&target_dir, &source_mappings)?,
+        "Claudius-managed Claude skills target has stale deployed files.",
+        skill_prune_command(options.global, None),
+    );
+
+    Ok(())
+}
+
+fn inspect_gemini_targets(
+    options: DoctorOptions,
+    deployment_base_dir: &Path,
+    source_state: &SourceSurfaceState,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    if !matches_filter(options.agent_filter, Agent::Gemini) {
+        return Ok(());
+    }
+
+    let gemini_skill_source_mappings = combine_mappings(&[
+        &source_state.shared_skills,
+        &source_state.gemini_skills,
+        &source_state.legacy_commands,
+    ]);
+    let gemini_config = Config::new_with_agent(options.global, Some(Agent::Gemini))?;
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&gemini_config.skills_target_dir, &gemini_skill_source_mappings)?,
+        "Claudius-managed Gemini skills target has stale deployed files.",
+        skill_prune_command(options.global, Some(Agent::Gemini)),
+    );
+
+    let gemini_command_target = gemini_config
+        .gemini_commands_target_dir()?
+        .unwrap_or_else(|| deployment_base_dir.join(".gemini").join("commands"));
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&gemini_command_target, &source_state.gemini_commands)?,
+        "Claudius-managed Gemini commands target has stale deployed files.",
+        config_prune_command(options.global, Agent::Gemini),
+    );
+
+    Ok(())
+}
+
+fn inspect_claude_code_targets(
+    options: DoctorOptions,
+    deployment_base_dir: &Path,
+    source_state: &SourceSurfaceState,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    if !matches_filter(options.agent_filter, Agent::ClaudeCode) {
+        return Ok(());
+    }
+
+    let claude_code_agent_target = Config::new_with_agent(options.global, Some(Agent::ClaudeCode))?
+        .claude_code_agents_target_dir()?
+        .unwrap_or_else(|| deployment_base_dir.join(".claude").join("agents"));
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&claude_code_agent_target, &source_state.claude_code_agents)?,
+        "Claudius-managed Claude Code subagents target has stale deployed files.",
+        config_prune_command(options.global, Agent::ClaudeCode),
+    );
+
+    Ok(())
+}
+
+fn inspect_codex_targets(
+    options: DoctorOptions,
+    source_state: &SourceSurfaceState,
+    findings: &mut Vec<DoctorFinding>,
+) -> Result<()> {
+    if !matches_filter(options.agent_filter, Agent::Codex) {
+        return Ok(());
+    }
+
+    let codex_skill_source_mappings = combine_mappings(&[
+        &source_state.shared_skills,
+        &source_state.codex_skills,
+        &source_state.legacy_commands,
+    ]);
+    let codex_config = Config::new_with_agent(options.global, Some(Agent::Codex))?;
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&codex_config.skills_target_dir, &codex_skill_source_mappings)?,
+        "Claudius-managed Codex skills target has stale deployed files.",
+        skill_prune_command(options.global, Some(Agent::Codex)),
+    );
+
+    if let Some(compat_target) = codex_config.codex_compat_skills_target_dir()? {
+        let inspection = inspect_managed_tree(&compat_target, &codex_skill_source_mappings)?;
+        let had_managed_files = !inspection.managed_files.is_empty();
+        push_stale_finding(
+            findings,
+            inspection,
+            "Claudius-managed Codex compatibility skills target has stale deployed files.",
+            skill_prune_command(options.global, Some(Agent::Codex)),
+        );
+
+        if had_managed_files || !source_state.codex_skills.is_empty() {
+            findings.push(DoctorFinding {
+                status: DoctorStatus::Experimental,
+                summary:
+                    "Codex compatibility skills target is present for experimental sync."
+                        .to_string(),
+                path: Some(compat_target),
+                detail: Some(
+                    "Claudius still publishes Codex skills to both .codex/skills and .agents/skills for compatibility."
+                        .to_string(),
+                ),
+                recommendation:
+                    "Keep Codex skills opt-in and expect compatibility targets to evolve."
+                        .to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn push_agent_skill_finding(
+    findings: &mut Vec<DoctorFinding>,
+    agent_filter: Option<Agent>,
+    agent: Agent,
+    path: PathBuf,
+    mappings: &[SourceFileMapping],
+    summary: &str,
+) {
+    if matches_filter(agent_filter, agent) && !mappings.is_empty() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: summary.to_string(),
+            path: Some(path),
+            detail: Some(format!("{} skill file(s) are ready to sync.", mappings.len())),
+            recommendation: "Publish them with `claudius skills sync` for the matching agent."
+                .to_string(),
+        });
+    }
+}
+
+fn push_stale_finding(
+    findings: &mut Vec<DoctorFinding>,
+    inspection: ManagedTreeInspection,
+    summary: &str,
+    recommendation: String,
+) {
+    if inspection.stale_files.is_empty() {
+        return;
+    }
+
+    findings.push(DoctorFinding {
+        status: DoctorStatus::Stale,
+        summary: summary.to_string(),
+        path: Some(inspection.target_dir),
+        detail: Some(format!(
+            "{} stale file(s): {}",
+            inspection.stale_files.len(),
+            summarize_paths(&inspection.stale_files),
+        )),
+        recommendation,
+    });
+}
+
+fn should_report_codex_experimental(
+    agent_filter: Option<Agent>,
+    shared_skill_mappings: &[SourceFileMapping],
+    codex_skill_mappings: &[SourceFileMapping],
+    legacy_command_mappings: &[SourceFileMapping],
+) -> bool {
+    if agent_filter == Some(Agent::Codex) {
+        return !shared_skill_mappings.is_empty()
+            || !codex_skill_mappings.is_empty()
+            || !legacy_command_mappings.is_empty();
+    }
+
+    !codex_skill_mappings.is_empty()
+}
+
+fn collect_tree_if_exists(path: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    crate::asset_sync::collect_directory_tree_mappings(path)
+}
+
+fn collect_agent_skill_mappings(path: &Path) -> Result<Vec<SourceFileMapping>> {
+    skills::collect_skill_mappings(path.exists().then_some(path))
+}
+
+fn collect_shared_skill_mappings(skills_root: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !skills_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut mappings = Vec::new();
+    let mut entries = fs::read_dir(skills_root)
+        .with_context(|| format!("Failed to read directory: {}", skills_root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let path = entry.path();
+        let entry_name = entry.file_name();
+        let entry_name_lossy = entry_name.to_string_lossy();
+        if is_agent_skill_subdir(&entry_name_lossy) {
+            continue;
+        }
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let skill_name = entry_name_lossy.to_string();
+        let nested = crate::asset_sync::collect_directory_tree_mappings(&path)?;
+        mappings.extend(nested.into_iter().map(|mapping| SourceFileMapping {
+            source_path: mapping.source_path,
+            relative_path: format!("{skill_name}/{}", mapping.relative_path),
+        }));
+    }
+
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+fn collect_legacy_command_mappings(commands_root: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !commands_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut mappings = Vec::new();
+    let mut entries = fs::read_dir(commands_root)
+        .with_context(|| format!("Failed to read directory: {}", commands_root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+
+        let skill_name = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Invalid legacy command file name"))?
+            .to_string();
+        mappings.push(SourceFileMapping {
+            source_path: path,
+            relative_path: format!("{skill_name}/SKILL.md"),
+        });
+    }
+
+    Ok(mappings)
+}
+
+fn combine_mappings(mapping_sets: &[&[SourceFileMapping]]) -> Vec<SourceFileMapping> {
+    let mut combined = mapping_sets
+        .iter()
+        .flat_map(|mappings| mappings.iter().cloned())
+        .collect::<Vec<_>>();
+    combined.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    combined.dedup_by(|left, right| left.relative_path == right.relative_path);
+    combined
+}
+
+fn summarize_paths(paths: &[String]) -> String {
+    const MAX_ITEMS: usize = 5;
+    if paths.len() <= MAX_ITEMS {
+        return paths.join(", ");
+    }
+
+    let head = paths.iter().take(MAX_ITEMS).cloned().collect::<Vec<_>>().join(", ");
+    format!("{head}, +{} more", paths.len().saturating_sub(MAX_ITEMS))
+}
+
+fn skill_prune_command(global: bool, selected_agent: Option<Agent>) -> String {
+    let mut parts = vec!["claudius skills sync".to_string()];
+    if global {
+        parts.push("--global".to_string());
+    }
+    if let Some(agent_name) = selected_agent {
+        parts.push(format!("--agent {}", agent_cli_name(agent_name)));
+        if agent_name == Agent::Codex {
+            parts.push("--enable-codex-skills".to_string());
+        }
+    }
+    parts.push("--prune".to_string());
+    parts.join(" ")
+}
+
+fn config_prune_command(global: bool, agent: Agent) -> String {
+    let mut parts = vec!["claudius config sync".to_string()];
+    if global {
+        parts.push("--global".to_string());
+    }
+    parts.push(format!("--agent {}", agent_cli_name(agent)));
+    parts.push("--prune".to_string());
+    parts.join(" ")
+}
+
+fn directory_has_entries(path: &Path) -> bool {
+    fs::read_dir(path).map(|mut entries| entries.next().is_some()).unwrap_or(false)
+}
+
+fn matches_filter(agent_filter: Option<Agent>, candidate: Agent) -> bool {
+    agent_filter.is_none_or(|agent| agent == candidate)
+}
+
+fn agent_filter_label(agent_filter: Option<Agent>) -> String {
+    agent_filter.map_or_else(|| "all".to_string(), |agent| agent_cli_name(agent).to_string())
+}
+
+fn agent_cli_name(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "claude",
+        Agent::ClaudeCode => "claude-code",
+        Agent::Codex => "codex",
+        Agent::Gemini => "gemini",
+    }
+}
+
+fn is_agent_skill_subdir(name: &str) -> bool {
+    matches!(name, "claude" | "claude-code" | "codex" | "gemini")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod bootstrap;
 pub mod cli;
 pub mod codex_settings;
 pub mod config;
+pub mod doctor;
 pub mod gemini_settings;
 pub(crate) mod json_merge;
 pub mod merge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use claudius::{
     bootstrap,
     cli::{self, Cli},
     config::{reader, Config},
+    doctor::{render_report, run_doctor, DoctorOptions},
     secrets::SecretResolver,
     skills,
     sync_operations::{
@@ -115,6 +116,7 @@ fn dispatch_command(command: cli::Commands, app_config: Option<&AppConfig>) -> R
             cli::ConfigCommands::Init(args) => run_init(args.force, app_config),
             cli::ConfigCommands::Sync(args) => run_config_sync(args, app_config),
             cli::ConfigCommands::Validate(args) => run_config_validate(args, app_config),
+            cli::ConfigCommands::Doctor(args) => run_config_doctor(args),
         },
         cli::Commands::Skills(subcommand) => match subcommand {
             cli::SkillsCommands::Sync(args) => run_sync_skills(args, app_config),
@@ -435,6 +437,12 @@ fn run_config_validate(
     Ok(())
 }
 
+fn run_config_doctor(args: cli::ConfigDoctorArgs) -> Result<()> {
+    let report = run_doctor(DoctorOptions { global: args.global, agent_filter: args.agent })?;
+    println!("{}", render_report(&report));
+    Ok(())
+}
+
 fn validate_claude_code_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
     let mut warnings = validate_claude_settings_sources(config_dir)?;
     warnings.extend(validate_claude_code_subagent_sources(config_dir)?);
@@ -652,47 +660,45 @@ fn collect_files_with_extension(
     for entry in std::fs::read_dir(dir)
         .with_context(|| format!("Failed to read directory: {}", dir.display()))?
     {
-        let path = entry?.path();
+        let entry = entry.with_context(|| format!("Failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
         if path.is_dir() {
             collect_files_with_extension(&path, extension, files)?;
             continue;
         }
 
-        if path.extension().and_then(|value| value.to_str()) == Some(extension) {
+        if path.extension().and_then(|ext| ext.to_str()) == Some(extension) {
             files.push(path);
         }
     }
 
+    files.sort();
     Ok(())
 }
 
 fn run_list_context(args: cli::ContextListArgs, _app_config: Option<&AppConfig>) -> Result<()> {
     let rules_dir = ensure_rules_directory()?;
-    let mut rules = Vec::new();
-    collect_md_files(&rules_dir, &rules_dir, &mut rules)?;
-    rules.sort();
 
-    if rules.is_empty() {
-        println!("No rules found in {}", rules_dir.display());
+    if args.tree {
+        let tree = build_directory_tree(&rules_dir, 0)?;
+        if tree.is_empty() {
+            println!("No rules or templates found in: {}", rules_dir.display());
+        } else {
+            println!("Available rules and templates in {}:", rules_dir.display());
+            print!("{tree}");
+        }
         return Ok(());
     }
 
-    println!("Rules directory: {}", rules_dir.display());
+    let mut rules = Vec::new();
+    collect_rule_names(&rules_dir, &rules_dir, &mut rules)?;
+    rules.sort();
 
-    if args.tree {
-        let mut tree = RulesTree::default();
-        for rule in &rules {
-            let components: Vec<&str> =
-                rule.split('/').filter(|segment| !segment.is_empty()).collect();
-            if components.is_empty() {
-                continue;
-            }
-            insert_rule_path(&mut tree, &components);
-        }
-        print_rules_tree(&tree, "");
+    if rules.is_empty() {
+        println!("No rules or templates found in: {}", rules_dir.display());
     } else {
-        println!("Available rules ({}):", rules.len());
-        for rule in &rules {
+        println!("Available rules and templates in {}:", rules_dir.display());
+        for rule in rules {
             println!("  - {rule}");
         }
     }
@@ -700,91 +706,104 @@ fn run_list_context(args: cli::ContextListArgs, _app_config: Option<&AppConfig>)
     Ok(())
 }
 
-#[derive(Default)]
-struct RulesTree {
-    directories: BTreeMap<String, Self>,
-    files: BTreeSet<String>,
+fn collect_rule_names(
+    dir: &std::path::Path,
+    base_dir: &std::path::Path,
+    rules: &mut Vec<String>,
+) -> Result<()> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(());
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rule_names(&path, base_dir, rules)?;
+            continue;
+        }
+
+        let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
+            continue;
+        };
+        if !filename.to_ascii_lowercase().ends_with(".md") {
+            continue;
+        }
+
+        let Ok(relative_path) = path.strip_prefix(base_dir) else {
+            continue;
+        };
+        let Some(rule_path) = relative_path.to_str() else {
+            continue;
+        };
+
+        rules.push(rule_path.trim_end_matches(".md").replace('\\', "/"));
+    }
+
+    Ok(())
 }
 
-fn insert_rule_path(node: &mut RulesTree, components: &[&str]) {
-    if let Some((head, tail)) = components.split_first() {
-        if tail.is_empty() {
-            node.files.insert(format!("{head}.md"));
-        } else {
-            insert_rule_path(node.directories.entry((*head).to_owned()).or_default(), tail);
+fn build_directory_tree(dir: &std::path::Path, depth: usize) -> Result<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(String::new());
+    };
+
+    let mut entries = entries.collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut output = String::new();
+    for entry in entries {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let indent = "  ".repeat(depth);
+
+        if path.is_dir() {
+            output.push_str(&format!("{indent}{name}/\n"));
+            output.push_str(&build_directory_tree(&path, depth + 1)?);
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            output.push_str(&format!("{indent}{name}\n"));
         }
     }
+
+    Ok(output)
 }
 
-fn print_rules_tree(node: &RulesTree, prefix: &str) {
-    let total = node.directories.len().saturating_add(node.files.len());
-    if total == 0 {
-        return;
-    }
-
-    let mut index = 0_usize;
-
-    for (dir, child) in &node.directories {
-        index = index.saturating_add(1);
-        let is_last = index == total;
-        let connector = if is_last { "└── " } else { "├── " };
-        println!("{prefix}{connector}{dir}/");
-        let next_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
-        print_rules_tree(child, &next_prefix);
-    }
-
-    for file in &node.files {
-        index = index.saturating_add(1);
-        let is_last = index == total;
-        let connector = if is_last { "└── " } else { "├── " };
-        println!("{prefix}{connector}{file}");
-    }
-}
-
-/// Determine the context filename based on agent and configuration
 fn determine_context_filename(
     agent_override: Option<claudius::app_config::Agent>,
     app_config: Option<&AppConfig>,
-    agent: claudius::app_config::Agent,
+    fallback_agent: claudius::app_config::Agent,
 ) -> String {
-    // If agent was explicitly overridden, always use agent-specific file
-    if agent_override.is_some() {
-        debug!("Agent explicitly overridden, using agent-specific file");
-        return get_agent_context_filename(agent);
-    }
-
-    // Check for custom context file in configuration
-    if let Some(config) = app_config {
-        debug!("App config found: {:?}", config);
-        if let Some(ref default_config) = config.default {
-            debug!("Default config found: {:?}", default_config);
-            if let Some(ref context_file) = default_config.context_file {
-                debug!("Using custom context file from config: {}", context_file);
-                return context_file.clone();
+    app_config
+        .and_then(|cfg| cfg.default.as_ref())
+        .and_then(|defaults| {
+            let effective_agent = agent_override.unwrap_or(defaults.agent);
+            if effective_agent == fallback_agent {
+                defaults.context_file.clone()
+            } else {
+                None
             }
-        }
-    }
-
-    // Fall back to agent-based default
-    debug!("Using agent default context file");
-    get_agent_context_filename(agent)
+        })
+        .unwrap_or_else(|| get_agent_context_filename(fallback_agent))
 }
 
-/// Determine the target directory for context files
-fn determine_target_directory(
-    global: bool,
-    path: Option<std::path::PathBuf>,
-) -> Result<std::path::PathBuf> {
-    if global {
-        Ok(directories::BaseDirs::new()
-            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
-            .home_dir()
-            .to_path_buf())
-    } else if let Some(p) = path {
-        Ok(if p.is_absolute() { p } else { std::env::current_dir()?.join(p) })
-    } else {
-        std::env::current_dir().map_err(Into::into)
+fn determine_target_directory(global: bool, path: Option<std::path::PathBuf>) -> Result<std::path::PathBuf> {
+    if let Some(custom_path) = path {
+        if custom_path.is_absolute() {
+            return Ok(custom_path);
+        }
+
+        return Ok(std::env::current_dir()?.join(custom_path));
     }
+
+    if global {
+        let base_dirs = directories::BaseDirs::new()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        return Ok(base_dirs.home_dir().to_path_buf());
+    }
+
+    std::env::current_dir().context("Failed to get current directory")
 }
 
 fn run_append_context(
@@ -892,619 +911,4 @@ fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()>
 
         execute_sync_operation(&config, &paths, agent_context, flags)
     }
-}
-
-/// Sync all available agents in global mode
-fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()> {
-    // Detect available agents
-    let available_agents = Config::detect_available_agents()?;
-
-    if available_agents.is_empty() {
-        warn!("No agent configuration files found in config directory");
-        // Still sync skills if they exist
-        let config = Config::new_with_agent(true, None)?;
-        let _ = sync_supporting_assets(
-            &config,
-            AgentContext::new(None, None),
-            SyncBehavior { dry_run: options.dry_run, prune: options.prune },
-        );
-        return Ok(());
-    }
-
-    println!(
-        "Found configurations for {} agent(s): {}",
-        available_agents.len(),
-        available_agents.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>().join(", ")
-    );
-
-    // Sync each available agent
-    for agent in &available_agents {
-        let agent_name = match agent {
-            claudius::app_config::Agent::Claude => "Claude",
-            claudius::app_config::Agent::ClaudeCode => "Claude Code",
-            claudius::app_config::Agent::Codex => "Codex",
-            claudius::app_config::Agent::Gemini => "Gemini",
-        };
-        println!("\nSyncing agent: {agent_name}");
-        println!("===============================================");
-
-        let (agent_context, config, paths) = setup_sync_context(
-            Some(*agent),
-            app_config,
-            true,
-            options.config_path.clone(),
-            options.target_config_path.clone(),
-            None,
-        )?;
-
-        // Log configuration paths
-        log_sync_paths(&paths, true, &config);
-
-        // Execute sync operation for this agent
-        let flags = SyncExecutionFlags {
-            backup: options.backup,
-            dry_run: options.dry_run,
-            prune: options.prune,
-            codex_global: CodexGlobalSyncOptions::default(),
-        };
-
-        execute_sync_operation(&config, &paths, agent_context, flags)?;
-    }
-
-    println!("\nAll agent configurations synced successfully");
-    Ok(())
-}
-
-/// Setup sync context with agent and paths
-fn setup_sync_context(
-    agent_override: Option<claudius::app_config::Agent>,
-    app_config: Option<&AppConfig>,
-    global: bool,
-    config_opt: Option<std::path::PathBuf>,
-    target_config_opt: Option<std::path::PathBuf>,
-    claude_code_scope: Option<claudius::app_config::ClaudeCodeScope>,
-) -> Result<(AgentContext, Config, SyncPaths)> {
-    let agent = determine_agent(agent_override, app_config);
-    if let Some(a) = agent {
-        debug!("Using agent: {:?}", a);
-    }
-
-    if claude_code_scope.is_some() && agent != Some(claudius::app_config::Agent::ClaudeCode) {
-        anyhow::bail!("--scope is only supported with --agent claude-code");
-    }
-
-    let agent_context = AgentContext::new(agent, claude_code_scope);
-    let config = Config::new_with_agent(global, agent)?;
-
-    let default_target_config = match agent_context.claude_code_scope {
-        Some(claudius::app_config::ClaudeCodeScope::Managed)
-            if agent_context.is_claude_code && global =>
-        {
-            agent_paths::claude_code_managed_mcp_path()
-        },
-        Some(claudius::app_config::ClaudeCodeScope::Local)
-            if agent_context.is_claude_code && !global =>
-        {
-            let base_dirs = directories::BaseDirs::new()
-                .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-            base_dirs.home_dir().join(".claude.json")
-        },
-        _ => config.target_config_path.clone(),
-    };
-
-    let paths = SyncPaths {
-        mcp_servers: config_opt.unwrap_or_else(|| config.mcp_servers_path.clone()),
-        target_config: target_config_opt.unwrap_or(default_target_config),
-    };
-
-    Ok((agent_context, config, paths))
-}
-
-/// Container for sync paths
-struct SyncPaths {
-    mcp_servers: std::path::PathBuf,
-    target_config: std::path::PathBuf,
-}
-
-/// Log sync configuration paths
-fn log_sync_paths(paths: &SyncPaths, global: bool, config: &Config) {
-    debug!("MCP servers config: {}", paths.mcp_servers.display());
-    debug!(
-        "Target config: {} ({}):",
-        paths.target_config.display(),
-        if global { "global" } else { "project-local" }
-    );
-    debug!("Settings file: {}", config.settings_path.display());
-}
-
-#[derive(Clone, Copy, Debug)]
-struct SyncExecutionFlags {
-    backup: bool,
-    dry_run: bool,
-    prune: bool,
-    codex_global: CodexGlobalSyncOptions,
-}
-
-/// Execute the main sync operation
-fn execute_sync_operation(
-    config: &Config,
-    paths: &SyncPaths,
-    agent_context: AgentContext,
-    flags: SyncExecutionFlags,
-) -> Result<()> {
-    // Read configurations
-    let read_result = read_configurations(config, &paths.mcp_servers, agent_context)?;
-
-    debug!("Reading target configuration");
-    let mut claude_config = if config.is_global && agent_context.is_codex {
-        // For Codex in global mode, don't read from paths.target_config (Codex uses ~/.codex/config.toml).
-        claudius::config::ClaudeConfig { mcp_servers: None, other: HashMap::new() }
-    } else {
-        reader::read_claude_config(&paths.target_config)
-            .context("Failed to read target configuration")?
-    };
-
-    // Process configurations
-    if flags.backup {
-        handle_backup(
-            config,
-            &paths.target_config,
-            &read_result,
-            agent_context,
-            flags.codex_global,
-        )?;
-    }
-    merge_all_configs(&mut claude_config, &read_result, agent_context, config.is_global)?;
-
-    // Output results
-    if flags.dry_run {
-        let supporting_assets = sync_supporting_assets(
-            config,
-            agent_context,
-            SyncBehavior { dry_run: true, prune: flags.prune },
-        );
-        handle_dry_run(
-            config,
-            &paths.target_config,
-            &claude_config,
-            &read_result,
-            agent_context,
-            flags.codex_global,
-        )?;
-        print_supporting_assets_dry_run(&supporting_assets);
-    } else {
-        write_configurations(
-            config,
-            &claude_config,
-            &paths.target_config,
-            &read_result,
-            agent_context,
-            flags.codex_global,
-        )?;
-        let _ = sync_supporting_assets(
-            config,
-            agent_context,
-            SyncBehavior { dry_run: false, prune: flags.prune },
-        );
-    }
-
-    Ok(())
-}
-
-fn print_skill_sync_result(reports: &[skills::SkillSyncReport], dry_run: bool) {
-    if reports.iter().all(skills::SkillSyncReport::is_empty) {
-        println!("No skills to sync");
-        return;
-    }
-
-    if dry_run {
-        print_skill_sync_dry_run(reports);
-        return;
-    }
-
-    print_skill_sync_summary(reports);
-}
-
-fn print_skill_sync_dry_run(reports: &[skills::SkillSyncReport]) {
-    println!("Dry run mode - not writing changes");
-    for report in reports {
-        if report.is_empty() {
-            continue;
-        }
-
-        println!("\n--- Skills ({}) ---", report.target_dir.display());
-        if !report.synced_skills.is_empty() {
-            println!("Would sync {} skill(s):", report.synced_skills.len());
-            for skill in &report.synced_skills {
-                println!("  + {skill}");
-            }
-        }
-        if !report.pruned_files.is_empty() {
-            println!("Would prune {} stale file(s):", report.pruned_files.len());
-            for path in &report.pruned_files {
-                println!("  - {path}");
-            }
-        }
-    }
-}
-
-fn print_skill_sync_summary(reports: &[skills::SkillSyncReport]) {
-    let synced_skills =
-        reports.first().map_or_else(Vec::new, |report| report.synced_skills.clone());
-    if !synced_skills.is_empty() {
-        println!("Successfully synced {} skill(s):", synced_skills.len());
-        for skill in &synced_skills {
-            println!("  - {skill}");
-        }
-    }
-
-    for report in reports.iter().filter(|report| !report.pruned_files.is_empty()) {
-        println!(
-            "Pruned {} stale skill file(s) from {}:",
-            report.pruned_files.len(),
-            report.target_dir.display()
-        );
-        for path in &report.pruned_files {
-            println!("  - {path}");
-        }
-    }
-
-    if reports.len() > 1 {
-        println!("Published to:");
-        for report in reports {
-            println!("  - {}", report.target_dir.display());
-        }
-    }
-}
-
-/// Execute command with inherited stdio
-fn execute_command(program: &str, args: &[String]) -> Result<std::process::ExitStatus> {
-    use std::process::{Command, Stdio};
-
-    let mut child = Command::new(program)
-        .args(args)
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .with_context(|| format!("Failed to execute command: {program}"))?;
-
-    child.wait().with_context(|| format!("Failed to wait for command: {program}"))
-}
-
-/// Handle the exit status of a child process
-fn handle_exit_status(status: std::process::ExitStatus) -> ! {
-    if !status.success() {
-        if let Some(code) = status.code() {
-            debug!("Command exited with code: {}", code);
-            std::process::exit(code);
-        } else {
-            // Terminated by signal (Unix)
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::ExitStatusExt;
-                if let Some(signal) = status.signal() {
-                    error!("Command terminated by signal: {}", signal);
-                    // Exit with 128 + signal number (standard Unix convention)
-                    std::process::exit(128_i32.saturating_add(signal));
-                }
-            }
-            error!("Command terminated abnormally");
-            std::process::exit(1);
-        }
-    }
-    std::process::exit(0);
-}
-
-fn run_command(command: &[String], _app_config: Option<&AppConfig>) -> Result<()> {
-    if command.is_empty() {
-        error!("No command specified");
-        std::process::exit(1);
-    }
-
-    // Check if profiling is enabled
-    #[allow(unused_variables)]
-    let profiling_enabled = std::env::var("CLAUDIUS_PROFILE").is_ok();
-
-    #[cfg(feature = "profiling")]
-    let status = if profiling_enabled {
-        profile_flamegraph("run-command", || run_command_inner(command))??
-    } else {
-        run_command_inner(command)?
-    };
-
-    #[cfg(not(feature = "profiling"))]
-    let status = {
-        let _ = profiling_enabled; // Suppress unused variable warning
-        run_command_inner(command)?
-    };
-
-    handle_exit_status(status);
-}
-
-fn run_command_inner(command: &[String]) -> Result<std::process::ExitStatus> {
-    // Secrets are already resolved in main(), no need to resolve again
-
-    // Extract command and arguments
-    let (program, args) =
-        command.split_first().ok_or_else(|| anyhow::anyhow!("Command is empty"))?;
-
-    debug!("Running command: {}", command.join(" "));
-
-    // Execute command and handle exit status
-    execute_command(program, args)
-}
-
-// Helper functions for run_install_context
-fn collect_md_files(
-    dir: &std::path::Path,
-    base_dir: &std::path::Path,
-    rules: &mut Vec<String>,
-) -> Result<()> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Ok(());
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            // Recurse into subdirectories
-            collect_md_files(&path, base_dir, rules)?;
-        } else {
-            process_file_entry(&path, base_dir, rules);
-        }
-    }
-    Ok(())
-}
-
-fn process_file_entry(path: &std::path::Path, base_dir: &std::path::Path, rules: &mut Vec<String>) {
-    let Some(filename) = path.file_name().and_then(|f| f.to_str()) else { return };
-    if !filename.to_ascii_lowercase().ends_with(".md") {
-        return;
-    }
-
-    // Get relative path from base_dir without .md extension
-    let Ok(relative_path) = path.strip_prefix(base_dir) else { return };
-    let Some(rule_path) = relative_path.to_str() else { return };
-
-    // Remove .md extension and use forward slashes
-    let rule_name = rule_path.trim_end_matches(".md").replace('\\', "/");
-    rules.push(rule_name);
-}
-
-fn copy_rules(
-    rules_to_copy: &[String],
-    source_rules_dir: &std::path::Path,
-    rules_dir: &std::path::Path,
-) -> Result<Vec<String>> {
-    use std::fs;
-
-    let mut copied_rules = Vec::new();
-    for rule_name in rules_to_copy {
-        let source_path = source_rules_dir.join(format!("{rule_name}.md"));
-        let dest_path = rules_dir.join(format!("{rule_name}.md"));
-
-        debug!("Checking for rule at: {}", source_path.display());
-
-        if !source_path.exists() {
-            warn!("Rule '{}' not found at {}", rule_name, source_path.display());
-            continue;
-        }
-
-        // Create subdirectories if needed
-        if let Some(parent) = dest_path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
-        }
-
-        fs::copy(&source_path, &dest_path).with_context(|| {
-            format!("Failed to copy {} to {}", source_path.display(), dest_path.display())
-        })?;
-
-        copied_rules.push(rule_name.clone());
-        println!("Installed rule: {rule_name}");
-    }
-
-    if copied_rules.is_empty() {
-        error!("No rules were installed");
-        return Err(anyhow::anyhow!("No valid rules found"));
-    }
-
-    Ok(copied_rules)
-}
-
-const CLAUDIUS_RULES_SECTION_START: &str = "<!-- CLAUDIUS_RULES_START -->";
-const CLAUDIUS_RULES_SECTION_END: &str = "<!-- CLAUDIUS_RULES_END -->";
-
-fn add_reference_directive(
-    target_dir: &std::path::Path,
-    rules_dir: &std::path::Path,
-    context_filename: &str,
-    copied_rules: &[String],
-) -> Result<()> {
-    use std::fs;
-    use std::io::Write;
-
-    let context_file_path = target_dir.join(context_filename);
-
-    // Calculate relative path from target_dir to rules_dir
-    let relative_rules_path = rules_dir
-        .strip_prefix(target_dir)
-        .map_or_else(|_| rules_dir.to_path_buf(), std::path::Path::to_path_buf);
-
-    // Read existing content
-    let existing_content = if context_file_path.exists() {
-        fs::read_to_string(&context_file_path)?
-    } else {
-        String::new()
-    };
-
-    let reference_directive = build_reference_directive(&relative_rules_path, copied_rules)?;
-
-    if existing_content.contains(CLAUDIUS_RULES_SECTION_START) {
-        let new_content = replace_existing_reference_section(
-            &existing_content,
-            &reference_directive,
-            context_filename,
-        )?;
-
-        fs::write(&context_file_path, new_content)
-            .with_context(|| format!("Failed to update {}", context_file_path.display()))?;
-        println!("Updated reference directive in {context_filename}");
-        return Ok(());
-    }
-
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&context_file_path)
-        .with_context(|| format!("Failed to open {}", context_file_path.display()))?;
-
-    file.write_all(reference_directive.as_bytes())?;
-    println!("Added reference directive to {context_filename}");
-    Ok(())
-}
-
-fn build_reference_directive(
-    relative_rules_path: &std::path::Path,
-    copied_rules: &[String],
-) -> Result<String> {
-    let rule_list = build_installed_rules_list(relative_rules_path, copied_rules)?;
-
-    Ok(format!(
-        "\n{section_start}\n\
-# External Rule References\n\
-\n\
-The following rules from `{rules_dir}` are installed:\n\
-\n\
-{rule_list}\
-\n\
-Read these files to understand the project conventions and guidelines.\n\
-{section_end}\n",
-        section_start = CLAUDIUS_RULES_SECTION_START,
-        section_end = CLAUDIUS_RULES_SECTION_END,
-        rules_dir = relative_rules_path.display(),
-        rule_list = rule_list,
-    ))
-}
-
-fn build_installed_rules_list(
-    relative_rules_path: &std::path::Path,
-    copied_rules: &[String],
-) -> Result<String> {
-    use std::fmt::Write as _;
-
-    let mut rule_list = String::new();
-    for rule_name in copied_rules {
-        let rule_path = relative_rules_path.join(format!("{rule_name}.md"));
-        let rule_path_str = rule_path.to_string_lossy().replace('\\', "/");
-        writeln!(&mut rule_list, "- `{rule_path_str}`: {}", rule_name.replace('/', " / "),)
-            .map_err(|e| anyhow::anyhow!("Failed to format rules list: {e}"))?;
-    }
-
-    Ok(rule_list)
-}
-
-fn replace_existing_reference_section(
-    existing_content: &str,
-    reference_directive: &str,
-    context_filename: &str,
-) -> Result<String> {
-    let Some(start_pos) = existing_content.find(CLAUDIUS_RULES_SECTION_START) else {
-        return Ok(existing_content.to_string());
-    };
-
-    let remaining = existing_content
-        .get(start_pos..)
-        .ok_or_else(|| anyhow::anyhow!("Invalid section start boundary in {context_filename}"))?;
-    let Some(end_rel) = remaining.find(CLAUDIUS_RULES_SECTION_END) else {
-        anyhow::bail!("Found section start marker but no end marker in {context_filename}");
-    };
-
-    let end_pos = start_pos
-        .checked_add(end_rel)
-        .ok_or_else(|| anyhow::anyhow!("Section end marker position overflow"))?;
-    let end_with_marker = end_pos
-        .checked_add(CLAUDIUS_RULES_SECTION_END.len())
-        .ok_or_else(|| anyhow::anyhow!("Section end marker position overflow"))?;
-
-    let prefix = existing_content
-        .get(..start_pos)
-        .ok_or_else(|| anyhow::anyhow!("Invalid section start boundary in {context_filename}"))?;
-    let suffix = existing_content
-        .get(end_with_marker..)
-        .ok_or_else(|| anyhow::anyhow!("Invalid section end boundary in {context_filename}"))?;
-
-    Ok(format!("{prefix}{}{suffix}", reference_directive.trim_start()))
-}
-
-fn run_install_context(
-    rules: Vec<String>,
-    all: bool,
-    path: Option<std::path::PathBuf>,
-    agent_override: Option<claudius::app_config::Agent>,
-    install_dir: Option<std::path::PathBuf>,
-    app_config: Option<&AppConfig>,
-) -> Result<()> {
-    use std::fs;
-
-    // Determine agent
-    let agent = agent_override
-        .or_else(|| app_config.as_ref().and_then(|c| c.default.as_ref()).map(|d| d.agent))
-        .unwrap_or(claudius::app_config::Agent::Claude);
-
-    debug!("Using agent: {:?}", agent);
-
-    // Determine context filename
-    let context_filename = determine_context_filename(agent_override, app_config, agent);
-
-    // Determine target directory
-    let target_dir = if let Some(p) = path {
-        if p.is_absolute() {
-            p
-        } else {
-            std::env::current_dir()?.join(p)
-        }
-    } else {
-        std::env::current_dir()?
-    };
-
-    // Create rules directory (default: .agents/rules, or custom install_dir)
-    let rules_base = install_dir.unwrap_or_else(|| std::path::PathBuf::from(".agents/rules"));
-    let rules_dir = if rules_base.is_absolute() { rules_base } else { target_dir.join(rules_base) };
-    fs::create_dir_all(&rules_dir)
-        .with_context(|| format!("Failed to create directory: {}", rules_dir.display()))?;
-
-    // Get config directory for source rules
-    let source_rules_dir = Config::get_config_dir()?.join("rules");
-    debug!("Looking for rules in: {}", source_rules_dir.display());
-
-    // Determine which rules to copy
-    let rules_to_copy = if all {
-        // Get all .md files from the rules directory recursively
-        println!(
-            "Installing ALL rules from {} (including subdirectories)",
-            source_rules_dir.display()
-        );
-        let mut all_rules = Vec::new();
-        collect_md_files(&source_rules_dir, &source_rules_dir, &mut all_rules)?;
-
-        if all_rules.is_empty() {
-            return Err(anyhow::anyhow!("No rules found in {}", source_rules_dir.display()));
-        }
-        all_rules.sort(); // Sort for consistent ordering
-        all_rules
-    } else {
-        rules
-    };
-
-    // Copy specified rules
-    let copied_rules = copy_rules(&rules_to_copy, &source_rules_dir, &rules_dir)?;
-
-    // Add reference directive to context file with the list of copied rules
-    add_reference_directive(&target_dir, &rules_dir, &context_filename, &copied_rules)?;
-
-    println!("Successfully installed {} rule(s) to {}", copied_rules.len(), rules_dir.display());
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,45 +660,47 @@ fn collect_files_with_extension(
     for entry in std::fs::read_dir(dir)
         .with_context(|| format!("Failed to read directory: {}", dir.display()))?
     {
-        let entry = entry.with_context(|| format!("Failed to read entry in {}", dir.display()))?;
-        let path = entry.path();
+        let path = entry?.path();
         if path.is_dir() {
             collect_files_with_extension(&path, extension, files)?;
             continue;
         }
 
-        if path.extension().and_then(|ext| ext.to_str()) == Some(extension) {
+        if path.extension().and_then(|value| value.to_str()) == Some(extension) {
             files.push(path);
         }
     }
 
-    files.sort();
     Ok(())
 }
 
 fn run_list_context(args: cli::ContextListArgs, _app_config: Option<&AppConfig>) -> Result<()> {
     let rules_dir = ensure_rules_directory()?;
-
-    if args.tree {
-        let tree = build_directory_tree(&rules_dir, 0)?;
-        if tree.is_empty() {
-            println!("No rules or templates found in: {}", rules_dir.display());
-        } else {
-            println!("Available rules and templates in {}:", rules_dir.display());
-            print!("{tree}");
-        }
-        return Ok(());
-    }
-
     let mut rules = Vec::new();
-    collect_rule_names(&rules_dir, &rules_dir, &mut rules)?;
+    collect_md_files(&rules_dir, &rules_dir, &mut rules)?;
     rules.sort();
 
     if rules.is_empty() {
-        println!("No rules or templates found in: {}", rules_dir.display());
+        println!("No rules found in {}", rules_dir.display());
+        return Ok(());
+    }
+
+    println!("Rules directory: {}", rules_dir.display());
+
+    if args.tree {
+        let mut tree = RulesTree::default();
+        for rule in &rules {
+            let components: Vec<&str> =
+                rule.split('/').filter(|segment| !segment.is_empty()).collect();
+            if components.is_empty() {
+                continue;
+            }
+            insert_rule_path(&mut tree, &components);
+        }
+        print_rules_tree(&tree, "");
     } else {
-        println!("Available rules and templates in {}:", rules_dir.display());
-        for rule in rules {
+        println!("Available rules ({}):", rules.len());
+        for rule in &rules {
             println!("  - {rule}");
         }
     }
@@ -706,104 +708,91 @@ fn run_list_context(args: cli::ContextListArgs, _app_config: Option<&AppConfig>)
     Ok(())
 }
 
-fn collect_rule_names(
-    dir: &std::path::Path,
-    base_dir: &std::path::Path,
-    rules: &mut Vec<String>,
-) -> Result<()> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Ok(());
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_rule_names(&path, base_dir, rules)?;
-            continue;
-        }
-
-        let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
-            continue;
-        };
-        if !filename.to_ascii_lowercase().ends_with(".md") {
-            continue;
-        }
-
-        let Ok(relative_path) = path.strip_prefix(base_dir) else {
-            continue;
-        };
-        let Some(rule_path) = relative_path.to_str() else {
-            continue;
-        };
-
-        rules.push(rule_path.trim_end_matches(".md").replace('\\', "/"));
-    }
-
-    Ok(())
+#[derive(Default)]
+struct RulesTree {
+    directories: BTreeMap<String, Self>,
+    files: BTreeSet<String>,
 }
 
-fn build_directory_tree(dir: &std::path::Path, depth: usize) -> Result<String> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Ok(String::new());
-    };
-
-    let mut entries = entries.collect::<std::result::Result<Vec<_>, _>>()?;
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-
-    let mut output = String::new();
-    for entry in entries {
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy().to_string();
-        let indent = "  ".repeat(depth);
-
-        if path.is_dir() {
-            output.push_str(&format!("{indent}{name}/\n"));
-            output.push_str(&build_directory_tree(&path, depth + 1)?);
-            continue;
-        }
-
-        if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
-            output.push_str(&format!("{indent}{name}\n"));
+fn insert_rule_path(node: &mut RulesTree, components: &[&str]) {
+    if let Some((head, tail)) = components.split_first() {
+        if tail.is_empty() {
+            node.files.insert(format!("{head}.md"));
+        } else {
+            insert_rule_path(node.directories.entry((*head).to_owned()).or_default(), tail);
         }
     }
-
-    Ok(output)
 }
 
+fn print_rules_tree(node: &RulesTree, prefix: &str) {
+    let total = node.directories.len().saturating_add(node.files.len());
+    if total == 0 {
+        return;
+    }
+
+    let mut index = 0_usize;
+
+    for (dir, child) in &node.directories {
+        index = index.saturating_add(1);
+        let is_last = index == total;
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{prefix}{connector}{dir}/");
+        let next_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
+        print_rules_tree(child, &next_prefix);
+    }
+
+    for file in &node.files {
+        index = index.saturating_add(1);
+        let is_last = index == total;
+        let connector = if is_last { "└── " } else { "├── " };
+        println!("{prefix}{connector}{file}");
+    }
+}
+
+/// Determine the context filename based on agent and configuration
 fn determine_context_filename(
     agent_override: Option<claudius::app_config::Agent>,
     app_config: Option<&AppConfig>,
-    fallback_agent: claudius::app_config::Agent,
+    agent: claudius::app_config::Agent,
 ) -> String {
-    app_config
-        .and_then(|cfg| cfg.default.as_ref())
-        .and_then(|defaults| {
-            let effective_agent = agent_override.unwrap_or(defaults.agent);
-            if effective_agent == fallback_agent {
-                defaults.context_file.clone()
-            } else {
-                None
+    // If agent was explicitly overridden, always use agent-specific file
+    if agent_override.is_some() {
+        debug!("Agent explicitly overridden, using agent-specific file");
+        return get_agent_context_filename(agent);
+    }
+
+    // Check for custom context file in configuration
+    if let Some(config) = app_config {
+        debug!("App config found: {:?}", config);
+        if let Some(ref default_config) = config.default {
+            debug!("Default config found: {:?}", default_config);
+            if let Some(ref context_file) = default_config.context_file {
+                debug!("Using custom context file from config: {}", context_file);
+                return context_file.clone();
             }
-        })
-        .unwrap_or_else(|| get_agent_context_filename(fallback_agent))
+        }
+    }
+
+    // Fall back to agent-based default
+    debug!("Using agent default context file");
+    get_agent_context_filename(agent)
 }
 
-fn determine_target_directory(global: bool, path: Option<std::path::PathBuf>) -> Result<std::path::PathBuf> {
-    if let Some(custom_path) = path {
-        if custom_path.is_absolute() {
-            return Ok(custom_path);
-        }
-
-        return Ok(std::env::current_dir()?.join(custom_path));
-    }
-
+/// Determine the target directory for context files
+fn determine_target_directory(
+    global: bool,
+    path: Option<std::path::PathBuf>,
+) -> Result<std::path::PathBuf> {
     if global {
-        let base_dirs = directories::BaseDirs::new()
-            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
-        return Ok(base_dirs.home_dir().to_path_buf());
+        Ok(directories::BaseDirs::new()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?
+            .home_dir()
+            .to_path_buf())
+    } else if let Some(p) = path {
+        Ok(if p.is_absolute() { p } else { std::env::current_dir()?.join(p) })
+    } else {
+        std::env::current_dir().map_err(Into::into)
     }
-
-    std::env::current_dir().context("Failed to get current directory")
 }
 
 fn run_append_context(
@@ -911,4 +900,619 @@ fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()>
 
         execute_sync_operation(&config, &paths, agent_context, flags)
     }
+}
+
+/// Sync all available agents in global mode
+fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()> {
+    // Detect available agents
+    let available_agents = Config::detect_available_agents()?;
+
+    if available_agents.is_empty() {
+        warn!("No agent configuration files found in config directory");
+        // Still sync skills if they exist
+        let config = Config::new_with_agent(true, None)?;
+        let _ = sync_supporting_assets(
+            &config,
+            AgentContext::new(None, None),
+            SyncBehavior { dry_run: options.dry_run, prune: options.prune },
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Found configurations for {} agent(s): {}",
+        available_agents.len(),
+        available_agents.iter().map(|a| format!("{a:?}")).collect::<Vec<_>>().join(", ")
+    );
+
+    // Sync each available agent
+    for agent in &available_agents {
+        let agent_name = match agent {
+            claudius::app_config::Agent::Claude => "Claude",
+            claudius::app_config::Agent::ClaudeCode => "Claude Code",
+            claudius::app_config::Agent::Codex => "Codex",
+            claudius::app_config::Agent::Gemini => "Gemini",
+        };
+        println!("\nSyncing agent: {agent_name}");
+        println!("===============================================");
+
+        let (agent_context, config, paths) = setup_sync_context(
+            Some(*agent),
+            app_config,
+            true,
+            options.config_path.clone(),
+            options.target_config_path.clone(),
+            None,
+        )?;
+
+        // Log configuration paths
+        log_sync_paths(&paths, true, &config);
+
+        // Execute sync operation for this agent
+        let flags = SyncExecutionFlags {
+            backup: options.backup,
+            dry_run: options.dry_run,
+            prune: options.prune,
+            codex_global: CodexGlobalSyncOptions::default(),
+        };
+
+        execute_sync_operation(&config, &paths, agent_context, flags)?;
+    }
+
+    println!("\nAll agent configurations synced successfully");
+    Ok(())
+}
+
+/// Setup sync context with agent and paths
+fn setup_sync_context(
+    agent_override: Option<claudius::app_config::Agent>,
+    app_config: Option<&AppConfig>,
+    global: bool,
+    config_opt: Option<std::path::PathBuf>,
+    target_config_opt: Option<std::path::PathBuf>,
+    claude_code_scope: Option<claudius::app_config::ClaudeCodeScope>,
+) -> Result<(AgentContext, Config, SyncPaths)> {
+    let agent = determine_agent(agent_override, app_config);
+    if let Some(a) = agent {
+        debug!("Using agent: {:?}", a);
+    }
+
+    if claude_code_scope.is_some() && agent != Some(claudius::app_config::Agent::ClaudeCode) {
+        anyhow::bail!("--scope is only supported with --agent claude-code");
+    }
+
+    let agent_context = AgentContext::new(agent, claude_code_scope);
+    let config = Config::new_with_agent(global, agent)?;
+
+    let default_target_config = match agent_context.claude_code_scope {
+        Some(claudius::app_config::ClaudeCodeScope::Managed)
+            if agent_context.is_claude_code && global =>
+        {
+            agent_paths::claude_code_managed_mcp_path()
+        },
+        Some(claudius::app_config::ClaudeCodeScope::Local)
+            if agent_context.is_claude_code && !global =>
+        {
+            let base_dirs = directories::BaseDirs::new()
+                .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+            base_dirs.home_dir().join(".claude.json")
+        },
+        _ => config.target_config_path.clone(),
+    };
+
+    let paths = SyncPaths {
+        mcp_servers: config_opt.unwrap_or_else(|| config.mcp_servers_path.clone()),
+        target_config: target_config_opt.unwrap_or(default_target_config),
+    };
+
+    Ok((agent_context, config, paths))
+}
+
+/// Container for sync paths
+struct SyncPaths {
+    mcp_servers: std::path::PathBuf,
+    target_config: std::path::PathBuf,
+}
+
+/// Log sync configuration paths
+fn log_sync_paths(paths: &SyncPaths, global: bool, config: &Config) {
+    debug!("MCP servers config: {}", paths.mcp_servers.display());
+    debug!(
+        "Target config: {} ({}):",
+        paths.target_config.display(),
+        if global { "global" } else { "project-local" }
+    );
+    debug!("Settings file: {}", config.settings_path.display());
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SyncExecutionFlags {
+    backup: bool,
+    dry_run: bool,
+    prune: bool,
+    codex_global: CodexGlobalSyncOptions,
+}
+
+/// Execute the main sync operation
+fn execute_sync_operation(
+    config: &Config,
+    paths: &SyncPaths,
+    agent_context: AgentContext,
+    flags: SyncExecutionFlags,
+) -> Result<()> {
+    // Read configurations
+    let read_result = read_configurations(config, &paths.mcp_servers, agent_context)?;
+
+    debug!("Reading target configuration");
+    let mut claude_config = if config.is_global && agent_context.is_codex {
+        // For Codex in global mode, don't read from paths.target_config (Codex uses ~/.codex/config.toml).
+        claudius::config::ClaudeConfig { mcp_servers: None, other: HashMap::new() }
+    } else {
+        reader::read_claude_config(&paths.target_config)
+            .context("Failed to read target configuration")?
+    };
+
+    // Process configurations
+    if flags.backup {
+        handle_backup(
+            config,
+            &paths.target_config,
+            &read_result,
+            agent_context,
+            flags.codex_global,
+        )?;
+    }
+    merge_all_configs(&mut claude_config, &read_result, agent_context, config.is_global)?;
+
+    // Output results
+    if flags.dry_run {
+        let supporting_assets = sync_supporting_assets(
+            config,
+            agent_context,
+            SyncBehavior { dry_run: true, prune: flags.prune },
+        );
+        handle_dry_run(
+            config,
+            &paths.target_config,
+            &claude_config,
+            &read_result,
+            agent_context,
+            flags.codex_global,
+        )?;
+        print_supporting_assets_dry_run(&supporting_assets);
+    } else {
+        write_configurations(
+            config,
+            &claude_config,
+            &paths.target_config,
+            &read_result,
+            agent_context,
+            flags.codex_global,
+        )?;
+        let _ = sync_supporting_assets(
+            config,
+            agent_context,
+            SyncBehavior { dry_run: false, prune: flags.prune },
+        );
+    }
+
+    Ok(())
+}
+
+fn print_skill_sync_result(reports: &[skills::SkillSyncReport], dry_run: bool) {
+    if reports.iter().all(skills::SkillSyncReport::is_empty) {
+        println!("No skills to sync");
+        return;
+    }
+
+    if dry_run {
+        print_skill_sync_dry_run(reports);
+        return;
+    }
+
+    print_skill_sync_summary(reports);
+}
+
+fn print_skill_sync_dry_run(reports: &[skills::SkillSyncReport]) {
+    println!("Dry run mode - not writing changes");
+    for report in reports {
+        if report.is_empty() {
+            continue;
+        }
+
+        println!("\n--- Skills ({}) ---", report.target_dir.display());
+        if !report.synced_skills.is_empty() {
+            println!("Would sync {} skill(s):", report.synced_skills.len());
+            for skill in &report.synced_skills {
+                println!("  + {skill}");
+            }
+        }
+        if !report.pruned_files.is_empty() {
+            println!("Would prune {} stale file(s):", report.pruned_files.len());
+            for path in &report.pruned_files {
+                println!("  - {path}");
+            }
+        }
+    }
+}
+
+fn print_skill_sync_summary(reports: &[skills::SkillSyncReport]) {
+    let synced_skills =
+        reports.first().map_or_else(Vec::new, |report| report.synced_skills.clone());
+    if !synced_skills.is_empty() {
+        println!("Successfully synced {} skill(s):", synced_skills.len());
+        for skill in &synced_skills {
+            println!("  - {skill}");
+        }
+    }
+
+    for report in reports.iter().filter(|report| !report.pruned_files.is_empty()) {
+        println!(
+            "Pruned {} stale skill file(s) from {}:",
+            report.pruned_files.len(),
+            report.target_dir.display()
+        );
+        for path in &report.pruned_files {
+            println!("  - {path}");
+        }
+    }
+
+    if reports.len() > 1 {
+        println!("Published to:");
+        for report in reports {
+            println!("  - {}", report.target_dir.display());
+        }
+    }
+}
+
+/// Execute command with inherited stdio
+fn execute_command(program: &str, args: &[String]) -> Result<std::process::ExitStatus> {
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("Failed to execute command: {program}"))?;
+
+    child.wait().with_context(|| format!("Failed to wait for command: {program}"))
+}
+
+/// Handle the exit status of a child process
+fn handle_exit_status(status: std::process::ExitStatus) -> ! {
+    if !status.success() {
+        if let Some(code) = status.code() {
+            debug!("Command exited with code: {}", code);
+            std::process::exit(code);
+        } else {
+            // Terminated by signal (Unix)
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                if let Some(signal) = status.signal() {
+                    error!("Command terminated by signal: {}", signal);
+                    // Exit with 128 + signal number (standard Unix convention)
+                    std::process::exit(128_i32.saturating_add(signal));
+                }
+            }
+            error!("Command terminated abnormally");
+            std::process::exit(1);
+        }
+    }
+    std::process::exit(0);
+}
+
+fn run_command(command: &[String], _app_config: Option<&AppConfig>) -> Result<()> {
+    if command.is_empty() {
+        error!("No command specified");
+        std::process::exit(1);
+    }
+
+    // Check if profiling is enabled
+    #[allow(unused_variables)]
+    let profiling_enabled = std::env::var("CLAUDIUS_PROFILE").is_ok();
+
+    #[cfg(feature = "profiling")]
+    let status = if profiling_enabled {
+        profile_flamegraph("run-command", || run_command_inner(command))??
+    } else {
+        run_command_inner(command)?
+    };
+
+    #[cfg(not(feature = "profiling"))]
+    let status = {
+        let _ = profiling_enabled; // Suppress unused variable warning
+        run_command_inner(command)?
+    };
+
+    handle_exit_status(status);
+}
+
+fn run_command_inner(command: &[String]) -> Result<std::process::ExitStatus> {
+    // Secrets are already resolved in main(), no need to resolve again
+
+    // Extract command and arguments
+    let (program, args) =
+        command.split_first().ok_or_else(|| anyhow::anyhow!("Command is empty"))?;
+
+    debug!("Running command: {}", command.join(" "));
+
+    // Execute command and handle exit status
+    execute_command(program, args)
+}
+
+// Helper functions for run_install_context
+fn collect_md_files(
+    dir: &std::path::Path,
+    base_dir: &std::path::Path,
+    rules: &mut Vec<String>,
+) -> Result<()> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(());
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Recurse into subdirectories
+            collect_md_files(&path, base_dir, rules)?;
+        } else {
+            process_file_entry(&path, base_dir, rules);
+        }
+    }
+    Ok(())
+}
+
+fn process_file_entry(path: &std::path::Path, base_dir: &std::path::Path, rules: &mut Vec<String>) {
+    let Some(filename) = path.file_name().and_then(|f| f.to_str()) else { return };
+    if !filename.to_ascii_lowercase().ends_with(".md") {
+        return;
+    }
+
+    // Get relative path from base_dir without .md extension
+    let Ok(relative_path) = path.strip_prefix(base_dir) else { return };
+    let Some(rule_path) = relative_path.to_str() else { return };
+
+    // Remove .md extension and use forward slashes
+    let rule_name = rule_path.trim_end_matches(".md").replace('\\', "/");
+    rules.push(rule_name);
+}
+
+fn copy_rules(
+    rules_to_copy: &[String],
+    source_rules_dir: &std::path::Path,
+    rules_dir: &std::path::Path,
+) -> Result<Vec<String>> {
+    use std::fs;
+
+    let mut copied_rules = Vec::new();
+    for rule_name in rules_to_copy {
+        let source_path = source_rules_dir.join(format!("{rule_name}.md"));
+        let dest_path = rules_dir.join(format!("{rule_name}.md"));
+
+        debug!("Checking for rule at: {}", source_path.display());
+
+        if !source_path.exists() {
+            warn!("Rule '{}' not found at {}", rule_name, source_path.display());
+            continue;
+        }
+
+        // Create subdirectories if needed
+        if let Some(parent) = dest_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+
+        fs::copy(&source_path, &dest_path).with_context(|| {
+            format!("Failed to copy {} to {}", source_path.display(), dest_path.display())
+        })?;
+
+        copied_rules.push(rule_name.clone());
+        println!("Installed rule: {rule_name}");
+    }
+
+    if copied_rules.is_empty() {
+        error!("No rules were installed");
+        return Err(anyhow::anyhow!("No valid rules found"));
+    }
+
+    Ok(copied_rules)
+}
+
+const CLAUDIUS_RULES_SECTION_START: &str = "<!-- CLAUDIUS_RULES_START -->";
+const CLAUDIUS_RULES_SECTION_END: &str = "<!-- CLAUDIUS_RULES_END -->";
+
+fn add_reference_directive(
+    target_dir: &std::path::Path,
+    rules_dir: &std::path::Path,
+    context_filename: &str,
+    copied_rules: &[String],
+) -> Result<()> {
+    use std::fs;
+    use std::io::Write;
+
+    let context_file_path = target_dir.join(context_filename);
+
+    // Calculate relative path from target_dir to rules_dir
+    let relative_rules_path = rules_dir
+        .strip_prefix(target_dir)
+        .map_or_else(|_| rules_dir.to_path_buf(), std::path::Path::to_path_buf);
+
+    // Read existing content
+    let existing_content = if context_file_path.exists() {
+        fs::read_to_string(&context_file_path)?
+    } else {
+        String::new()
+    };
+
+    let reference_directive = build_reference_directive(&relative_rules_path, copied_rules)?;
+
+    if existing_content.contains(CLAUDIUS_RULES_SECTION_START) {
+        let new_content = replace_existing_reference_section(
+            &existing_content,
+            &reference_directive,
+            context_filename,
+        )?;
+
+        fs::write(&context_file_path, new_content)
+            .with_context(|| format!("Failed to update {}", context_file_path.display()))?;
+        println!("Updated reference directive in {context_filename}");
+        return Ok(());
+    }
+
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&context_file_path)
+        .with_context(|| format!("Failed to open {}", context_file_path.display()))?;
+
+    file.write_all(reference_directive.as_bytes())?;
+    println!("Added reference directive to {context_filename}");
+    Ok(())
+}
+
+fn build_reference_directive(
+    relative_rules_path: &std::path::Path,
+    copied_rules: &[String],
+) -> Result<String> {
+    let rule_list = build_installed_rules_list(relative_rules_path, copied_rules)?;
+
+    Ok(format!(
+        "\n{section_start}\n\
+# External Rule References\n\
+\n\
+The following rules from `{rules_dir}` are installed:\n\
+\n\
+{rule_list}\
+\n\
+Read these files to understand the project conventions and guidelines.\n\
+{section_end}\n",
+        section_start = CLAUDIUS_RULES_SECTION_START,
+        section_end = CLAUDIUS_RULES_SECTION_END,
+        rules_dir = relative_rules_path.display(),
+        rule_list = rule_list,
+    ))
+}
+
+fn build_installed_rules_list(
+    relative_rules_path: &std::path::Path,
+    copied_rules: &[String],
+) -> Result<String> {
+    use std::fmt::Write as _;
+
+    let mut rule_list = String::new();
+    for rule_name in copied_rules {
+        let rule_path = relative_rules_path.join(format!("{rule_name}.md"));
+        let rule_path_str = rule_path.to_string_lossy().replace('\\', "/");
+        writeln!(&mut rule_list, "- `{rule_path_str}`: {}", rule_name.replace('/', " / "),)
+            .map_err(|e| anyhow::anyhow!("Failed to format rules list: {e}"))?;
+    }
+
+    Ok(rule_list)
+}
+
+fn replace_existing_reference_section(
+    existing_content: &str,
+    reference_directive: &str,
+    context_filename: &str,
+) -> Result<String> {
+    let Some(start_pos) = existing_content.find(CLAUDIUS_RULES_SECTION_START) else {
+        return Ok(existing_content.to_string());
+    };
+
+    let remaining = existing_content
+        .get(start_pos..)
+        .ok_or_else(|| anyhow::anyhow!("Invalid section start boundary in {context_filename}"))?;
+    let Some(end_rel) = remaining.find(CLAUDIUS_RULES_SECTION_END) else {
+        anyhow::bail!("Found section start marker but no end marker in {context_filename}");
+    };
+
+    let end_pos = start_pos
+        .checked_add(end_rel)
+        .ok_or_else(|| anyhow::anyhow!("Section end marker position overflow"))?;
+    let end_with_marker = end_pos
+        .checked_add(CLAUDIUS_RULES_SECTION_END.len())
+        .ok_or_else(|| anyhow::anyhow!("Section end marker position overflow"))?;
+
+    let prefix = existing_content
+        .get(..start_pos)
+        .ok_or_else(|| anyhow::anyhow!("Invalid section start boundary in {context_filename}"))?;
+    let suffix = existing_content
+        .get(end_with_marker..)
+        .ok_or_else(|| anyhow::anyhow!("Invalid section end boundary in {context_filename}"))?;
+
+    Ok(format!("{prefix}{}{suffix}", reference_directive.trim_start()))
+}
+
+fn run_install_context(
+    rules: Vec<String>,
+    all: bool,
+    path: Option<std::path::PathBuf>,
+    agent_override: Option<claudius::app_config::Agent>,
+    install_dir: Option<std::path::PathBuf>,
+    app_config: Option<&AppConfig>,
+) -> Result<()> {
+    use std::fs;
+
+    // Determine agent
+    let agent = agent_override
+        .or_else(|| app_config.as_ref().and_then(|c| c.default.as_ref()).map(|d| d.agent))
+        .unwrap_or(claudius::app_config::Agent::Claude);
+
+    debug!("Using agent: {:?}", agent);
+
+    // Determine context filename
+    let context_filename = determine_context_filename(agent_override, app_config, agent);
+
+    // Determine target directory
+    let target_dir = if let Some(p) = path {
+        if p.is_absolute() {
+            p
+        } else {
+            std::env::current_dir()?.join(p)
+        }
+    } else {
+        std::env::current_dir()?
+    };
+
+    // Create rules directory (default: .agents/rules, or custom install_dir)
+    let rules_base = install_dir.unwrap_or_else(|| std::path::PathBuf::from(".agents/rules"));
+    let rules_dir = if rules_base.is_absolute() { rules_base } else { target_dir.join(rules_base) };
+    fs::create_dir_all(&rules_dir)
+        .with_context(|| format!("Failed to create directory: {}", rules_dir.display()))?;
+
+    // Get config directory for source rules
+    let source_rules_dir = Config::get_config_dir()?.join("rules");
+    debug!("Looking for rules in: {}", source_rules_dir.display());
+
+    // Determine which rules to copy
+    let rules_to_copy = if all {
+        // Get all .md files from the rules directory recursively
+        println!(
+            "Installing ALL rules from {} (including subdirectories)",
+            source_rules_dir.display()
+        );
+        let mut all_rules = Vec::new();
+        collect_md_files(&source_rules_dir, &source_rules_dir, &mut all_rules)?;
+
+        if all_rules.is_empty() {
+            return Err(anyhow::anyhow!("No rules found in {}", source_rules_dir.display()));
+        }
+        all_rules.sort(); // Sort for consistent ordering
+        all_rules
+    } else {
+        rules
+    };
+
+    // Copy specified rules
+    let copied_rules = copy_rules(&rules_to_copy, &source_rules_dir, &rules_dir)?;
+
+    // Add reference directive to context file with the list of copied rules
+    add_reference_directive(&target_dir, &rules_dir, &context_filename, &copied_rules)?;
+
+    println!("Successfully installed {} rule(s) to {}", copied_rules.len(), rules_dir.display());
+
+    Ok(())
 }

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -1,0 +1,153 @@
+use crate::fixtures::TestFixture;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::fs;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_reports_legacy_and_supported_sources() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture.with_settings(r#"{"apiKeyHelper":"legacy-helper"}"#).unwrap();
+        fixture.with_skill("shared-skill", "# Shared Skill").unwrap();
+        fixture
+            .with_gemini_command(
+                "review",
+                "description = \"Review the current diff\"\nprompt = \"Review this change set.\"",
+            )
+            .unwrap();
+        fixture
+            .with_claude_code_agent(
+                "reviewer",
+                "---\nname: reviewer\ndescription: Review code changes\n---\nFocus on regressions.",
+            )
+            .unwrap();
+        fs::write(fixture.config.join("commands").join("legacy-review.md"), "# Legacy command")
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("SUPPORTED"))
+            .stdout(predicate::str::contains("Shared skills source is present."))
+            .stdout(predicate::str::contains("Gemini custom command source is present."))
+            .stdout(predicate::str::contains("Claude Code subagent source is present."))
+            .stdout(predicate::str::contains("LEGACY"))
+            .stdout(predicate::str::contains(
+                "Legacy settings.json is still active for Claude / Claude Code settings.",
+            ))
+            .stdout(predicate::str::contains(
+                "Legacy commands/*.md skill fallback is still in use.",
+            ));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_reports_stale_and_unmanaged_gemini_surfaces() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture
+            .with_gemini_command(
+                "review",
+                "description = \"Review the current diff\"\nprompt = \"Review this change set.\"",
+            )
+            .unwrap();
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success();
+
+        fs::remove_file(fixture.config.join("commands").join("gemini").join("review.toml"))
+            .unwrap();
+        fs::create_dir_all(fixture.project.join(".gemini").join("extensions").join("sample"))
+            .unwrap();
+        fs::write(
+            fixture
+                .project
+                .join(".gemini")
+                .join("extensions")
+                .join("sample")
+                .join("extension.json"),
+            "{}",
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--agent", "gemini"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("UNMANAGED"))
+            .stdout(predicate::str::contains(
+                "Gemini extensions are present in an unmanaged target directory.",
+            ))
+            .stdout(predicate::str::contains(".gemini/extensions"))
+            .stdout(predicate::str::contains("STALE"))
+            .stdout(predicate::str::contains(
+                "Claudius-managed Gemini commands target has stale deployed files.",
+            ))
+            .stdout(predicate::str::contains("claudius config sync --agent gemini --prune"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_global_reports_best_effort_and_experimental_surfaces() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture.with_existing_claude_desktop_config(r#"{"mcpServers": {}}"#).unwrap();
+
+        let codex_skill_dir = fixture.config.join("skills").join("codex").join("reviewer");
+        fs::create_dir_all(&codex_skill_dir).unwrap();
+        fs::write(codex_skill_dir.join("SKILL.md"), "# Reviewer Skill").unwrap();
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["skills", "sync", "--global", "--agent", "codex", "--enable-codex-skills"])
+            .assert()
+            .success();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--global"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("BEST-EFFORT"))
+            .stdout(predicate::str::contains(
+                "Claude Desktop JSON target is present as a legacy / best-effort surface.",
+            ))
+            .stdout(predicate::str::contains("claude_desktop_config.json"))
+            .stdout(predicate::str::contains("EXPERIMENTAL"))
+            .stdout(predicate::str::contains(
+                "Codex skill sync remains in experimental compatibility mode.",
+            ))
+            .stdout(predicate::str::contains(".agents/skills"));
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,6 +5,7 @@ mod codex_model_providers_test;
 mod codex_sync_test;
 mod codex_toml_test;
 mod context_test;
+mod doctor_test;
 mod gemini_system_settings_test;
 mod init_test;
 mod install_context_test;


### PR DESCRIPTION
## Summary
- add `claudius config doctor` to inspect configuration health across source files and deployed targets
- report supported, best-effort, legacy, unmanaged, experimental, and stale surfaces, including manifest-backed stale asset inspection
- document the new command and add integration coverage for the doctor workflow

## Testing
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c just test`
- `nix develop -c just build`

Closes #67