### PR TITLE
feat: make Codex skill target selection configurable

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -10,6 +10,8 @@ pub struct AppConfig {
     pub secret_manager: Option<SecretManagerConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<DefaultConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codex: Option<CodexConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,6 +20,13 @@ pub struct DefaultConfig {
     pub agent: Agent,
     #[serde(skip_serializing_if = "Option::is_none", rename = "context-file")]
     pub context_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct CodexConfig {
+    #[serde(skip_serializing_if = "Option::is_none", rename = "skill-target")]
+    pub skill_target: Option<CodexSkillTargetMode>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
@@ -40,6 +49,20 @@ pub enum ClaudeCodeScope {
     Project,
     /// Local (per-repo, per-user) configuration (.claude/*.local.* and ~/.claude.json per-project).
     Local,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodexSkillTargetMode {
+    /// Keep following Claudius's compatibility default for Codex skills.
+    #[default]
+    Auto,
+    /// Publish only to the Codex-native skills directory.
+    Codex,
+    /// Publish only to the compatibility `.agents/skills` directory.
+    Agents,
+    /// Publish to both Codex-native and compatibility directories.
+    Both,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -150,6 +173,54 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_skill_target_mode_serialization() {
+        assert_eq!(
+            serde_json::to_string(&CodexSkillTargetMode::Auto)
+                .expect("Failed to serialize CodexSkillTargetMode::Auto"),
+            "\"auto\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CodexSkillTargetMode::Codex)
+                .expect("Failed to serialize CodexSkillTargetMode::Codex"),
+            "\"codex\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CodexSkillTargetMode::Agents)
+                .expect("Failed to serialize CodexSkillTargetMode::Agents"),
+            "\"agents\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CodexSkillTargetMode::Both)
+                .expect("Failed to serialize CodexSkillTargetMode::Both"),
+            "\"both\""
+        );
+    }
+
+    #[test]
+    fn test_codex_skill_target_mode_deserialization() {
+        assert_eq!(
+            serde_json::from_str::<CodexSkillTargetMode>("\"auto\"")
+                .expect("Failed to deserialize CodexSkillTargetMode::Auto"),
+            CodexSkillTargetMode::Auto
+        );
+        assert_eq!(
+            serde_json::from_str::<CodexSkillTargetMode>("\"codex\"")
+                .expect("Failed to deserialize CodexSkillTargetMode::Codex"),
+            CodexSkillTargetMode::Codex
+        );
+        assert_eq!(
+            serde_json::from_str::<CodexSkillTargetMode>("\"agents\"")
+                .expect("Failed to deserialize CodexSkillTargetMode::Agents"),
+            CodexSkillTargetMode::Agents
+        );
+        assert_eq!(
+            serde_json::from_str::<CodexSkillTargetMode>("\"both\"")
+                .expect("Failed to deserialize CodexSkillTargetMode::Both"),
+            CodexSkillTargetMode::Both
+        );
+    }
+
+    #[test]
     fn test_secret_manager_type_serialization() {
         assert_eq!(
             serde_json::to_string(&SecretManagerType::Vault)
@@ -194,6 +265,7 @@ mod tests {
                 agent: Agent::Claude,
                 context_file: Some("CUSTOM.md".to_string()),
             }),
+            codex: Some(CodexConfig { skill_target: Some(CodexSkillTargetMode::Agents) }),
         };
 
         let toml_str = toml::to_string(&config).expect("Failed to serialize AppConfig");
@@ -202,6 +274,8 @@ mod tests {
         assert!(toml_str.contains("[default]"));
         assert!(toml_str.contains("agent = \"claude\""));
         assert!(toml_str.contains("context-file = \"CUSTOM.md\""));
+        assert!(toml_str.contains("[codex]"));
+        assert!(toml_str.contains("skill-target = \"agents\""));
     }
 
     #[test]
@@ -213,6 +287,9 @@ type = "1password"
 [default]
 agent = "codex"
 context-file = "AGENTS.md"
+
+[codex]
+skill-target = "both"
 "#;
 
         let config: AppConfig = toml::from_str(toml_str).expect("Failed to deserialize AppConfig");
@@ -225,6 +302,10 @@ context-file = "AGENTS.md"
         let default = config.default.expect("Default config should be present");
         assert_eq!(default.agent, Agent::Codex);
         assert_eq!(default.context_file, Some("AGENTS.md".to_string()));
+        assert_eq!(
+            config.codex.expect("Codex config should be present").skill_target,
+            Some(CodexSkillTargetMode::Both)
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::self_named_module_files)]
 
+use crate::app_config::{AppConfig, CodexSkillTargetMode};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -135,7 +136,7 @@ impl Config {
 
         let current_dir = if use_global { None } else { Some(std::env::current_dir()?) };
         let skills_target_dir =
-            Self::determine_skills_dir(use_global, agent, &home_dir, current_dir.as_deref());
+            Self::determine_skills_dir(use_global, agent, &home_dir, current_dir.as_deref())?;
 
         Ok(Self {
             mcp_servers_path: config_dir.join("mcpServers.json"),
@@ -239,14 +240,25 @@ impl Config {
         agent: Option<crate::app_config::Agent>,
         home_dir: &Path,
         current_dir: Option<&Path>,
-    ) -> PathBuf {
+    ) -> anyhow::Result<PathBuf> {
         let base_dir = if use_global { home_dir } else { current_dir.unwrap_or(home_dir) };
 
-        match agent {
+        Ok(match agent {
             Some(crate::app_config::Agent::Gemini) => base_dir.join(".gemini").join("skills"),
-            Some(crate::app_config::Agent::Codex) => base_dir.join(".codex").join("skills"),
+            Some(crate::app_config::Agent::Codex) => match Self::load_codex_skill_target_mode()? {
+                CodexSkillTargetMode::Agents => base_dir.join(".agents").join("skills"),
+                CodexSkillTargetMode::Auto
+                | CodexSkillTargetMode::Codex
+                | CodexSkillTargetMode::Both => base_dir.join(".codex").join("skills"),
+            },
             _ => base_dir.join(".claude").join("skills"),
-        }
+        })
+    }
+
+    fn load_codex_skill_target_mode() -> anyhow::Result<CodexSkillTargetMode> {
+        Ok(AppConfig::load()?
+            .and_then(|config| config.codex.and_then(|codex| codex.skill_target))
+            .unwrap_or_default())
     }
 
     fn skills_dir_has_entries(path: &Path) -> bool {
@@ -357,7 +369,12 @@ impl Config {
             return Ok(None);
         }
 
-        Ok(Some(self.deployment_base_dir()?.join(".agents").join("skills")))
+        Ok(match Self::load_codex_skill_target_mode()? {
+            CodexSkillTargetMode::Auto | CodexSkillTargetMode::Both => {
+                Some(self.deployment_base_dir()?.join(".agents").join("skills"))
+            },
+            CodexSkillTargetMode::Codex | CodexSkillTargetMode::Agents => None,
+        })
     }
 
     pub fn with_paths<P: Into<PathBuf>>(mcp_servers: P, target_config: P) -> Self {

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -38,6 +38,28 @@ mod tests {
         }
     }
 
+    fn run_codex_skill_sync(mode: &str) -> TestFixture {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_skill("codex-test", "# Codex Skill").unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(
+            fixture.config.join("config.toml"),
+            format!("[codex]\nskill-target = \"{mode}\"\n"),
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "codex", "--enable-codex-skills"])
+            .assert()
+            .success();
+
+        fixture
+    }
+
     #[test]
     #[serial]
     fn test_skills_sync_project_local() {
@@ -131,20 +153,39 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_skills_sync_codex_project_local_uses_compatibility_targets() {
+    fn test_skills_sync_codex_auto_targets_both_project_local() {
         let _env_guard = EnvGuard::new();
-        let fixture = TestFixture::new().unwrap();
-        fixture.setup_env();
+        let fixture = run_codex_skill_sync("auto");
 
-        fixture.with_skill("codex-test", "# Codex Skill").unwrap();
-        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        assert!(fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
+        assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
+    }
 
-        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
-        cmd.current_dir(&fixture.project)
-            .env("XDG_CONFIG_HOME", fixture.config_home())
-            .args(["skills", "sync", "--agent", "codex", "--enable-codex-skills"])
-            .assert()
-            .success();
+    #[test]
+    #[serial]
+    fn test_skills_sync_codex_mode_targets_only_codex_project_local() {
+        let _env_guard = EnvGuard::new();
+        let fixture = run_codex_skill_sync("codex");
+
+        assert!(fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
+        assert!(!fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_codex_mode_targets_only_agents_project_local() {
+        let _env_guard = EnvGuard::new();
+        let fixture = run_codex_skill_sync("agents");
+
+        assert!(!fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
+        assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_codex_mode_targets_both_project_local() {
+        let _env_guard = EnvGuard::new();
+        let fixture = run_codex_skill_sync("both");
 
         assert!(fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
         assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));

--- a/tests/unit/config_agent_test.rs
+++ b/tests/unit/config_agent_test.rs
@@ -104,9 +104,9 @@ mod tests {
         fs::create_dir_all(&project_dir).unwrap();
         std::env::set_current_dir(&project_dir).unwrap();
 
-        let canonical_project_dir = fs::canonicalize(&project_dir).unwrap();
-        let codex_target = canonical_project_dir.join(".codex").join("skills");
-        let agents_target = canonical_project_dir.join(".agents").join("skills");
+        let current_project_dir = std::env::current_dir().unwrap();
+        let codex_target = current_project_dir.join(".codex").join("skills");
+        let agents_target = current_project_dir.join(".agents").join("skills");
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
@@ -142,9 +142,9 @@ mod tests {
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(config_dir.join("mcpServers.json"), "{}").unwrap();
 
-        let canonical_home_dir = fs::canonicalize(temp_dir.path()).unwrap();
-        let codex_target = canonical_home_dir.join(".codex").join("skills");
-        let agents_target = canonical_home_dir.join(".agents").join("skills");
+        let resolved_home_dir = directories::BaseDirs::new().unwrap().home_dir().to_path_buf();
+        let codex_target = resolved_home_dir.join(".codex").join("skills");
+        let agents_target = resolved_home_dir.join(".agents").join("skills");
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();

--- a/tests/unit/config_agent_test.rs
+++ b/tests/unit/config_agent_test.rs
@@ -90,6 +90,83 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_codex_skills_target_dirs_project_local_modes() {
+        let _env_guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+
+        let config_dir = temp_dir.path().join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join("mcpServers.json"), "{}").unwrap();
+
+        let project_dir = temp_dir.path().join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        std::env::set_current_dir(&project_dir).unwrap();
+
+        let codex_target = project_dir.join(".codex").join("skills");
+        let agents_target = project_dir.join(".agents").join("skills");
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
+        let auto = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
+        assert_eq!(auto.skills_target_dir, codex_target);
+        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), Some(agents_target.clone()));
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
+        let codex_only = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
+        assert_eq!(codex_only.skills_target_dir, project_dir.join(".codex").join("skills"));
+        assert_eq!(codex_only.codex_compat_skills_target_dir().unwrap(), None);
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
+        let agents_only = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
+        assert_eq!(agents_only.skills_target_dir, agents_target.clone());
+        assert_eq!(agents_only.codex_compat_skills_target_dir().unwrap(), None);
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
+        let both = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
+        assert_eq!(both.skills_target_dir, project_dir.join(".codex").join("skills"));
+        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
+    }
+
+    #[test]
+    #[serial]
+    fn test_codex_skills_target_dirs_global_modes() {
+        let _env_guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+        std::env::set_var("HOME", temp_dir.path());
+
+        let config_dir = temp_dir.path().join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(config_dir.join("mcpServers.json"), "{}").unwrap();
+
+        let codex_target = temp_dir.path().join(".codex").join("skills");
+        let agents_target = temp_dir.path().join(".agents").join("skills");
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
+        let auto = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
+        assert_eq!(auto.skills_target_dir, codex_target);
+        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), Some(agents_target.clone()));
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
+        let codex_only = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
+        assert_eq!(codex_only.skills_target_dir, temp_dir.path().join(".codex").join("skills"));
+        assert_eq!(codex_only.codex_compat_skills_target_dir().unwrap(), None);
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
+        let agents_only = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
+        assert_eq!(agents_only.skills_target_dir, agents_target.clone());
+        assert_eq!(agents_only.codex_compat_skills_target_dir().unwrap(), None);
+
+        fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
+        let both = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
+        assert_eq!(both.skills_target_dir, temp_dir.path().join(".codex").join("skills"));
+        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_with_gemini_agent_local() {
         let _env_guard = EnvGuard::new();
         let temp_dir = TempDir::new().unwrap();

--- a/tests/unit/config_agent_test.rs
+++ b/tests/unit/config_agent_test.rs
@@ -104,8 +104,9 @@ mod tests {
         fs::create_dir_all(&project_dir).unwrap();
         std::env::set_current_dir(&project_dir).unwrap();
 
-        let codex_target = project_dir.join(".codex").join("skills");
-        let agents_target = project_dir.join(".agents").join("skills");
+        let canonical_project_dir = fs::canonicalize(&project_dir).unwrap();
+        let codex_target = canonical_project_dir.join(".codex").join("skills");
+        let agents_target = canonical_project_dir.join(".agents").join("skills");
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
@@ -114,7 +115,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
         let codex_only = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
-        assert_eq!(codex_only.skills_target_dir, project_dir.join(".codex").join("skills"));
+        assert_eq!(codex_only.skills_target_dir, codex_target);
         assert_eq!(codex_only.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
@@ -124,7 +125,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
         let both = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
-        assert_eq!(both.skills_target_dir, project_dir.join(".codex").join("skills"));
+        assert_eq!(both.skills_target_dir, codex_target);
         assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
     }
 
@@ -141,8 +142,9 @@ mod tests {
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(config_dir.join("mcpServers.json"), "{}").unwrap();
 
-        let codex_target = temp_dir.path().join(".codex").join("skills");
-        let agents_target = temp_dir.path().join(".agents").join("skills");
+        let canonical_home_dir = fs::canonicalize(temp_dir.path()).unwrap();
+        let codex_target = canonical_home_dir.join(".codex").join("skills");
+        let agents_target = canonical_home_dir.join(".agents").join("skills");
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
@@ -151,7 +153,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
         let codex_only = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
-        assert_eq!(codex_only.skills_target_dir, temp_dir.path().join(".codex").join("skills"));
+        assert_eq!(codex_only.skills_target_dir, codex_target);
         assert_eq!(codex_only.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
@@ -161,7 +163,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
         let both = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
-        assert_eq!(both.skills_target_dir, temp_dir.path().join(".codex").join("skills"));
+        assert_eq!(both.skills_target_dir, codex_target);
         assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
     }
 


### PR DESCRIPTION
## Summary
- add `[codex] skill-target` to `config.toml` via `AppConfig`
- route Codex skill sync to `.codex/skills`, `.agents/skills`, or both based on that mode
- cover the new project-local and global target selection behavior with unit and integration tests

## Verification
- `cargo fmt --all --check`
- `cargo test`
- `cargo build --release`

Closes #71