### PR TITLE
chore: refresh Nix inputs and Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rust: [stable, "1.92.0"]  # Test both stable and MSRV
+        rust: [stable, "1.95.0"]  # Test both stable and MSRV
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -155,6 +155,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "claudius"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.92"
+rust-version = "1.95"
 authors = ["claudius contributors"]
 description = "Comprehensive configuration management tool for Claude Desktop/CLI"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cargo install --path .
 
 ## Prerequisites
 
-- **Rust**: 1.92.0 or higher
+- **Rust**: 1.95.0 or higher
 - **Nix**: 2.19.0 or higher (optional, for development)
 - **1Password CLI**: For secret management features (optional)
 

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776136407,
-        "narHash": "sha256-Cp8XrVLGruSDBTRs8L4LmvaEcd76tHHU9esLk7Ysa4E=",
+        "lastModified": 1777432579,
+        "narHash": "sha256-Ce11TStDsqCge2vAAfLKe2+4lDI5cSX5ZYZOuKJBKKQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "753568957a87312ed599cba5699e67126eded6c0",
+        "rev": "3ecb5e6ab380ced3272ef7fcfe398bffbcc0f152",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
 
         # Use a specific Rust version for reproducibility.
         # Keep this in sync with the MSRV in Cargo.toml.
-        rustToolchain = pkgs.rust-bin.stable."1.92.0".default;
+        rustToolchain = pkgs.rust-bin.stable."1.95.0".default;
         rustPlatform = pkgs.makeRustPlatform {
           cargo = rustToolchain;
           rustc = rustToolchain;


### PR DESCRIPTION
## Summary
- update `flake.lock` inputs for `nixpkgs`, `rust-overlay`, and `pre-commit-hooks`
- bump the pinned Rust toolchain and MSRV references from `1.92`/`1.92.0` to `1.95`/`1.95.0`
- keep CI and README prerequisites aligned with the new toolchain baseline

## Validation
- `nix develop -c rustc --version`
- `nix develop -c cargo test`
- `nix flake check`

## Notes
- this PR intentionally excludes any Cargo dependency refresh so toolchain changes remain isolated and reviewable