### PR TITLE
chore: add baseline repository hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default owner for all repository changes.
+* @cariandrum22
+
+# Repository policy and automation.
+/.github/ @cariandrum22
+/.github/CODEOWNERS @cariandrum22
+
+# Security- and release-sensitive files.
+/Cargo.toml @cariandrum22
+/Cargo.lock @cariandrum22
+/deny.toml @cariandrum22
+/flake.nix @cariandrum22
+/flake.lock @cariandrum22
+/src/config.rs @cariandrum22
+/src/secrets.rs @cariandrum22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
   # Security audit job
   security:
-    name: Security Audit
+    name: CI Security Audit
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: Security Audit
+name: Repository Security Audit
 
 on:
   schedule:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   audit:
-    name: Security Audit
+    name: Scheduled Security Audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ target/llvm-cov/
 !README.md
 !CLAUDE.md
 !CHANGELOG.md
+!SECURITY.md
 !docs/*.md
 
 # Logs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| `main` branch | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Do not report security issues through public GitHub issues, discussions, or pull requests.
+
+Preferred channel:
+
+- Use GitHub Private Vulnerability Reporting from the repository Security tab.
+
+If private reporting is not available:
+
+- Open a regular issue that asks for a private contact channel and does not include
+  vulnerability details, proof of concept, or exploit steps.
+
+Please include:
+
+- The affected version, tag, or commit SHA
+- Reproduction steps or a proof of concept
+- Impact, attack scenario, and any relevant prerequisites
+- Suggested remediation or mitigations, if known
+
+We will triage reports, validate impact, and coordinate disclosure before publishing a fix.

--- a/flake.nix
+++ b/flake.nix
@@ -270,13 +270,13 @@
             };
 
             check-yaml = {
-              enable = false; # No YAML files in the project
+              enable = true;
               entry = "${pkgs.writeShellScript "check-yaml" ''
                 if [ $# -eq 0 ]; then
                   exit 0
                 fi
                 for file in "$@"; do
-                  ${pkgs.yq}/bin/yq e '.' "$file" > /dev/null || exit 1
+                  ${pkgs.yq}/bin/yq '.' "$file" > /dev/null || exit 1
                 done
               ''}";
               types = [ "yaml" ];


### PR DESCRIPTION
## Summary
- add `SECURITY.md` with supported versions and a private reporting path
- add `.github/CODEOWNERS` for repository-wide ownership and sensitive files
- add a `Dependency Review` workflow for pull request dependency changes
- make security-related job names unique across workflows so required checks can be configured cleanly
- enable the existing YAML validation hook and fix its `yq` invocation

## Validation
- `nix develop -c just test`
- `nix flake check`

## Follow-up In GitHub Settings
- enable a `main` ruleset with required PRs, approvals, conversation resolution, and required checks
- enable private vulnerability reporting
- enable secret scanning / push protection if available for this repository