### PR TITLE
ci: update codecov action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info


### PR DESCRIPTION
## Summary
- update `codecov/codecov-action` from `v4` to `v6` in the CI workflow
- keep the existing upload inputs (`token`, `files`, `fail_ci_if_error`) unchanged
- supersede Dependabot PR #79 with a signed, isolated major-version update

## Notes
- this is a major action update, so the change is intentionally limited to the Codecov step
- CI on GitHub will provide the final confirmation for the hosted action runtime change

## Validation
- `nix develop -c pre-commit run --files .github/workflows/ci.yml`
- `nix develop -c just test`
- `nix flake check`
