### PR TITLE
feat: add configurable 1Password auth modes for secrets run

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,9 +564,18 @@ context-file = "CLAUDE.md"  # optional custom filename
 [secret-manager]
 type = "1password"  # or "vault"
 
+[secret-manager.onepassword]
+# Optional auth policy for 1Password resolution during `claudius secrets run`.
+# Leave `mode` unset to keep using your ambient `op` environment.
+mode = "service-account"  # or "desktop" or "manual"
+service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
+
 # When using 1Password:
 # - Install 1Password CLI (`op`)
-# - Sign in with `op signin`
+# - Choose one of:
+#   - `mode = "desktop"` for desktop app integration
+#   - `mode = "manual"` after `op signin`
+#   - `mode = "service-account"` for headless hosts
 # - Use op:// references in CLAUDIUS_SECRET_* variables
 #
 # For op:// references in URLs, use {{op://...}} syntax:
@@ -771,6 +780,13 @@ type = "codex"' >> ~/.config/claudius/config.toml
 echo '[secret-manager]
 type = "1password"' >> ~/.config/claudius/config.toml
 
+# Optional: make headless Linux use a 1Password service account token file
+cat <<'EOF' >> ~/.config/claudius/config.toml
+[secret-manager.onepassword]
+mode = "service-account"
+service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
+EOF
+
 # Use secrets in environment
 export CLAUDIUS_SECRET_API_KEY=op://vault/api/key
 export CLAUDIUS_SECRET_DB_PASS=op://vault/db/password
@@ -783,6 +799,17 @@ export CLAUDIUS_SECRET_AUTH="Bearer {{op://vault/tokens/api}}"
 claudius secrets run -- ./my-app
 # API_KEY, DB_PASS, BASE_URL, and AUTH are available to my-app with resolved values
 ```
+
+Environment overrides are also available when you need to switch auth policy without editing
+`config.toml`:
+
+```bash
+export CLAUDIUS_1PASSWORD_MODE=service-account
+export CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH=~/.config/op/service-accounts/headless-linux-cli.token
+```
+
+For backward compatibility, Claudius also accepts the legacy names
+`CLAUDIUS_OP_MODE` and `CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH`.
 
 ### Team Collaboration
 

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
@@ -65,11 +65,13 @@ pub enum CodexSkillTargetMode {
     Both,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct SecretManagerConfig {
     #[serde(rename = "type")]
     pub manager_type: SecretManagerType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub onepassword: Option<OnePasswordConfig>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -78,6 +80,36 @@ pub enum SecretManagerType {
     Vault,
     #[serde(rename = "1password")]
     OnePassword, // Represents 1Password
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct OnePasswordConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<OnePasswordMode>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "service-account-token-path")]
+    pub service_account_token_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnePasswordMode {
+    Desktop,
+    Manual,
+    ServiceAccount,
+}
+
+impl FromStr for OnePasswordMode {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value {
+            "desktop" => Ok(Self::Desktop),
+            "manual" => Ok(Self::Manual),
+            "service-account" => Ok(Self::ServiceAccount),
+            _ => Err("expected one of: desktop, manual, service-account"),
+        }
+    }
 }
 
 impl AppConfig {
@@ -260,6 +292,12 @@ mod tests {
         let config = AppConfig {
             secret_manager: Some(SecretManagerConfig {
                 manager_type: SecretManagerType::OnePassword,
+                onepassword: Some(OnePasswordConfig {
+                    mode: Some(OnePasswordMode::ServiceAccount),
+                    service_account_token_path: Some(
+                        "~/.config/op/service-accounts/headless-linux-cli.token".to_string(),
+                    ),
+                }),
             }),
             default: Some(DefaultConfig {
                 agent: Agent::Claude,
@@ -271,6 +309,9 @@ mod tests {
         let toml_str = toml::to_string(&config).expect("Failed to serialize AppConfig");
         assert!(toml_str.contains("[secret-manager]"));
         assert!(toml_str.contains("type = \"1password\""));
+        assert!(toml_str.contains("[secret-manager.onepassword]"));
+        assert!(toml_str.contains("mode = \"service-account\""));
+        assert!(toml_str.contains("service-account-token-path"));
         assert!(toml_str.contains("[default]"));
         assert!(toml_str.contains("agent = \"claude\""));
         assert!(toml_str.contains("context-file = \"CUSTOM.md\""));
@@ -284,6 +325,10 @@ mod tests {
 [secret-manager]
 type = "1password"
 
+[secret-manager.onepassword]
+mode = "service-account"
+service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
+
 [default]
 agent = "codex"
 context-file = "AGENTS.md"
@@ -294,9 +339,16 @@ skill-target = "both"
 
         let config: AppConfig = toml::from_str(toml_str).expect("Failed to deserialize AppConfig");
         assert!(config.secret_manager.is_some());
+        let secret_manager = config.secret_manager.expect("Secret manager should be present");
+        assert_eq!(secret_manager.manager_type, SecretManagerType::OnePassword);
         assert_eq!(
-            config.secret_manager.expect("Secret manager should be present").manager_type,
-            SecretManagerType::OnePassword
+            secret_manager.onepassword,
+            Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::ServiceAccount),
+                service_account_token_path: Some(
+                    "~/.config/op/service-accounts/headless-linux-cli.token".to_string(),
+                ),
+            })
         );
         assert!(config.default.is_some());
         let default = config.default.expect("Default config should be present");
@@ -399,6 +451,63 @@ agent = "claude"
         let config: AppConfig = toml::from_str(toml_str).expect("Failed to deserialize AppConfig");
         assert!(config.secret_manager.is_none());
         assert_eq!(config.default.expect("Default config should be present").agent, Agent::Claude);
+    }
+
+    #[test]
+    fn test_onepassword_mode_serialization() {
+        assert_eq!(
+            serde_json::to_string(&OnePasswordMode::Desktop)
+                .expect("Failed to serialize OnePasswordMode::Desktop"),
+            "\"desktop\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OnePasswordMode::Manual)
+                .expect("Failed to serialize OnePasswordMode::Manual"),
+            "\"manual\""
+        );
+        assert_eq!(
+            serde_json::to_string(&OnePasswordMode::ServiceAccount)
+                .expect("Failed to serialize OnePasswordMode::ServiceAccount"),
+            "\"service-account\""
+        );
+    }
+
+    #[test]
+    fn test_onepassword_mode_deserialization() {
+        assert_eq!(
+            serde_json::from_str::<OnePasswordMode>("\"desktop\"")
+                .expect("Failed to deserialize OnePasswordMode::Desktop"),
+            OnePasswordMode::Desktop
+        );
+        assert_eq!(
+            serde_json::from_str::<OnePasswordMode>("\"manual\"")
+                .expect("Failed to deserialize OnePasswordMode::Manual"),
+            OnePasswordMode::Manual
+        );
+        assert_eq!(
+            serde_json::from_str::<OnePasswordMode>("\"service-account\"")
+                .expect("Failed to deserialize OnePasswordMode::ServiceAccount"),
+            OnePasswordMode::ServiceAccount
+        );
+    }
+
+    #[test]
+    fn test_onepassword_mode_from_str() {
+        assert_eq!(
+            "desktop".parse::<OnePasswordMode>().expect("desktop should parse"),
+            OnePasswordMode::Desktop
+        );
+        assert_eq!(
+            "manual".parse::<OnePasswordMode>().expect("manual should parse"),
+            OnePasswordMode::Manual
+        );
+        assert_eq!(
+            "service-account"
+                .parse::<OnePasswordMode>()
+                .expect("service-account should parse"),
+            OnePasswordMode::ServiceAccount
+        );
+        assert!("invalid".parse::<OnePasswordMode>().is_err());
     }
 
     #[test]

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -79,6 +79,11 @@ const EXAMPLE_CONFIG: &str = r#"# Claudius Configuration File
 #
 # Example for 1Password:
 # type = "1password"
+# [secret-manager.onepassword]
+# Optional auth policy for 1Password resolution during `claudius secrets run`.
+# Leave `mode` unset to keep using your ambient `op` environment.
+# mode = "service-account"  # "desktop", "manual", or "service-account"
+# service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
 #
 # When using 1Password, environment variables starting with CLAUDIUS_SECRET_*
 # that contain values starting with op:// will be resolved using 1Password CLI.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,11 @@ fn main() -> Result<()> {
 
     initialize_tracing(cli.debug, cli.trace);
 
-    let app_config = load_and_log_config()?;
-    resolve_and_inject_secrets(app_config.as_ref());
+    let log_app_config_warnings = !matches!(
+        cli.command.as_ref(),
+        Some(cli::Commands::Config(cli::ConfigCommands::Validate(_)))
+    );
+    let app_config = load_and_log_config(log_app_config_warnings)?;
 
     if cli.list_commands {
         print_available_commands();
@@ -71,7 +74,7 @@ fn initialize_tracing(debug: bool, trace: bool) {
 }
 
 /// Load application configuration and log its status
-fn load_and_log_config() -> Result<Option<AppConfig>> {
+fn load_and_log_config(log_app_config_warnings: bool) -> Result<Option<AppConfig>> {
     let app_config = AppConfig::load().context("Failed to load app configuration")?;
 
     if let Some(ref config) = app_config {
@@ -80,6 +83,12 @@ fn load_and_log_config() -> Result<Option<AppConfig>> {
         if let Some(ref secret_manager) = config.secret_manager {
             debug!("Secret manager configured: {:?}", secret_manager.manager_type);
         }
+
+        if log_app_config_warnings {
+            for warning in claudius::validation::validate_app_config(config).warnings {
+                warn!("{warning}");
+            }
+        }
     } else {
         debug!("No app configuration file found at: {}", AppConfig::config_path()?.display());
     }
@@ -87,26 +96,21 @@ fn load_and_log_config() -> Result<Option<AppConfig>> {
     Ok(app_config)
 }
 
-/// Resolve and inject secrets from environment variables
-fn resolve_and_inject_secrets(app_config: Option<&AppConfig>) {
-    let secret_manager_config = app_config.and_then(|c| c.secret_manager);
+/// Resolve and inject secrets from environment variables for `secrets run`.
+fn resolve_and_inject_secrets(app_config: Option<&AppConfig>) -> Result<()> {
+    let secret_manager_config = app_config.and_then(|c| c.secret_manager.clone());
     let resolver = SecretResolver::new(secret_manager_config);
 
-    match resolver.resolve_env_vars() {
-        Ok(resolved_vars) => {
-            if !resolved_vars.is_empty() {
-                debug!("Resolved {} secret(s) from environment variables", resolved_vars.len());
-                for key in resolved_vars.keys() {
-                    debug!("  - {} (from CLAUDIUS_SECRET_{})", key, key);
-                }
-                SecretResolver::inject_env_vars(resolved_vars);
-            }
-        },
-        Err(e) => {
-            error!("Failed to resolve secrets: {}", e);
-            std::process::exit(1);
-        },
+    let resolved_vars = resolver.resolve_env_vars()?;
+    if !resolved_vars.is_empty() {
+        debug!("Resolved {} secret(s) from environment variables", resolved_vars.len());
+        for key in resolved_vars.keys() {
+            debug!("  - {} (from CLAUDIUS_SECRET_{})", key, key);
+        }
+        SecretResolver::inject_env_vars(resolved_vars);
     }
+
+    Ok(())
 }
 
 /// Dispatch to the appropriate command handler
@@ -374,51 +378,13 @@ fn run_config_validate(
     args: cli::ConfigValidateArgs,
     app_config: Option<&AppConfig>,
 ) -> Result<()> {
-    use claudius::app_config::Agent;
-
     let cli::ConfigValidateArgs { agent, strict } = args;
     let effective_agent =
         agent.or_else(|| app_config.and_then(|cfg| cfg.default.as_ref()).map(|d| d.agent));
 
     let config_dir =
         Config::get_config_dir().context("Failed to determine Claudius config directory")?;
-
-    let mut warnings = Vec::new();
-
-    // MCP servers (required)
-    let mcp_servers_path = config_dir.join("mcpServers.json");
-    let mcp_servers = reader::read_mcp_servers_config(&mcp_servers_path).with_context(|| {
-        format!("Failed to read MCP servers config: {}", mcp_servers_path.display())
-    })?;
-
-    for (name, server) in &mcp_servers.mcp_servers {
-        if server.command.is_none() && server.url.is_none() {
-            warnings.push(format!(
-                "{}: mcpServers.{name} must define either command or url",
-                mcp_servers_path.display(),
-            ));
-        }
-    }
-
-    match effective_agent {
-        Some(Agent::Claude) => {
-            warnings.extend(validate_claude_settings_sources(&config_dir)?);
-        },
-        Some(Agent::ClaudeCode) => {
-            warnings.extend(validate_claude_code_sources(&config_dir)?);
-        },
-        Some(Agent::Codex) => {
-            warnings.extend(validate_codex_sources(&config_dir)?);
-        },
-        Some(Agent::Gemini) => {
-            warnings.extend(validate_gemini_sources(&config_dir)?);
-        },
-        None => {
-            warnings.extend(validate_claude_code_sources(&config_dir)?);
-            warnings.extend(validate_codex_sources(&config_dir)?);
-            warnings.extend(validate_gemini_sources(&config_dir)?);
-        },
-    }
+    let warnings = collect_config_validation_warnings(&config_dir, effective_agent, app_config)?;
 
     if warnings.is_empty() {
         println!("Configuration validation passed");
@@ -435,6 +401,60 @@ fn run_config_validate(
     }
 
     Ok(())
+}
+
+fn collect_config_validation_warnings(
+    config_dir: &std::path::Path,
+    effective_agent: Option<claudius::app_config::Agent>,
+    app_config: Option<&AppConfig>,
+) -> Result<Vec<String>> {
+    let mut warnings = app_config
+        .map(|config| claudius::validation::validate_app_config(config).warnings)
+        .unwrap_or_default();
+
+    warnings.extend(validate_mcp_server_sources(config_dir)?);
+    warnings.extend(validate_agent_sources(config_dir, effective_agent)?);
+
+    Ok(warnings)
+}
+
+fn validate_mcp_server_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
+    let mcp_servers_path = config_dir.join("mcpServers.json");
+    let mcp_servers = reader::read_mcp_servers_config(&mcp_servers_path).with_context(|| {
+        format!("Failed to read MCP servers config: {}", mcp_servers_path.display())
+    })?;
+
+    Ok(mcp_servers
+        .mcp_servers
+        .iter()
+        .filter(|(_, server)| server.command.is_none() && server.url.is_none())
+        .map(|(name, _)| {
+            format!(
+                "{}: mcpServers.{name} must define either command or url",
+                mcp_servers_path.display(),
+            )
+        })
+        .collect())
+}
+
+fn validate_agent_sources(
+    config_dir: &std::path::Path,
+    effective_agent: Option<claudius::app_config::Agent>,
+) -> Result<Vec<String>> {
+    use claudius::app_config::Agent;
+
+    match effective_agent {
+        Some(Agent::Claude) => validate_claude_settings_sources(config_dir),
+        Some(Agent::ClaudeCode) => validate_claude_code_sources(config_dir),
+        Some(Agent::Codex) => validate_codex_sources(config_dir),
+        Some(Agent::Gemini) => validate_gemini_sources(config_dir),
+        None => {
+            let mut warnings = validate_claude_code_sources(config_dir)?;
+            warnings.extend(validate_codex_sources(config_dir)?);
+            warnings.extend(validate_gemini_sources(config_dir)?);
+            Ok(warnings)
+        },
+    }
 }
 
 fn run_config_doctor(args: cli::ConfigDoctorArgs) -> Result<()> {
@@ -1204,9 +1224,14 @@ fn handle_exit_status(status: std::process::ExitStatus) -> ! {
     std::process::exit(0);
 }
 
-fn run_command(command: &[String], _app_config: Option<&AppConfig>) -> Result<()> {
+fn run_command(command: &[String], app_config: Option<&AppConfig>) -> Result<()> {
     if command.is_empty() {
         error!("No command specified");
+        std::process::exit(1);
+    }
+
+    if let Err(error) = resolve_and_inject_secrets(app_config) {
+        error!("Failed to resolve secrets: {}", error);
         std::process::exit(1);
     }
 
@@ -1231,7 +1256,7 @@ fn run_command(command: &[String], _app_config: Option<&AppConfig>) -> Result<()
 }
 
 fn run_command_inner(command: &[String]) -> Result<std::process::ExitStatus> {
-    // Secrets are already resolved in main(), no need to resolve again
+    // Secrets are already resolved in run_command(), no need to resolve again
 
     // Extract command and arguments
     let (program, args) =

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,16 +1,95 @@
-#[cfg(not(test))]
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rayon::prelude::*;
 use std::collections::HashMap;
+use std::path::PathBuf;
 #[cfg(not(test))]
 use std::process::Command;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, warn};
 
-use crate::app_config::{SecretManagerConfig, SecretManagerType};
+#[cfg(test)]
+use crate::app_config::OnePasswordConfig;
+use crate::app_config::{OnePasswordMode, SecretManagerConfig, SecretManagerType};
 use crate::profiling::{SecretResolutionMetrics, Timer};
 use crate::variable_expansion::expand_variables;
+
+const ONEPASSWORD_MODE_ENV: &str = "CLAUDIUS_1PASSWORD_MODE";
+const LEGACY_ONEPASSWORD_MODE_ENV: &str = "CLAUDIUS_OP_MODE";
+const ONEPASSWORD_TOKEN_PATH_ENV: &str = "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH";
+const LEGACY_ONEPASSWORD_TOKEN_PATH_ENV: &str = "CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH";
+const OP_SERVICE_ACCOUNT_TOKEN_ENV: &str = "OP_SERVICE_ACCOUNT_TOKEN";
+const ONEPASSWORD_AUTH_BASE_ENV_VARS: [&str; 5] = [
+    OP_SERVICE_ACCOUNT_TOKEN_ENV,
+    "OP_SESSION",
+    "OP_ACCOUNT",
+    "OP_CONNECT_HOST",
+    "OP_CONNECT_TOKEN",
+];
+
+fn is_op_session_env(name: &str) -> bool {
+    name == "OP_SESSION" || name.starts_with("OP_SESSION_")
+}
+
+fn onepassword_auth_env_var_names() -> Vec<String> {
+    let mut names: Vec<String> =
+        ONEPASSWORD_AUTH_BASE_ENV_VARS.iter().map(|name| (*name).to_string()).collect();
+
+    names.extend(
+        std::env::vars()
+            .map(|(name, _)| name)
+            .filter(|name| is_op_session_env(name) && name != "OP_SESSION"),
+    );
+
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+fn sanitize_onepassword_account_suffix(account: &str) -> String {
+    account
+        .chars()
+        .map(|character| if character.is_ascii_alphanumeric() { character } else { '_' })
+        .collect()
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct EffectiveOnePasswordConfig {
+    mode: Option<OnePasswordMode>,
+    service_account_token_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct ScopedEnvVarChanges {
+    originals: Vec<(String, Option<String>)>,
+}
+
+impl ScopedEnvVarChanges {
+    fn capture(var_names: &[String]) -> Self {
+        let originals =
+            var_names.iter().map(|name| (name.clone(), std::env::var(name).ok())).collect();
+
+        Self { originals }
+    }
+
+    fn set_var(name: &str, value: &str) {
+        std::env::set_var(name, value);
+    }
+
+    fn remove_var(name: &str) {
+        std::env::remove_var(name);
+    }
+}
+
+impl Drop for ScopedEnvVarChanges {
+    fn drop(&mut self) {
+        for (name, original_value) in self.originals.iter().rev() {
+            match original_value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct SecretResolver {
@@ -44,6 +123,7 @@ impl SecretResolver {
 
         // Phase 1: Collect environment variables
         let claudius_secrets = self.collect_claudius_secrets();
+        let _auth_guard = self.prepare_onepassword_environment(&claudius_secrets)?;
 
         // Phase 1.5: If using 1Password, perform a single preflight resolution so any interactive
         // unlock happens before parallel resolution begins.
@@ -119,6 +199,207 @@ impl SecretResolver {
 
         debug!("Found {} CLAUDIUS_SECRET_* variables", secrets.len());
         secrets
+    }
+
+    fn prepare_onepassword_environment(
+        &self,
+        secrets: &HashMap<String, String>,
+    ) -> Result<Option<ScopedEnvVarChanges>> {
+        if !Self::contains_onepassword_reference(secrets) {
+            return Ok(None);
+        }
+
+        let Some(config) = self.effective_onepassword_config()? else {
+            return Ok(None);
+        };
+        let Some(mode) = config.mode else {
+            return Ok(None);
+        };
+
+        let auth_env_vars = onepassword_auth_env_var_names();
+        let existing_service_account_token = Self::read_env_non_empty(OP_SERVICE_ACCOUNT_TOKEN_ENV);
+        let guard = ScopedEnvVarChanges::capture(&auth_env_vars);
+
+        match mode {
+            OnePasswordMode::Desktop => {
+                for name in &auth_env_vars {
+                    ScopedEnvVarChanges::remove_var(name);
+                }
+            },
+            OnePasswordMode::Manual => {
+                ScopedEnvVarChanges::remove_var(OP_SERVICE_ACCOUNT_TOKEN_ENV);
+                ScopedEnvVarChanges::remove_var("OP_CONNECT_HOST");
+                ScopedEnvVarChanges::remove_var("OP_CONNECT_TOKEN");
+
+                if !Self::has_manual_onepassword_session() {
+                    anyhow::bail!(Self::manual_mode_session_error_message());
+                }
+            },
+            OnePasswordMode::ServiceAccount => {
+                for name in &auth_env_vars {
+                    ScopedEnvVarChanges::remove_var(name);
+                }
+
+                let service_account_token = if let Some(token) = existing_service_account_token {
+                    token
+                } else if let Some(token_path) = config.service_account_token_path.as_deref() {
+                    Self::read_service_account_token(token_path)?
+                } else {
+                    anyhow::bail!(
+                        "1Password service-account mode requires OP_SERVICE_ACCOUNT_TOKEN or a configured service-account-token-path."
+                    );
+                };
+
+                ScopedEnvVarChanges::set_var(OP_SERVICE_ACCOUNT_TOKEN_ENV, &service_account_token);
+            },
+        }
+
+        Ok(Some(guard))
+    }
+
+    fn effective_onepassword_config(&self) -> Result<Option<EffectiveOnePasswordConfig>> {
+        let Some(config) = self.config.as_ref() else {
+            return Ok(None);
+        };
+
+        if config.manager_type != SecretManagerType::OnePassword {
+            return Ok(None);
+        }
+
+        let onepassword = config.onepassword.as_ref();
+        Ok(Some(EffectiveOnePasswordConfig {
+            mode: Self::read_onepassword_mode_override()?
+                .or_else(|| onepassword.and_then(|cfg| cfg.mode)),
+            service_account_token_path: Self::read_string_override(&[
+                ONEPASSWORD_TOKEN_PATH_ENV,
+                LEGACY_ONEPASSWORD_TOKEN_PATH_ENV,
+            ])
+            .or_else(|| onepassword.and_then(|cfg| cfg.service_account_token_path.clone())),
+        }))
+    }
+
+    fn read_onepassword_mode_override() -> Result<Option<OnePasswordMode>> {
+        Self::read_string_override(&[ONEPASSWORD_MODE_ENV, LEGACY_ONEPASSWORD_MODE_ENV])
+            .map(|value| {
+                value.parse::<OnePasswordMode>().map_err(|error| {
+                    anyhow::anyhow!(
+                        "Invalid 1Password mode `{value}` from {}: {error}",
+                        Self::mode_override_source()
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    fn mode_override_source() -> &'static str {
+        if Self::read_env_non_empty(ONEPASSWORD_MODE_ENV).is_some() {
+            ONEPASSWORD_MODE_ENV
+        } else {
+            LEGACY_ONEPASSWORD_MODE_ENV
+        }
+    }
+
+    fn read_string_override(names: &[&str]) -> Option<String> {
+        names.iter().find_map(|name| Self::read_env_non_empty(name))
+    }
+
+    fn read_env_non_empty(name: &str) -> Option<String> {
+        std::env::var(name)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+    }
+
+    fn has_manual_onepassword_session() -> bool {
+        Self::manual_mode_session_env_names()
+            .iter()
+            .any(|name| Self::read_env_non_empty(name).is_some())
+    }
+
+    fn manual_mode_session_env_names() -> Vec<String> {
+        let mut names = vec!["OP_SESSION".to_string()];
+
+        if let Some(account) = Self::read_env_non_empty("OP_ACCOUNT") {
+            names.extend(Self::account_specific_session_env_names(&account));
+        } else {
+            names.extend(
+                std::env::vars()
+                    .map(|(name, _)| name)
+                    .filter(|name| is_op_session_env(name) && name != "OP_SESSION"),
+            );
+        }
+
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
+    fn account_specific_session_env_names(account: &str) -> Vec<String> {
+        let mut names = vec![format!("OP_SESSION_{account}")];
+        let sanitized = sanitize_onepassword_account_suffix(account);
+        if sanitized != account {
+            names.push(format!("OP_SESSION_{sanitized}"));
+        }
+
+        names.sort_unstable();
+        names.dedup();
+        names
+    }
+
+    fn manual_mode_session_error_message() -> String {
+        let required_envs = Self::manual_mode_session_env_names();
+        let requirements = required_envs.join(" or ");
+
+        Self::read_env_non_empty("OP_ACCOUNT").map_or_else(
+            || {
+                format!(
+                    "1Password manual mode requires {requirements} to already be set. Run `op signin` first or choose another mode."
+                )
+            },
+            |account| {
+                format!(
+                "1Password manual mode requires {requirements} to already be set. OP_ACCOUNT is `{account}`, so the matching session token must be available. Run `op signin` first or choose another mode."
+                )
+            },
+        )
+    }
+
+    fn contains_onepassword_reference(secrets: &HashMap<String, String>) -> bool {
+        secrets.values().any(|value| value.contains("op://"))
+    }
+
+    fn read_service_account_token(path: &str) -> Result<String> {
+        let expanded_path = Self::expand_path(path);
+        let token = std::fs::read_to_string(&expanded_path).with_context(|| {
+            format!(
+                "Failed to read 1Password service account token from {}",
+                expanded_path.display()
+            )
+        })?;
+        let trimmed = token.trim();
+
+        if trimmed.is_empty() {
+            anyhow::bail!(
+                "1Password service account token file is empty: {}",
+                expanded_path.display()
+            );
+        }
+
+        Ok(trimmed.to_string())
+    }
+
+    fn expand_path(path: &str) -> PathBuf {
+        if path == "~" {
+            return std::env::var_os("HOME").map_or_else(|| PathBuf::from(path), PathBuf::from);
+        }
+
+        if let Some(stripped) = path.strip_prefix("~/") {
+            return std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .map_or_else(|| PathBuf::from(path), |home| home.join(stripped));
+        }
+
+        PathBuf::from(path)
     }
 
     fn resolve_secrets_parallel(
@@ -532,6 +813,7 @@ fn mock_op_read(reference: &str) -> Result<String> {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use tempfile::TempDir;
 
     // Mutex to ensure tests that modify environment variables run one at a time
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
@@ -548,12 +830,41 @@ mod tests {
         }
     }
 
+    fn cleanup_onepassword_env() {
+        let mut vars_to_remove = vec![
+            ONEPASSWORD_MODE_ENV.to_string(),
+            LEGACY_ONEPASSWORD_MODE_ENV.to_string(),
+            ONEPASSWORD_TOKEN_PATH_ENV.to_string(),
+            LEGACY_ONEPASSWORD_TOKEN_PATH_ENV.to_string(),
+            OP_SERVICE_ACCOUNT_TOKEN_ENV.to_string(),
+            "OP_SESSION".to_string(),
+            "OP_ACCOUNT".to_string(),
+            "OP_CONNECT_HOST".to_string(),
+            "OP_CONNECT_TOKEN".to_string(),
+            "HOME".to_string(),
+        ];
+
+        vars_to_remove.extend(
+            std::env::vars()
+                .map(|(name, _)| name)
+                .filter(|name| is_op_session_env(name) && name != "OP_SESSION"),
+        );
+
+        vars_to_remove.sort_unstable();
+        vars_to_remove.dedup();
+
+        for name in vars_to_remove {
+            std::env::remove_var(name);
+        }
+    }
+
     #[test]
     fn test_secret_resolver_new() {
         let resolver = SecretResolver::new(None);
         assert!(resolver.config.is_none());
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::Vault };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::Vault, onepassword: None };
         let resolver_with_config = SecretResolver::new(Some(config));
         assert!(resolver_with_config.config.is_some());
         assert_eq!(
@@ -638,7 +949,8 @@ mod tests {
 
     #[test]
     fn test_resolve_value_vault_config() {
-        let config = SecretManagerConfig { manager_type: SecretManagerType::Vault };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::Vault, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         let result = resolver
@@ -649,13 +961,202 @@ mod tests {
 
     #[test]
     fn test_resolve_value_onepassword_non_reference() {
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         let result = resolver
             .resolve_value("CLAUDIUS_SECRET_KEY", "plain-value")
             .expect("resolve_value should succeed");
         assert_eq!(result, None); // No op:// references, so no resolution needed
+    }
+
+    #[test]
+    #[serial]
+    fn test_manual_mode_requires_existing_session() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+
+        let config = SecretManagerConfig {
+            manager_type: SecretManagerType::OnePassword,
+            onepassword: Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::Manual),
+                service_account_token_path: None,
+            }),
+        };
+        let resolver = SecretResolver::new(Some(config));
+
+        let error = resolver.resolve_env_vars().expect_err("manual mode should require OP_SESSION");
+        assert!(error.to_string().contains("requires OP_SESSION"));
+
+        std::env::remove_var("CLAUDIUS_TEST_MOCK_OP");
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_manual_mode_accepts_account_specific_session_env() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+        std::env::set_var("OP_ACCOUNT", "my");
+        std::env::set_var("OP_SESSION_my", "session-token");
+
+        let config = SecretManagerConfig {
+            manager_type: SecretManagerType::OnePassword,
+            onepassword: Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::Manual),
+                service_account_token_path: None,
+            }),
+        };
+        let resolver = SecretResolver::new(Some(config));
+
+        let resolved = resolver.resolve_env_vars().expect("manual mode should accept OP_SESSION_*");
+        assert_eq!(resolved.get("API_KEY"), Some(&"secret-api-key-12345".to_string()));
+
+        std::env::remove_var("CLAUDIUS_TEST_MOCK_OP");
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_manual_mode_rejects_mismatched_account_specific_session_env() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+        std::env::set_var("OP_ACCOUNT", "my");
+        std::env::set_var("OP_SESSION_other", "session-token");
+
+        let config = SecretManagerConfig {
+            manager_type: SecretManagerType::OnePassword,
+            onepassword: Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::Manual),
+                service_account_token_path: None,
+            }),
+        };
+        let resolver = SecretResolver::new(Some(config));
+
+        let error = resolver
+            .resolve_env_vars()
+            .expect_err("manual mode should reject mismatched OP_SESSION_<account>");
+        assert!(error.to_string().contains("OP_SESSION_my"));
+
+        std::env::remove_var("CLAUDIUS_TEST_MOCK_OP");
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_service_account_mode_reads_token_file_and_restores_env() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let token_path = temp_dir.path().join("service-account.token");
+        std::fs::write(&token_path, "service-account-token-123\n")
+            .expect("Failed to write service account token");
+
+        std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+        std::env::set_var("OP_SESSION", "session-before");
+        std::env::set_var("OP_SESSION_my", "session-before-account");
+        std::env::set_var("OP_ACCOUNT", "account-before");
+
+        let config = SecretManagerConfig {
+            manager_type: SecretManagerType::OnePassword,
+            onepassword: Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::ServiceAccount),
+                service_account_token_path: Some(token_path.to_string_lossy().to_string()),
+            }),
+        };
+        let resolver = SecretResolver::new(Some(config));
+
+        let resolved = resolver.resolve_env_vars().expect("service-account mode should resolve");
+        assert_eq!(resolved.get("API_KEY"), Some(&"secret-api-key-12345".to_string()));
+
+        assert_eq!(std::env::var("OP_SESSION").ok().as_deref(), Some("session-before"));
+        assert_eq!(std::env::var("OP_SESSION_my").ok().as_deref(), Some("session-before-account"));
+        assert_eq!(std::env::var("OP_ACCOUNT").ok().as_deref(), Some("account-before"));
+        assert!(std::env::var(OP_SERVICE_ACCOUNT_TOKEN_ENV).is_err());
+
+        std::env::remove_var("CLAUDIUS_TEST_MOCK_OP");
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_onepassword_mode_override_takes_precedence() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let token_path = temp_dir.path().join("service-account.token");
+        std::fs::write(&token_path, "service-account-token-override\n")
+            .expect("Failed to write service account token");
+
+        std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+        std::env::set_var(ONEPASSWORD_MODE_ENV, "service-account");
+        std::env::set_var(ONEPASSWORD_TOKEN_PATH_ENV, token_path);
+
+        let config = SecretManagerConfig {
+            manager_type: SecretManagerType::OnePassword,
+            onepassword: Some(OnePasswordConfig {
+                mode: Some(OnePasswordMode::Manual),
+                service_account_token_path: None,
+            }),
+        };
+        let resolver = SecretResolver::new(Some(config));
+
+        let resolved = resolver.resolve_env_vars().expect("env override should win over config");
+        assert_eq!(resolved.get("API_KEY"), Some(&"secret-api-key-12345".to_string()));
+
+        std::env::remove_var("CLAUDIUS_TEST_MOCK_OP");
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalid_onepassword_mode_override_errors() {
+        let _guard = ENV_MUTEX.lock().expect("Failed to acquire mutex lock");
+
+        cleanup_claudius_secrets();
+        cleanup_onepassword_env();
+
+        std::env::set_var("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key");
+        std::env::set_var(ONEPASSWORD_MODE_ENV, "unsupported");
+
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
+        let resolver = SecretResolver::new(Some(config));
+
+        let error = resolver.resolve_env_vars().expect_err("invalid mode override should fail");
+        assert!(error.to_string().contains("Invalid 1Password mode"));
+
+        std::env::remove_var("CLAUDIUS_SECRET_API_KEY");
+        cleanup_onepassword_env();
     }
 
     #[test]
@@ -745,7 +1246,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set op:// references
@@ -775,7 +1277,8 @@ mod tests {
         std::env::set_var("CLAUDIUS_SECRET_A", "op://vault/item1/field1");
         std::env::set_var("CLAUDIUS_SECRET_B", "op://vault/item1/field1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         let resolved = resolver.resolve_env_vars().expect("resolve_env_vars should succeed");
@@ -803,7 +1306,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set invalid reference (must have 3 segments to match regex)
@@ -831,7 +1335,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set up inline op:// references (Cloudflare AI Gateway example)
@@ -878,7 +1383,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Mix of inline op:// and variable references
@@ -943,7 +1449,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set value with duplicate op:// references
@@ -978,7 +1485,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Test with delimited references in URL
@@ -1012,7 +1520,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Mix of delimited and bare references
@@ -1043,7 +1552,8 @@ mod tests {
         // Enable mock mode
         std::env::set_var("CLAUDIUS_TEST_MOCK_OP", "1");
 
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Use delimited syntax for clarity

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use toml::Value as TomlValue;
 
+use crate::app_config::{AppConfig, SecretManagerType};
 use crate::config::Settings;
 use crate::gemini_settings::{validate_gemini_settings, GeminiSettings};
 
@@ -17,6 +18,24 @@ static YAML_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
 #[derive(Debug)]
 pub struct ValidationResult {
     pub warnings: Vec<String>,
+}
+
+/// Validates Claudius app configuration and returns semantic warnings.
+#[must_use]
+pub fn validate_app_config(config: &AppConfig) -> ValidationResult {
+    let mut warnings = Vec::new();
+
+    if let Some(secret_manager) = &config.secret_manager {
+        if secret_manager.onepassword.is_some()
+            && secret_manager.manager_type != SecretManagerType::OnePassword
+        {
+            warnings.push(
+                "[secret-manager.onepassword] is configured but [secret-manager].type is not \"1password\"; these settings will be ignored".to_string(),
+            );
+        }
+    }
+
+    ValidationResult { warnings }
 }
 
 #[derive(Debug, Deserialize)]
@@ -306,9 +325,52 @@ pub fn prompt_continue() -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_config::{
+        OnePasswordConfig, OnePasswordMode, SecretManagerConfig, SecretManagerType,
+    };
     use serde_json::json;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_validate_app_config_warns_when_onepassword_subtable_is_ignored() {
+        let config = AppConfig {
+            secret_manager: Some(SecretManagerConfig {
+                manager_type: SecretManagerType::Vault,
+                onepassword: Some(OnePasswordConfig {
+                    mode: Some(OnePasswordMode::ServiceAccount),
+                    service_account_token_path: Some("~/.config/op/service-account.token".into()),
+                }),
+            }),
+            default: None,
+            codex: None,
+        };
+
+        let result = validate_app_config(&config);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result
+            .warnings
+            .first()
+            .is_some_and(|warning| warning.contains("[secret-manager.onepassword]")));
+    }
+
+    #[test]
+    fn test_validate_app_config_allows_matching_onepassword_config() {
+        let config = AppConfig {
+            secret_manager: Some(SecretManagerConfig {
+                manager_type: SecretManagerType::OnePassword,
+                onepassword: Some(OnePasswordConfig {
+                    mode: Some(OnePasswordMode::ServiceAccount),
+                    service_account_token_path: Some("~/.config/op/service-account.token".into()),
+                }),
+            }),
+            default: None,
+            codex: None,
+        };
+
+        let result = validate_app_config(&config);
+        assert!(result.warnings.is_empty());
+    }
 
     #[test]
     fn test_validate_claude_settings_known_fields() {

--- a/tests/integration/app_config_test.rs
+++ b/tests/integration/app_config_test.rs
@@ -46,40 +46,39 @@ type = "1password"
 
     #[test]
     #[serial]
-    fn test_vault_warning() {
+    fn test_config_sync_does_not_require_manual_session_for_op_references() {
         let temp_dir = TempDir::new().unwrap();
         let config_dir = temp_dir.path().join("config").join("claudius");
         fs::create_dir_all(&config_dir).unwrap();
 
-        // Create a config file with Vault
         let config_content = r#"
 [secret-manager]
-type = "vault"
+type = "1password"
+
+[secret-manager.onepassword]
+mode = "manual"
 "#;
         fs::write(config_dir.join("config.toml"), config_content).unwrap();
 
-        // Create minimal mcpServers.json
         let mcp_content = r#"{
         "mcpServers": {}
     }"#;
         fs::write(config_dir.join("mcpServers.json"), mcp_content).unwrap();
 
-        // Create a project directory for the sync operation
         let project_dir = temp_dir.path().join("project");
         fs::create_dir_all(&project_dir).unwrap();
 
-        // Set a secret env var
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&project_dir)
             .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
-            .env("CLAUDIUS_SECRET_TEST", "test_value")
+            .env("CLAUDIUS_SECRET_TEST", "op://vault/test-item/api-key")
             .arg("--debug")
             .args(["config", "sync"])
             .arg("--dry-run");
 
-        cmd.assert().success().stderr(predicate::str::contains(
-            "Vault secret manager is configured but not yet implemented",
-        ));
+        cmd.assert()
+            .success()
+            .stderr(predicate::str::contains("requires OP_SESSION").not());
     }
 
     #[test]

--- a/tests/integration/run_command_test.rs
+++ b/tests/integration/run_command_test.rs
@@ -2,6 +2,8 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -17,6 +19,48 @@ mod tests {
         // Use cargo manifest dir to reliably find the test fixtures
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
         PathBuf::from(manifest_dir).join("tests").join("fixtures").join("mock_op.sh")
+    }
+
+    fn escape_for_toml(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace('\\', "\\\\")
+    }
+
+    fn write_service_account_mock_op(script_path: &std::path::Path, expected_token: &str) {
+        let script = format!(
+            r#"#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+    echo "2.20.0"
+    exit 0
+fi
+
+if [[ "$1" == "read" && "$2" == "op://vault/test-item/api-key" ]]; then
+    if [[ "${{OP_SERVICE_ACCOUNT_TOKEN:-}}" != "{expected_token}" ]]; then
+        echo "unexpected OP_SERVICE_ACCOUNT_TOKEN" >&2
+        exit 1
+    fi
+
+    if [[ -n "${{OP_SESSION:-}}" || -n "${{OP_ACCOUNT:-}}" ]]; then
+        echo "unexpected session-based auth env" >&2
+        exit 1
+    fi
+
+    echo "secret-api-key-12345"
+    exit 0
+fi
+
+echo "ERROR: Unknown command or reference" >&2
+exit 1
+"#
+        );
+
+        fs::write(script_path, script).unwrap();
+
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(script_path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(script_path, permissions).unwrap();
+        }
     }
 
     // ===========================
@@ -237,6 +281,190 @@ type = "1password"
             .success()
             .stdout(predicate::str::contains("OP=secret-api-key-12345"))
             .stdout(predicate::str::contains("PLAIN=plain-value"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_run_with_onepassword_service_account_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("config").join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let token_path = temp_dir.path().join("service-account.token");
+        fs::write(&token_path, "service-account-token-123\n").unwrap();
+
+        let config_content = format!(
+            r#"
+[secret-manager]
+type = "1password"
+
+[secret-manager.onepassword]
+mode = "service-account"
+service-account-token-path = "{}"
+"#,
+            escape_for_toml(&token_path)
+        );
+        fs::write(config_dir.join("config.toml"), config_content).unwrap();
+
+        let mock_bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&mock_bin_dir).unwrap();
+        write_service_account_mock_op(&mock_bin_dir.join("op"), "service-account-token-123");
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(temp_dir.path())
+            .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
+            .env(
+                "PATH",
+                format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
+            )
+            .env("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key")
+            .arg("--debug")
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg(
+                "echo API_KEY=$API_KEY; if [ -n \"$OP_SERVICE_ACCOUNT_TOKEN\" ]; then echo OP_SERVICE_ACCOUNT_TOKEN=set; else echo OP_SERVICE_ACCOUNT_TOKEN=unset; fi",
+            );
+
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("API_KEY=secret-api-key-12345"))
+            .stdout(predicate::str::contains("OP_SERVICE_ACCOUNT_TOKEN=unset"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_run_with_onepassword_manual_config_accepts_account_specific_session_env() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("config").join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let config_content = r#"
+[secret-manager]
+type = "1password"
+
+[secret-manager.onepassword]
+mode = "manual"
+"#;
+        fs::write(config_dir.join("config.toml"), config_content).unwrap();
+
+        let mock_op = setup_mock_op_path();
+        let mock_bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&mock_bin_dir).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&mock_op, mock_bin_dir.join("op")).unwrap();
+        }
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(temp_dir.path())
+            .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
+            .env(
+                "PATH",
+                format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
+            )
+            .env("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key")
+            .env("OP_ACCOUNT", "my")
+            .env("OP_SESSION_my", "manual-session-token")
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("echo API_KEY=$API_KEY");
+
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("API_KEY=secret-api-key-12345"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_run_with_onepassword_manual_config_rejects_mismatched_account_session_env() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("config").join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let config_content = r#"
+[secret-manager]
+type = "1password"
+
+[secret-manager.onepassword]
+mode = "manual"
+"#;
+        fs::write(config_dir.join("config.toml"), config_content).unwrap();
+
+        let mock_op = setup_mock_op_path();
+        let mock_bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&mock_bin_dir).unwrap();
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(&mock_op, mock_bin_dir.join("op")).unwrap();
+        }
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(temp_dir.path())
+            .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
+            .env(
+                "PATH",
+                format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
+            )
+            .env("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key")
+            .env("OP_ACCOUNT", "my")
+            .env("OP_SESSION_other", "manual-session-token")
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("echo API_KEY=$API_KEY");
+
+        cmd.assert().failure().stderr(predicate::str::contains("OP_SESSION_my"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_run_with_legacy_onepassword_service_account_env_overrides() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("config").join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        fs::write(
+            config_dir.join("config.toml"),
+            r#"
+[secret-manager]
+type = "1password"
+"#,
+        )
+        .unwrap();
+
+        let token_path = temp_dir.path().join("service-account.token");
+        fs::write(&token_path, "service-account-token-legacy\n").unwrap();
+
+        let mock_bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&mock_bin_dir).unwrap();
+        write_service_account_mock_op(&mock_bin_dir.join("op"), "service-account-token-legacy");
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(temp_dir.path())
+            .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
+            .env(
+                "PATH",
+                format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
+            )
+            .env("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key")
+            .env("CLAUDIUS_OP_MODE", "service-account")
+            .env("CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH", token_path.to_string_lossy().to_string())
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("echo API_KEY=$API_KEY");
+
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("API_KEY=secret-api-key-12345"));
     }
 
     // ===========================

--- a/tests/integration/secrets_fixture_test.rs
+++ b/tests/integration/secrets_fixture_test.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
 use serial_test::serial;
 use std::fs;
 use std::path::PathBuf;
@@ -28,20 +29,6 @@ type = "1password"
 "#;
         fs::write(config_dir.join("config.toml"), config_content).unwrap();
 
-        // Create empty mcpServers.json to prevent "No such file" error
-        fs::write(config_dir.join("mcpServers.json"), r#"{"mcpServers": {}}"#).unwrap();
-
-        // Create a test mcp servers config
-        let mcp_config = r#"{
-  "mcpServers": {
-    "test-server": {
-      "command": "echo",
-      "args": ["test"]
-    }
-  }
-}"#;
-        fs::write(config_dir.join("mcpServers.json"), mcp_config).unwrap();
-
         // Get the mock op path
         let mock_op = setup_mock_op_path();
         let mock_bin_dir = temp_dir.path().join("bin");
@@ -61,18 +48,22 @@ type = "1password"
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&project_dir)
             .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
-            .env("CLAUDIUS_TEST_MOCK_OP", "1")
             .env(
                 "PATH",
                 format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
             )
             .env("CLAUDIUS_SECRET_API_KEY", "op://vault/test-item/api-key")
             .env("CLAUDIUS_SECRET_DB_PASSWORD", "op://vault/database/password")
-            .arg("--debug")
-            .args(["config", "sync"])
-            .arg("--dry-run");
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("printf 'API_KEY=%s\nDB_PASSWORD=%s\n' \"$API_KEY\" \"$DB_PASSWORD\"");
 
-        cmd.assert().success();
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("API_KEY=secret-api-key-12345"))
+            .stdout(predicate::str::contains("DB_PASSWORD=db-password-xyz789"));
     }
 
     #[test]
@@ -88,9 +79,6 @@ type = "1password"
 type = "1password"
 "#;
         fs::write(config_dir.join("config.toml"), config_content).unwrap();
-
-        // Create empty mcpServers.json to prevent "No such file" error
-        fs::write(config_dir.join("mcpServers.json"), r#"{"mcpServers": {}}"#).unwrap();
 
         // Get the mock op path
         let mock_op = setup_mock_op_path();
@@ -111,18 +99,20 @@ type = "1password"
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&project_dir)
             .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
-            .env("CLAUDIUS_TEST_MOCK_OP", "1")
             .env(
                 "PATH",
                 format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
             )
             .env("CLAUDIUS_SECRET_INVALID", "op://invalid/reference/field")
-            .args(["config", "sync"])
-            .arg("--dry-run");
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("printf 'INVALID=%s\n' \"$INVALID\"");
 
-        // The command should succeed but keep the unresolved reference
-        // This is the resilient behavior - we warn but don't fail
-        cmd.assert().success();
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("INVALID=op://invalid/reference/field"));
     }
 
     #[test]
@@ -138,20 +128,6 @@ type = "1password"
 type = "1password"
 "#;
         fs::write(config_dir.join("config.toml"), config_content).unwrap();
-
-        // Create empty mcpServers.json to prevent "No such file" error
-        fs::write(config_dir.join("mcpServers.json"), r#"{"mcpServers": {}}"#).unwrap();
-
-        // Create a test mcp servers config
-        let mcp_config = r#"{
-  "mcpServers": {
-    "test-server": {
-      "command": "echo",
-      "args": ["test"]
-    }
-  }
-}"#;
-        fs::write(config_dir.join("mcpServers.json"), mcp_config).unwrap();
 
         // Get the mock op path
         let mock_op = setup_mock_op_path();
@@ -172,17 +148,21 @@ type = "1password"
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&project_dir)
             .env("XDG_CONFIG_HOME", temp_dir.path().join("config"))
-            .env("CLAUDIUS_TEST_MOCK_OP", "1")
             .env(
                 "PATH",
                 format!("{}:{}", mock_bin_dir.display(), std::env::var("PATH").unwrap_or_default()),
             )
             .env("CLAUDIUS_SECRET_OP_SECRET", "op://vault/test-item/api-key")
             .env("CLAUDIUS_SECRET_PLAIN_SECRET", "plain-text-value")
-            .arg("--debug")
-            .args(["config", "sync"])
-            .arg("--dry-run");
+            .args(["secrets", "run"])
+            .arg("--")
+            .arg("/bin/sh")
+            .arg("-c")
+            .arg("printf 'OP_SECRET=%s\nPLAIN_SECRET=%s\n' \"$OP_SECRET\" \"$PLAIN_SECRET\"");
 
-        cmd.assert().success().success();
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("OP_SECRET=secret-api-key-12345"))
+            .stdout(predicate::str::contains("PLAIN_SECRET=plain-text-value"));
     }
 }

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -2,6 +2,7 @@ use crate::fixtures::TestFixture;
 use assert_cmd::Command;
 use predicates::prelude::*;
 use serial_test::serial;
+use std::fs;
 
 #[cfg(test)]
 mod tests {
@@ -148,5 +149,67 @@ mod tests {
             .stdout(predicate::str::contains(
                 "Codex skills sync remains experimental and publishes to both .codex/skills and .agents/skills for compatibility",
             ));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_warns_when_onepassword_subtable_is_ignored() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(
+            fixture.config.join("config.toml"),
+            r#"
+[secret-manager]
+type = "vault"
+
+[secret-manager.onepassword]
+mode = "service-account"
+service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
+"#,
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("[secret-manager.onepassword]"))
+            .stderr(predicate::str::contains("[secret-manager.onepassword]").not());
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_strict_fails_when_onepassword_subtable_is_ignored() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(
+            fixture.config.join("config.toml"),
+            r#"
+[secret-manager]
+type = "vault"
+
+[secret-manager.onepassword]
+mode = "service-account"
+"#,
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--strict"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains("[secret-manager.onepassword]"))
+            .stderr(predicate::str::contains("Validation failed due to warnings"))
+            .stderr(predicate::str::contains("[secret-manager.onepassword]").not());
     }
 }

--- a/tests/unit/app_config_test.rs
+++ b/tests/unit/app_config_test.rs
@@ -1,4 +1,4 @@
-use claudius::app_config::{Agent, AppConfig, SecretManagerType};
+use claudius::app_config::{Agent, AppConfig, OnePasswordMode, SecretManagerType};
 use serial_test::serial;
 use std::fs;
 use tempfile::TempDir;
@@ -68,6 +68,7 @@ type = "1password"
 
         let secret_manager = config.secret_manager.unwrap();
         assert_eq!(secret_manager.manager_type, SecretManagerType::OnePassword);
+        assert!(secret_manager.onepassword.is_none());
     }
 
     #[test]
@@ -296,5 +297,42 @@ type = "1password"
         assert!(config.secret_manager.is_some());
         let secret_manager = config.secret_manager.unwrap();
         assert_eq!(secret_manager.manager_type, SecretManagerType::OnePassword);
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_config_with_onepassword_settings() {
+        let _guard = EnvGuard::new();
+
+        let temp_dir = TempDir::new().unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", temp_dir.path());
+
+        let config_dir = temp_dir.path().join("claudius");
+        fs::create_dir_all(&config_dir).unwrap();
+
+        let config_content = r#"
+[secret-manager]
+type = "1password"
+
+[secret-manager.onepassword]
+mode = "service-account"
+service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.token"
+"#;
+
+        fs::write(config_dir.join("config.toml"), config_content).unwrap();
+
+        let result = AppConfig::load().unwrap();
+        assert!(result.is_some());
+
+        let config = result.unwrap();
+        let secret_manager = config.secret_manager.unwrap();
+        assert_eq!(secret_manager.manager_type, SecretManagerType::OnePassword);
+
+        let onepassword = secret_manager.onepassword.expect("1Password settings should be present");
+        assert_eq!(onepassword.mode, Some(OnePasswordMode::ServiceAccount));
+        assert_eq!(
+            onepassword.service_account_token_path.as_deref(),
+            Some("~/.config/op/service-accounts/headless-linux-cli.token")
+        );
     }
 }

--- a/tests/unit/config_agent_test.rs
+++ b/tests/unit/config_agent_test.rs
@@ -120,7 +120,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
         let agents_only = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
-        assert_eq!(agents_only.skills_target_dir, agents_target.clone());
+        assert_eq!(agents_only.skills_target_dir, agents_target);
         assert_eq!(agents_only.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
@@ -158,7 +158,7 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"agents\"\n").unwrap();
         let agents_only = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
-        assert_eq!(agents_only.skills_target_dir, agents_target.clone());
+        assert_eq!(agents_only.skills_target_dir, agents_target);
         assert_eq!(agents_only.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();

--- a/tests/unit/secrets_test.rs
+++ b/tests/unit/secrets_test.rs
@@ -39,7 +39,8 @@ mod tests {
     #[serial]
     fn test_onepassword_non_op_reference() {
         cleanup_claudius_secrets();
-        let config = SecretManagerConfig { manager_type: SecretManagerType::OnePassword };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::OnePassword, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set a non-op:// value
@@ -56,7 +57,8 @@ mod tests {
     #[serial]
     fn test_vault_warning() {
         cleanup_claudius_secrets();
-        let config = SecretManagerConfig { manager_type: SecretManagerType::Vault };
+        let config =
+            SecretManagerConfig { manager_type: SecretManagerType::Vault, onepassword: None };
         let resolver = SecretResolver::new(Some(config));
 
         // Set a test environment variable


### PR DESCRIPTION
## Summary
- add `[secret-manager.onepassword]` configuration with `desktop`, `manual`, and `service-account` modes plus token path support
- scope secret resolution to `claudius secrets run` and warn when onepassword-specific config is ignored under a different secret manager type
- harden manual mode session validation, preserve and restore 1Password auth env vars, and document supported overrides including legacy aliases
- add unit and integration coverage for manual mode account matching, service-account mode, legacy env overrides, and `config validate` warning behavior

## Validation
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy --lib --tests -- -D warnings`
- `nix develop -c cargo test --lib`
- `nix develop -c cargo test --test lib -- --test-threads=1`