### PR TITLE
docs: clarify Codex skill target configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,13 @@ claudius skills sync --dry-run --prune
 # Remove stale deployed skill files that Claudius previously published
 claudius skills sync --prune
 
-# Codex skills are experimental and must be explicitly enabled
-# (synced to both .codex/skills and .agents/skills for compatibility)
+# Codex skills are experimental and must be explicitly enabled.
+# Target selection is driven by ~/.config/claudius/config.toml:
+#
+# [codex]
+# skill-target = "auto"   # auto | codex | agents | both
+#
+# `auto` currently syncs to both .codex/skills and .agents/skills for compatibility.
 claudius skills sync --agent codex --enable-codex-skills
 ```
 
@@ -587,8 +592,15 @@ claudius config sync
 
 Skills are deployed to `~/.claude/skills/` (Claude / Claude Code) or `~/.gemini/skills/`
 (Gemini), preserving the directory structure. Codex skills are experimental and require
-explicit opt-in; when enabled they are synced to both `~/.codex/skills/` and
-`~/.agents/skills/` for compatibility.
+explicit opt-in. Configure Codex target selection in `~/.config/claudius/config.toml`:
+
+```toml
+[codex]
+skill-target = "auto" # auto | codex | agents | both
+```
+
+Today `auto` remains compatibility-oriented and publishes to both `~/.codex/skills/`
+and `~/.agents/skills/`.
 
 By default, skill and auxiliary file sync is non-destructive. Use `--prune` to remove
 stale files that Claudius previously deployed. Pruning only touches files tracked in

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -69,6 +69,10 @@ const EXAMPLE_CONFIG: &str = r#"# Claudius Configuration File
 # agent = "claude"  # Options: "claude", "claude-code", "codex", "gemini"
 # context-file = "CONTEXT.md"  # Custom context file name (overrides agent defaults)
 
+# [codex]
+# Configure experimental Codex skills target selection
+# skill-target = "auto"  # Options: "auto", "codex", "agents", "both"
+
 # [secret-manager]
 # Configure a secret manager to resolve environment variables
 # Supported types: "vault", "1password"
@@ -503,6 +507,11 @@ mod tests {
         let mcp_content = fs::read_to_string(config_dir.join("mcpServers.json"))
             .expect("mcpServers.json should be readable");
         assert!(mcp_content.contains("filesystem"));
+
+        let app_config =
+            fs::read_to_string(config_dir.join("config.toml")).expect("config.toml should exist");
+        assert!(app_config.contains("[codex]"));
+        assert!(app_config.contains("skill-target = \"auto\""));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -209,7 +209,15 @@ pub enum SkillsCommands {
     #[command(long_about = "Synchronize skills into agent directories.
 
 This command copies skills from your skills/ directory into \
-the agent's skills directory, ensuring all skills are up to date.")]
+the agent's skills directory, ensuring all skills are up to date.
+
+Codex skills remain experimental and require `--enable-codex-skills`.
+Choose the Codex target behavior in $XDG_CONFIG_HOME/claudius/config.toml:
+
+  [codex]
+  skill-target = \"auto\"   # auto | codex | agents | both
+
+`auto` currently publishes to both .codex/skills and .agents/skills for compatibility.")]
     Sync(SkillsSyncArgs),
 }
 


### PR DESCRIPTION
## Summary
- document that Codex skill target selection is configured through `config.toml`
- align `skills sync` CLI help with the current Codex target modes and compatibility behavior
- add the same guidance to the bootstrap `config.toml` template and cover it in the bootstrap test

## Context
The Codex skill target selection feature landed in #77. This follow-up makes the docs and generated config template match the implemented behavior on `main`.

## Testing
- `XDG_CACHE_HOME=/tmp/claudius-nix-cache nix develop --command cargo test skills_sync_codex -- --test-threads=1`
- `XDG_CACHE_HOME=/tmp/claudius-nix-cache nix develop --command cargo test codex_skills_target_dirs -- --test-threads=1`
- `XDG_CACHE_HOME=/tmp/claudius-nix-cache nix develop --command cargo test bootstrap_creates_structure -- --test-threads=1`