### PR TITLE
ci: update actions/github-script to v9

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create issue for security failures
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '🚨 Security Audit Failed';


### PR DESCRIPTION
## Summary
- update `actions/github-script` from `v8` to `v9` in the security workflow
- keep the workflow change isolated from other dependency updates
- supersede Dependabot PR #82 with a signed, verified update

## Validation
- `nix develop -c pre-commit run --files .github/workflows/security.yml`
- `nix develop -c just test`
- `nix flake check`
