### PR TITLE
feat: manage more agent surfaces and harden skill sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ claudius --list-commands
 ```
 
 ### Prerequisites
-- Rust 1.92.0 or higher
+- Rust 1.95.0 or higher
 - Nix 2.19.0 or higher (optional, for development)
 
 ### Basic Usage
@@ -80,7 +80,18 @@ claudius context append security
 $XDG_CONFIG_HOME/claudius/     # or ~/.config/claudius/
 ├── config.toml                # Claudius app configuration (optional)
 ├── mcpServers.json            # MCP server definitions
+├── claude.settings.json       # Claude / Claude Code settings (optional)
+├── codex.settings.toml        # Codex settings (optional)
+├── codex.requirements.toml    # Codex admin-enforced requirements (optional)
+├── codex.managed_config.toml  # Codex managed defaults (optional)
+├── gemini.settings.json       # Gemini settings (optional)
+├── gemini.system_defaults.json # Gemini system defaults (optional)
 ├── settings.json              # General Claude settings (optional)
+├── commands/
+│   └── gemini/                # Gemini custom commands (*.toml)
+├── agents/
+│   ├── gemini/                # Gemini custom agents (*.md)
+│   └── claude-code/           # Claude Code subagents (*.md)
 ├── skills/                    # Skills (shared + agent-specific)
 │   ├── <skill>/               # Shared skill
 │   │   └── SKILL.md           # Skill definition
@@ -97,11 +108,14 @@ Project Directory (default):
 ├── .mcp.json                  # Project-local MCP servers configuration
 ├── .claude/
 │   ├── settings.json          # Project-local Claude Code settings (when using --agent claude-code)
+│   ├── agents/                # Project-local Claude Code subagents
 │   └── skills/                # Project-local skills (Claude)
 ├── .codex/
 │   └── skills/                # Project-local skills (Codex, experimental)
 ├── .gemini/
 │   ├── settings.json          # Project-local Gemini settings + MCP servers (when using --agent gemini)
+│   ├── commands/              # Project-local Gemini commands
+│   ├── agents/                # Project-local Gemini agents
 │   └── skills/                # Project-local skills (Gemini)
 └── CLAUDE.md                  # Project-specific instructions
 
@@ -109,7 +123,7 @@ Global targets (--global):
 ├── Claude Desktop: $XDG_CONFIG_HOME/Claude/claude_desktop_config.json
 ├── Claude Code: ~/.claude.json + ~/.claude/settings.json
 ├── Codex: ~/.codex/config.toml
-├── Gemini: ~/.gemini/settings.json
+├── Gemini: ~/.gemini/settings.json + /etc/gemini-cli/settings.json + /etc/gemini-cli/system-defaults.json
 └── Skills: ~/.claude/skills (Claude), ~/.gemini/skills (Gemini), ~/.codex/skills (Codex, experimental)
 ```
 
@@ -129,6 +143,8 @@ Global targets (--global):
 - Claude Code: MCP servers → `~/.claude.json`, settings → `~/.claude/settings.json`
 - Codex: settings + MCP servers → `~/.codex/config.toml`
 - Gemini: settings + MCP servers → `~/.gemini/settings.json`
+- Gemini system settings: `claudius config sync --global --agent gemini --gemini-system` → `/etc/gemini-cli/settings.json`
+- Gemini system defaults: `claudius config sync --global --agent gemini --gemini-system-defaults` → `/etc/gemini-cli/system-defaults.json`
 
 ## Command Reference
 
@@ -158,7 +174,16 @@ claudius config init --force
 Creates default:
 - `mcpServers.json` with filesystem MCP server example
 - `settings.json` with default Claude settings
+- `claude.settings.json` with preferred Claude / Claude Code settings
+- `codex.settings.toml` with default Codex settings
+- `codex.requirements.toml` with Codex requirements template
+- `codex.managed_config.toml` with Codex managed defaults template
+- `gemini.settings.json` with Gemini settings template
+- `gemini.system_defaults.json` with Gemini system defaults template
 - `config.toml` with commented configuration options
+- `commands/gemini/` for Gemini custom commands
+- `agents/gemini/` for Gemini custom agents
+- `agents/claude-code/` for Claude Code subagents
 - `skills/example/SKILL.md` - Example skill
 - `rules/example.md` - Example CLAUDE.md rule
 
@@ -169,13 +194,15 @@ Synchronize configurations to target files.
 - Claude Desktop (`--agent claude`): MCP servers → `./.mcp.json`
 - Claude Code (`--agent claude-code`): MCP servers → `./.mcp.json`, settings → `./.claude/settings.json`, skills → `./.claude/skills/`
 - Codex (`--agent codex`): settings + MCP servers → `./.codex/config.toml` (skills are experimental)
-- Gemini (`--agent gemini`): settings + MCP servers → `./.gemini/settings.json`, skills → `./.gemini/skills/`
+- Gemini (`--agent gemini`): settings + MCP servers → `./.gemini/settings.json`, commands → `./.gemini/commands/`, agents → `./.gemini/agents/`, skills → `./.gemini/skills/`
 
 **Global mode (--global):**
 - Claude Desktop (`--agent claude`) → `$XDG_CONFIG_HOME/Claude/claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`, Windows: `%APPDATA%\\Claude\\claude_desktop_config.json`)
 - Claude Code (`--agent claude-code`) → `~/.claude.json` + `~/.claude/settings.json`
 - Codex (`--agent codex`) → `~/.codex/config.toml`
 - Gemini (`--agent gemini`) → `~/.gemini/settings.json`
+- Gemini system settings (`--gemini-system`) → `/etc/gemini-cli/settings.json`
+- Gemini system defaults (`--gemini-system-defaults`) → `/etc/gemini-cli/system-defaults.json`
 - Skills → `~/.claude/skills/` (Claude), `~/.gemini/skills/` (Gemini), `~/.codex/skills/` (Codex, experimental)
 
 ```bash
@@ -202,6 +229,9 @@ claudius skills sync
 
 # Sync only skills for Gemini
 claudius skills sync --agent gemini
+
+# Sync Gemini system defaults
+claudius config sync --global --agent gemini --gemini-system-defaults
 
 # Codex skills are experimental and must be explicitly enabled
 claudius skills sync --agent codex --enable-codex-skills
@@ -393,7 +423,8 @@ Skill definitions stored in individual directories.
 Deployed to `~/.claude/skills/` (Claude) or `~/.gemini/skills/` (Gemini), preserving the
 directory structure. Codex skills are experimental and require explicit opt-in.
 Claude Code still honors legacy `~/.claude/commands` slash commands, but skills are
-recommended.
+recommended. Claudius does not currently sync `.claude/commands`, so skills remain the
+cross-agent managed path.
 
 To override a shared skill for a specific agent, place it under
 `~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude, claude-code, gemini, codex).
@@ -1177,7 +1208,7 @@ Coverage builds are slower than normal builds. For day-to-day development, run t
 
 ### Rust Version Compatibility
 
-This project targets **Rust 1.92.0+** (see `clippy.toml` `msrv`). The Nix devShell uses the latest
+This project targets **Rust 1.95.0+** (see `clippy.toml` `msrv`). The Nix devShell uses the latest
 stable Rust pinned by `flake.lock`.
 
 ### How to Update Dependencies

--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ claudius --list-commands
    - (Optional) Edit `~/.config/claudius/codex.requirements.toml` for Codex admin-enforced constraints
    - (Optional) Edit `~/.config/claudius/codex.managed_config.toml` for Codex admin-managed defaults
    - Edit `~/.config/claudius/gemini.settings.json` to configure Gemini settings
+   - (Optional) Edit `~/.config/claudius/gemini.system_defaults.json` for Gemini system defaults
    - Add skills to `~/.config/claudius/skills/` (one directory per skill with `SKILL.md`)
+   - (Optional) Add Gemini commands to `~/.config/claudius/commands/gemini/*.toml`
+   - (Optional) Add Gemini agents to `~/.config/claudius/agents/gemini/*.md`
+   - (Optional) Add Claude Code subagents to `~/.config/claudius/agents/claude-code/*.md`
    - Add context rules to `~/.config/claudius/rules/`
 
 3. **Sync configuration:**
@@ -168,9 +172,9 @@ Claudius does not treat every target surface equally. Current support levels are
 | Surface | Actively managed | Best-effort / compatibility | Intentionally unmanaged |
 | --- | --- | --- | --- |
 | Claude Desktop | Global `claude_desktop_config.json` MCP sync, project-local `.mcp.json` MCP sync | Entire Claude Desktop target is legacy / best-effort | Extensions, Connectors, and other UI-managed app surfaces |
-| Claude Code | Project, local, user, and managed MCP/settings files; `.claude/agents`; skills; context files | Legacy `settings.json` source alias | Non-file-based product features |
-| Codex | User and admin TOML config files; context files | Experimental skills; compatibility sync to `.agents/skills` | Non-file-based product features |
-| Gemini | User and system settings; `.gemini/commands`; skills; context files | OS-specific system settings path handling | Gemini extensions |
+| Claude Code | Project, local, user, and managed MCP/settings files; `.claude/agents`; skills; context files | Legacy `settings.json` source alias | Slash commands in `.claude/commands`; non-file-based product features |
+| Codex | User and admin TOML config files; context files | Experimental skills; compatibility sync to `.agents/skills` | Cloud-managed enterprise policies, macOS MDM payloads, and other non-file-based product features |
+| Gemini | User, system, and system-default settings; `.gemini/commands`; `.gemini/agents`; skills; context files | OS-specific system path handling | Gemini extensions and custom sandbox profiles |
 
 Prefer `--agent claude-code`, `--agent codex`, or `--agent gemini` for actively managed surfaces. Use `--agent claude` only when you specifically need the legacy Claude Desktop JSON target.
 
@@ -207,14 +211,18 @@ This creates:
 - `codex.requirements.toml` with default Codex requirements (admin-enforced)
 - `codex.managed_config.toml` with default Codex managed defaults (admin-managed)
 - `gemini.settings.json` with default Gemini settings
+- `gemini.system_defaults.json` with default Gemini system defaults
 - `config.toml` with Claudius application settings (optional)
+- `commands/gemini/` for Gemini custom commands
+- `agents/gemini/` for Gemini custom agents
+- `agents/claude-code/` for Claude Code subagents
 - `skills/example/SKILL.md` - Example skill
 - `rules/example.md` - Example context file rule template
 
 ### `claudius config sync`
 
 Synchronize all agent configurations to target files.
-When present, Claudius also syncs Gemini custom commands and Claude Code subagents.
+When present, Claudius also syncs Gemini custom commands, Gemini custom agents, and Claude Code subagents.
 Claude Desktop sync is retained as a legacy / best-effort path for JSON-based workflows. Claudius does not manage Claude Desktop Extensions or Connectors.
 
 **Project-local mode (default):**
@@ -237,6 +245,7 @@ Claude Desktop sync is retained as a legacy / best-effort path for JSON-based wo
 - Gemini (`--agent gemini`):
   - User settings: `~/.gemini/settings.json`
   - System settings: `/etc/gemini-cli/settings.json` (`--gemini-system`, path varies by OS)
+  - System defaults: `/etc/gemini-cli/system-defaults.json` (`--gemini-system-defaults`, path varies by OS)
 
 ```bash
 # Basic sync to project-local files
@@ -254,7 +263,7 @@ claudius config sync --dry-run --prune
 # Create backup before syncing
 claudius config sync --backup
 
-# Remove stale skills, Gemini commands, and Claude Code subagents that
+# Remove stale skills, Gemini commands, Gemini agents, and Claude Code subagents that
 # Claudius previously deployed
 claudius config sync --prune
 
@@ -275,15 +284,18 @@ claudius config sync --global --agent codex --codex-requirements --codex-managed
 
 # Gemini system settings (system-wide)
 claudius config sync --global --agent gemini --gemini-system
+
+# Gemini system defaults (system-wide)
+claudius config sync --global --agent gemini --gemini-system-defaults
 ```
 
 ### `claudius config validate`
 
 Validate configuration source files without writing anything.
 
-This command validates MCP servers, agent settings, Gemini custom commands, and
-Claude Code subagent definitions. When Codex skills are present, it also surfaces
-their current compatibility-mode warning.
+This command validates MCP servers, agent settings, Gemini custom commands,
+Gemini custom agents, and Claude Code subagent definitions. When Codex skills are
+present, it also surfaces their current compatibility-mode warning.
 
 ```bash
 # Validate all available source files
@@ -447,6 +459,7 @@ Features:
 ├── codex.requirements.toml # Codex requirements (admin-enforced, optional)
 ├── codex.managed_config.toml # Codex managed defaults (admin-managed, optional)
 ├── gemini.settings.json # Gemini settings (optional)
+├── gemini.system_defaults.json # Gemini system defaults (optional)
 ├── settings.json      # Legacy alias for claude.settings.json (backward compatible)
 ├── skills/            # Skills (shared + agent-specific)
 │   ├── <skill>/       # Shared skill
@@ -458,6 +471,8 @@ Features:
 │   └── gemini/       # Gemini custom commands
 │       └── *.toml
 ├── agents/
+│   ├── gemini/       # Gemini custom agents
+│   │   └── *.md
 │   └── claude-code/  # Claude Code subagents
 │       └── *.md
 └── rules/             # Context file templates
@@ -506,7 +521,7 @@ Configure Claude/Claude Code settings:
 Configure Codex CLI settings (merged into `.codex/config.toml` or `~/.codex/config.toml`):
 
 ```toml
-# model = "gpt-5-codex"
+# model = "gpt-5.5"
 # approval_policy = "on-request"
 ```
 
@@ -515,10 +530,11 @@ Configure Codex CLI settings (merged into `.codex/config.toml` or `~/.codex/conf
 Admin-enforced constraints for Codex (synced with `--codex-requirements`):
 
 - Target (Unix): `/etc/codex/requirements.toml`
+- Target (Windows): `%ProgramData%\\OpenAI\\Codex\\requirements.toml`
 - Override target path: `CLAUDIUS_CODEX_REQUIREMENTS_PATH`
 
 ```toml
-# allowed_approval_policies = ["untrusted", "on-request", "on-failure"]
+# allowed_approval_policies = ["untrusted", "on-request", "never"]
 # allowed_sandbox_modes = ["read-only", "workspace-write"]
 ```
 
@@ -527,6 +543,7 @@ Admin-enforced constraints for Codex (synced with `--codex-requirements`):
 Admin-managed defaults for Codex (synced with `--codex-managed-config`):
 
 - Target (Unix): `/etc/codex/managed_config.toml`
+- Target (Windows/non-Unix): `~/.codex/managed_config.toml`
 - Override target path: `CLAUDIUS_CODEX_MANAGED_CONFIG_PATH`
 
 ```toml
@@ -547,6 +564,24 @@ Configure Gemini CLI settings (category-based schema):
   "context": {},
   "privacy": {},
   "telemetry": {}
+}
+```
+
+### gemini.system_defaults.json (Optional)
+
+Configure Gemini CLI system defaults (synced with `--gemini-system-defaults`):
+
+- Target (Unix): `/etc/gemini-cli/system-defaults.json`
+- Override target path: `GEMINI_CLI_SYSTEM_DEFAULTS_PATH`
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json",
+  "billing": {
+    "project": "shared-project"
+  },
+  "policyPaths": ["/etc/gemini-cli/policy.json"],
+  "adminPolicyPaths": ["/etc/gemini-cli/admin-policy.json"]
 }
 ```
 
@@ -620,6 +655,7 @@ To override a shared skill for a specific agent, place it under
 
 When present, `claudius config sync` also deploys:
 - `~/.config/claudius/commands/gemini/*.toml` → `.gemini/commands/` or `~/.gemini/commands/`
+- `~/.config/claudius/agents/gemini/*.md` → `.gemini/agents/` or `~/.gemini/agents/`
 - `~/.config/claudius/agents/claude-code/*.md` → `.claude/agents/` or `~/.claude/agents/`
 
 Gemini extensions are not managed by Claudius. Install and update them through the Gemini CLI
@@ -628,6 +664,9 @@ extension workflow, then keep extension-specific settings in `gemini.settings.js
 ### Migration: commands → skills
 
 If you previously stored slash commands in `commands/*.md`, move them into skills:
+
+Claude Code still supports `.claude/commands/*.md`, but Claudius does not sync that
+surface yet. Skills keep a single cross-agent source of truth inside Claudius.
 
 ```bash
 # Example: migrate a legacy command to a skill
@@ -674,6 +713,7 @@ Claudius offers two ways to manage project context:
 - `CLAUDIUS_CODEX_REQUIREMENTS_PATH` - Override Codex `requirements.toml` target path
 - `CLAUDIUS_CODEX_MANAGED_CONFIG_PATH` - Override Codex `managed_config.toml` target path
 - `GEMINI_CLI_SYSTEM_SETTINGS_PATH` - Override Gemini CLI system settings path (used with `--gemini-system`)
+- `GEMINI_CLI_SYSTEM_DEFAULTS_PATH` - Override Gemini CLI system defaults path (used with `--gemini-system-defaults`)
 - `XDG_CONFIG_HOME` - Base directory for configuration files
 - `CLAUDIUS_SECRET_*` - Environment variables for secret injection (prefix is removed)
 - `CLAUDIUS_TEST_MOCK_OP` - Enable mock mode for 1Password CLI (for testing)
@@ -769,8 +809,8 @@ claudius config sync --agent codex   # Creates .codex/config.toml
 claudius config sync --agent gemini  # Creates .gemini/settings.json
 
 # Set default agent in config.toml
-echo '[agent]
-type = "codex"' >> ~/.config/claudius/config.toml
+echo '[default]
+agent = "codex"' >> ~/.config/claudius/config.toml
 ```
 
 ### Secret Management

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@
 
 # Deny dangerous and problematic patterns
 avoid-breaking-exported-api = false
-msrv = "1.92.0"
+msrv = "1.95.0"
 
 # Threshold configurations
 cognitive-complexity-threshold = 20

--- a/src/agent_paths.rs
+++ b/src/agent_paths.rs
@@ -4,6 +4,7 @@ const CLAUDE_CODE_MANAGED_DIR_ENV: &str = "CLAUDIUS_CLAUDE_CODE_MANAGED_DIR";
 const CODEX_REQUIREMENTS_PATH_ENV: &str = "CLAUDIUS_CODEX_REQUIREMENTS_PATH";
 const CODEX_MANAGED_CONFIG_PATH_ENV: &str = "CLAUDIUS_CODEX_MANAGED_CONFIG_PATH";
 const GEMINI_CLI_SYSTEM_SETTINGS_PATH_ENV: &str = "GEMINI_CLI_SYSTEM_SETTINGS_PATH";
+const GEMINI_CLI_SYSTEM_DEFAULTS_PATH_ENV: &str = "GEMINI_CLI_SYSTEM_DEFAULTS_PATH";
 
 #[must_use]
 pub fn claude_code_managed_dir() -> PathBuf {
@@ -51,6 +52,15 @@ pub fn gemini_cli_system_settings_path() -> PathBuf {
         .map_or_else(default_gemini_cli_system_settings_path, PathBuf::from)
 }
 
+#[must_use]
+pub fn gemini_cli_system_defaults_path() -> PathBuf {
+    std::env::var(GEMINI_CLI_SYSTEM_DEFAULTS_PATH_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map_or_else(default_gemini_cli_system_defaults_path, PathBuf::from)
+}
+
 #[cfg(target_os = "macos")]
 fn default_claude_code_managed_dir() -> PathBuf {
     PathBuf::from("/Library/Application Support/ClaudeCode")
@@ -78,7 +88,7 @@ fn default_codex_requirements_path() -> PathBuf {
 
 #[cfg(windows)]
 fn default_codex_requirements_path() -> PathBuf {
-    PathBuf::from(r"C:\ProgramData\codex\requirements.toml")
+    PathBuf::from(r"C:\ProgramData\OpenAI\Codex\requirements.toml")
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
@@ -125,6 +135,26 @@ fn default_gemini_cli_system_settings_path() -> PathBuf {
 #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
 fn default_gemini_cli_system_settings_path() -> PathBuf {
     PathBuf::from("/etc/gemini-cli/settings.json")
+}
+
+#[cfg(target_os = "macos")]
+fn default_gemini_cli_system_defaults_path() -> PathBuf {
+    PathBuf::from("/Library/Application Support/GeminiCli/system-defaults.json")
+}
+
+#[cfg(target_os = "linux")]
+fn default_gemini_cli_system_defaults_path() -> PathBuf {
+    PathBuf::from("/etc/gemini-cli/system-defaults.json")
+}
+
+#[cfg(windows)]
+fn default_gemini_cli_system_defaults_path() -> PathBuf {
+    PathBuf::from(r"C:\ProgramData\gemini-cli\system-defaults.json")
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn default_gemini_cli_system_defaults_path() -> PathBuf {
+    PathBuf::from("/etc/gemini-cli/system-defaults.json")
 }
 
 #[cfg(test)]
@@ -184,5 +214,17 @@ mod tests {
         assert_eq!(gemini_cli_system_settings_path(), path);
 
         std::env::remove_var(GEMINI_CLI_SYSTEM_SETTINGS_PATH_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_gemini_cli_system_defaults_path_env_override() {
+        let temp_dir = TempDir::new().expect("temp dir should be created for test");
+        let path = temp_dir.path().join("system-defaults.json");
+        std::env::set_var(GEMINI_CLI_SYSTEM_DEFAULTS_PATH_ENV, &path);
+
+        assert_eq!(gemini_cli_system_defaults_path(), path);
+
+        std::env::remove_var(GEMINI_CLI_SYSTEM_DEFAULTS_PATH_ENV);
     }
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -122,6 +122,15 @@ const DEFAULT_GEMINI_SETTINGS: &str = r#"{
 }
 "#;
 
+/// Default Gemini CLI system defaults content
+const DEFAULT_GEMINI_SYSTEM_DEFAULTS: &str = r#"{
+  "$schema": "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/schemas/settings.schema.json",
+  "general": {},
+  "ui": {},
+  "tools": {}
+}
+"#;
+
 /// Default Codex TOML settings content
 const DEFAULT_CODEX_SETTINGS: &str = r#"# Codex Settings
 # Configure your Codex CLI settings here
@@ -130,15 +139,15 @@ const DEFAULT_CODEX_SETTINGS: &str = r#"# Codex Settings
 # See the configuration reference for the latest options:
 # https://developers.openai.com/codex/config-reference
 
-# Model selection (examples: "gpt-5-codex", "openai/gpt-4.1", "anthropic/claude-3-5-sonnet")
-# model = "gpt-5-codex"
-# review_model = "gpt-5-codex"
+# Model selection (examples: "gpt-5.5", "openai/gpt-4.1", "anthropic/claude-3-5-sonnet")
+# model = "gpt-5.5"
+# review_model = "gpt-5.5"
 
 # The model provider to use if not specified in the model name
 # model_provider = "openai"
 
 # Approval policy for running commands:
-# - "untrusted" | "on-failure" | "on-request" | "never"
+# - "untrusted" | "on-request" | "never"
 # approval_policy = "on-request"
 
 # List of notification channels
@@ -197,7 +206,7 @@ const DEFAULT_CODEX_REQUIREMENTS: &str = r#"# Codex requirements.toml
 # https://developers.openai.com/codex/config-reference
 #
 # Example:
-# allowed_approval_policies = ["untrusted", "on-request", "on-failure"]
+# allowed_approval_policies = ["untrusted", "on-request", "never"]
 # allowed_sandbox_modes = ["read-only", "workspace-write"]
 "#;
 
@@ -319,6 +328,7 @@ fn init_agent_settings(config_dir: &Path, force: bool) -> Result<()> {
         ("codex.requirements.toml", DEFAULT_CODEX_REQUIREMENTS),
         ("codex.managed_config.toml", DEFAULT_CODEX_MANAGED_CONFIG),
         ("gemini.settings.json", DEFAULT_GEMINI_SETTINGS),
+        ("gemini.system_defaults.json", DEFAULT_GEMINI_SYSTEM_DEFAULTS),
     ];
 
     agent_settings.into_iter().try_for_each(|(filename, content)| {
@@ -367,6 +377,17 @@ fn init_rules_directory(config_dir: &Path, force: bool) -> Result<()> {
 
     let example_rule_path = rules_dir.join("example.md");
     create_file_if_needed(&example_rule_path, EXAMPLE_RULE, force, "example rule")
+}
+
+/// Initialize auxiliary source directories for agent-specific assets.
+fn init_auxiliary_source_directories(config_dir: &Path, force: bool) -> Result<()> {
+    [
+        config_dir.join("commands").join("gemini"),
+        config_dir.join("agents").join("gemini"),
+        config_dir.join("agents").join("claude-code"),
+    ]
+    .into_iter()
+    .try_for_each(|path| create_directory(&path, force))
 }
 
 /// Initialize context files in project directory based on config
@@ -452,6 +473,7 @@ pub fn bootstrap_config(config_dir: &Path, force: bool) -> Result<()> {
     init_app_config(config_dir, force)?;
     init_skills_directory(config_dir, force)?;
     init_rules_directory(config_dir, force)?;
+    init_auxiliary_source_directories(config_dir, force)?;
 
     info!("Bootstrap complete at: {}", config_dir.display());
     Ok(())
@@ -484,7 +506,15 @@ pub fn bootstrap_config_with_context(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
     use tempfile::TempDir;
+
+    fn assert_paths_exist(base: &Path, paths: &[&str]) {
+        assert!(
+            paths.iter().all(|path| base.join(path).exists()),
+            "Expected bootstrap to create: {paths:?}"
+        );
+    }
 
     #[test]
     fn test_bootstrap_creates_structure() {
@@ -493,20 +523,27 @@ mod tests {
 
         bootstrap_config(&config_dir, false).expect("bootstrap_config should succeed");
 
-        // Check all files and directories exist
-        assert!(config_dir.exists());
-        assert!(config_dir.join("mcpServers.json").exists());
-        assert!(config_dir.join("claude.settings.json").exists());
-        assert!(config_dir.join("codex.settings.toml").exists());
-        assert!(config_dir.join("codex.requirements.toml").exists());
-        assert!(config_dir.join("codex.managed_config.toml").exists());
-        assert!(config_dir.join("gemini.settings.json").exists());
-        assert!(config_dir.join("settings.json").exists());
-        assert!(config_dir.join("config.toml").exists());
-        assert!(config_dir.join("skills").exists());
-        assert!(config_dir.join("skills/example/SKILL.md").exists());
-        assert!(config_dir.join("rules").exists());
-        assert!(config_dir.join("rules/example.md").exists());
+        assert_paths_exist(
+            &config_dir,
+            &[
+                "mcpServers.json",
+                "claude.settings.json",
+                "codex.settings.toml",
+                "codex.requirements.toml",
+                "codex.managed_config.toml",
+                "gemini.settings.json",
+                "gemini.system_defaults.json",
+                "settings.json",
+                "config.toml",
+                "skills",
+                "skills/example/SKILL.md",
+                "commands/gemini",
+                "agents/gemini",
+                "agents/claude-code",
+                "rules",
+                "rules/example.md",
+            ],
+        );
 
         // Verify content
         let mcp_content = fs::read_to_string(config_dir.join("mcpServers.json"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,19 +16,21 @@ It helps you:
 Claude Desktop support is retained as a legacy / best-effort MCP target.
 Prefer Claude Code, Codex, or Gemini when you need actively managed surfaces.
 
-Configuration files are stored in:
-  • $XDG_CONFIG_HOME/claudius/ (or ~/.config/claudius/)
-    - mcpServers.json: MCP server definitions
-    - claude.settings.json: Claude/Claude Code settings (optional)
-    - codex.settings.toml: Codex settings (optional)
-    - codex.requirements.toml: Codex requirements (admin-enforced, optional)
-    - codex.managed_config.toml: Codex managed defaults (admin-managed, optional)
-    - gemini.settings.json: Gemini settings (optional)
-    - settings.json: Legacy Claude settings (backward compatible)
-    - skills/: Shared and agent-specific skills (directories with SKILL.md)
-    - commands/gemini/: Gemini custom commands (*.toml)
-    - agents/claude-code/: Claude Code subagents (*.md)
-    - rules/: Agent context templates (*.md)
+    Configuration files are stored in:
+      • $XDG_CONFIG_HOME/claudius/ (or ~/.config/claudius/)
+        - mcpServers.json: MCP server definitions
+        - claude.settings.json: Claude/Claude Code settings (optional)
+        - codex.settings.toml: Codex settings (optional)
+        - codex.requirements.toml: Codex requirements (admin-enforced, optional)
+        - codex.managed_config.toml: Codex managed defaults (admin-managed, optional)
+        - gemini.settings.json: Gemini settings (optional)
+        - gemini.system_defaults.json: Gemini CLI system defaults (optional)
+        - settings.json: Legacy Claude settings (backward compatible)
+        - skills/: Shared and agent-specific skills (directories with SKILL.md)
+        - commands/gemini/: Gemini custom commands (*.toml)
+        - agents/gemini/: Gemini custom agents (*.md)
+        - agents/claude-code/: Claude Code subagents (*.md)
+        - rules/: Agent context templates (*.md)
 
 Target files:
   • ./.mcp.json (MCP servers in project-local mode, default)
@@ -38,11 +40,12 @@ Target files:
   • ~/.claude.json + ~/.claude/settings.json (Claude Code global config)
   • System-level managed-settings.json / managed-mcp.json (Claude Code managed scope)
   • ~/.codex/config.toml (Codex global config)
-  • /etc/codex/requirements.toml (Codex requirements, admin-enforced)
-  • /etc/codex/managed_config.toml (Codex managed defaults)
-  • ~/.gemini/settings.json (Gemini global config)
-  • /etc/gemini-cli/settings.json (Gemini CLI system settings)
-  • ./CLAUDE.md / ./GEMINI.md / ./AGENTS.md (project instructions)",
+      • /etc/codex/requirements.toml (Codex requirements, admin-enforced)
+      • /etc/codex/managed_config.toml (Codex managed defaults)
+      • ~/.gemini/settings.json (Gemini global config)
+      • /etc/gemini-cli/settings.json (Gemini CLI system settings)
+      • /etc/gemini-cli/system-defaults.json (Gemini CLI system defaults)
+      • ./CLAUDE.md / ./GEMINI.md / ./AGENTS.md (project instructions)",
     version,
     author
 )]
@@ -91,18 +94,20 @@ pub enum ConfigCommands {
     /// Bootstrap Claudius configuration directory with default files
     #[command(long_about = "Bootstrap Claudius configuration directory with default files.
 
-This command creates the following structure in $XDG_CONFIG_HOME/claudius/:
-  • mcpServers.json - MCP server configuration template
-  • claude.settings.json - Claude/Claude Code settings template
-  • codex.settings.toml - Codex settings template
-  • codex.requirements.toml - Codex requirements template (admin-enforced)
-  • codex.managed_config.toml - Codex managed defaults template (admin-managed)
-  • gemini.settings.json - Gemini settings template
-  • settings.json - Legacy Claude settings (backward compatible)
-  • skills/ - Directory for shared and agent-specific skills
-  • commands/gemini/ - Gemini custom commands (*.toml)
-  • agents/claude-code/ - Claude Code subagents (*.md)
-  • rules/ - Directory for agent context rules
+    This command creates the following structure in $XDG_CONFIG_HOME/claudius/:
+      • mcpServers.json - MCP server configuration template
+      • claude.settings.json - Claude/Claude Code settings template
+      • codex.settings.toml - Codex settings template
+      • codex.requirements.toml - Codex requirements template (admin-enforced)
+      • codex.managed_config.toml - Codex managed defaults template (admin-managed)
+      • gemini.settings.json - Gemini settings template
+      • gemini.system_defaults.json - Gemini CLI system defaults template
+      • settings.json - Legacy Claude settings (backward compatible)
+      • skills/ - Directory for shared and agent-specific skills
+      • commands/gemini/ - Gemini custom commands (*.toml)
+      • agents/gemini/ - Gemini custom agents (*.md)
+      • agents/claude-code/ - Claude Code subagents (*.md)
+      • rules/ - Directory for agent context rules
 
 By default, existing files are preserved. Use --force to reinitialize.
 
@@ -119,12 +124,13 @@ Examples:
 
 This command:
   1. Reads mcpServers.json for MCP server definitions
-  2. Reads agent settings (if present):
-     - claude.settings.json (or legacy settings.json)
-     - codex.settings.toml
-     - codex.requirements.toml (optional; used with --codex-requirements)
-     - codex.managed_config.toml (optional; used with --codex-managed-config)
-     - gemini.settings.json
+     2. Reads agent settings (if present):
+        - claude.settings.json (or legacy settings.json)
+        - codex.settings.toml
+        - codex.requirements.toml (optional; used with --codex-requirements)
+        - codex.managed_config.toml (optional; used with --codex-managed-config)
+        - gemini.settings.json
+        - gemini.system_defaults.json (optional; used with --gemini-system-defaults)
   3. Writes configurations to:
      - Project-local mode (default):
        • Claude (`--agent claude`): ./.mcp.json (legacy / best-effort Desktop-compatible MCP target)
@@ -139,11 +145,13 @@ This command:
        • Codex: ~/.codex/config.toml
        • Gemini: ~/.gemini/settings.json
        • Gemini system settings (--gemini-system): /etc/gemini-cli/settings.json
-  4. Syncs auxiliary agent content when present:
-     - skills/ -> agent skills directories
-     - commands/gemini/ -> .gemini/commands
-     - agents/claude-code/ -> .claude/agents
-     - Codex skills stay explicit via `claudius skills sync --agent codex --enable-codex-skills`
+       • Gemini system defaults (--gemini-system-defaults): /etc/gemini-cli/system-defaults.json
+     4. Syncs auxiliary agent content when present:
+       - skills/ -> agent skills directories
+       - commands/gemini/ -> .gemini/commands
+       - agents/gemini/ -> .gemini/agents
+       - agents/claude-code/ -> .claude/agents
+       - Codex skills stay explicit via `claudius skills sync --agent codex --enable-codex-skills`
 
 Note: `--agent claude` is retained for legacy Claude Desktop JSON workflows.
 For actively managed CLI surfaces, prefer `claude-code`, `codex`, or `gemini`.
@@ -169,15 +177,17 @@ Examples:
     #[command(
         long_about = "Validate Claudius configuration source files without writing anything.
 
-This command checks:
-  • mcpServers.json (required) - MCP server definitions
-  • claude.settings.json / settings.json (optional) - Claude/Claude Code settings
-  • codex.settings.toml (optional) - Codex settings
-  • codex.requirements.toml (optional) - Codex admin-enforced requirements
-  • codex.managed_config.toml (optional) - Codex admin-managed defaults
-  • gemini.settings.json (optional) - Gemini settings
-  • commands/gemini/*.toml (optional) - Gemini custom commands
-  • agents/claude-code/*.md (optional) - Claude Code subagent definitions
+    This command checks:
+      • mcpServers.json (required) - MCP server definitions
+      • claude.settings.json / settings.json (optional) - Claude/Claude Code settings
+      • codex.settings.toml (optional) - Codex settings
+      • codex.requirements.toml (optional) - Codex admin-enforced requirements
+      • codex.managed_config.toml (optional) - Codex admin-managed defaults
+      • gemini.settings.json (optional) - Gemini settings
+      • gemini.system_defaults.json (optional) - Gemini CLI system defaults
+      • commands/gemini/*.toml (optional) - Gemini custom commands
+      • agents/gemini/*.md (optional) - Gemini custom agents
+      • agents/claude-code/*.md (optional) - Claude Code subagent definitions
 
 Use --agent to validate a specific agent's settings.
 Use --strict to fail on warnings."
@@ -193,6 +203,7 @@ to report situations such as:
   • legacy settings.json still in use
   • legacy commands/*.md fallback still present
   • Claude Desktop JSON targets being used as legacy / best-effort surfaces
+  • unmanaged Claude Code slash commands in .claude/commands
   • unmanaged Gemini extensions in the selected deployment context
   • experimental Codex skill sync surfaces
   • stale deployed assets that no longer exist in the source tree
@@ -407,6 +418,13 @@ pub struct ConfigSyncArgs {
         help = "Target Gemini CLI system settings file (e.g. /etc/gemini-cli/settings.json; global Gemini only)"
     )]
     pub gemini_system: bool,
+
+    /// Target Gemini CLI system-defaults.json file (global Gemini only)
+    #[arg(
+        long,
+        help = "Target Gemini CLI system-defaults.json (e.g. /etc/gemini-cli/system-defaults.json; global Gemini only)"
+    )]
+    pub gemini_system_defaults: bool,
 }
 
 #[derive(Args, Debug, Clone, Copy)]

--- a/src/codex_settings.rs
+++ b/src/codex_settings.rs
@@ -141,11 +141,31 @@ pub struct HistoryConfig {
 
 // Known field names for validation
 pub const KNOWN_CODEX_FIELDS: &[&str] = &[
+    "agents",
+    "allow_login_shell",
+    "analytics",
     "model",
+    "model_auto_compact_token_limit",
+    "model_catalog_json",
     "review_model",
+    "model_instructions_file",
     "model_provider",
+    "model_reasoning_effort",
+    "model_reasoning_summary",
+    "model_supports_reasoning_summaries",
     "model_context_window",
+    "model_verbosity",
+    "notice",
     "approval_policy",
+    "approvals_reviewer",
+    "apps",
+    "auto_review",
+    "background_terminal_max_timeout",
+    "background_terminal_timeout",
+    "commit_attribution",
+    "compact_prompt",
+    "default_permissions",
+    "disable_paste_burst",
     "notify",
     "model_providers",
     "shell_environment_policy",
@@ -153,18 +173,36 @@ pub const KNOWN_CODEX_FIELDS: &[&str] = &[
     "sandbox_workspace_write",
     "sandbox",
     "history",
+    "hooks",
+    "log_dir",
     "mcp_servers",
+    "mcp_oauth_callback_port",
+    "mcp_oauth_callback_url",
+    "mcp_oauth_credentials_store",
+    "memories",
     // Newer Codex CLI fields (non-exhaustive; used only for warning suppression)
     "check_for_update_on_startup",
     "instructions",
     "developer_instructions",
+    "default_profile",
+    "experimental_compact_prompt_file",
+    "experimental_instructions_file",
+    "experimental_use_unified_exec_tool",
+    "feedback",
     "features",
     "profile",
     "profiles",
+    "personality",
+    "plan_mode_reasoning_effort",
     "projects",
     "project_root_markers",
     "project_doc_max_bytes",
     "project_doc_fallback_filenames",
+    "service_tier",
+    "skills",
+    "sqlite_home",
+    "suppress_unstable_features_warning",
+    "tool_suggest",
     "tool_output_token_limit",
     "tui",
     "hide_agent_reasoning",
@@ -174,8 +212,14 @@ pub const KNOWN_CODEX_FIELDS: &[&str] = &[
     "forced_chatgpt_workspace_id",
     "forced_login_method",
     "chatgpt_base_url",
+    "openai_base_url",
     "otel",
     "oss_provider",
+    "permissions",
+    "tools",
+    "web_search",
+    "windows",
+    "windows_wsl_setup_acknowledged",
     // Legacy / compatibility fields
     "disable_response_storage",
 ];
@@ -199,6 +243,28 @@ pub const KNOWN_SANDBOX_WORKSPACE_WRITE_FIELDS: &[&str] =
 
 pub const KNOWN_HISTORY_FIELDS: &[&str] = &["persistence", "max_bytes"];
 
+pub const KNOWN_CODEX_FEATURE_FIELDS: &[&str] = &[
+    "apps",
+    "browser_use",
+    "codex_hooks",
+    "computer_use",
+    "enable_request_compression",
+    "fast_mode",
+    "in_app_browser",
+    "memories",
+    "multi_agent",
+    "personality",
+    "prevent_idle_sleep",
+    "shell_snapshot",
+    "shell_tool",
+    "skill_mcp_dependency_install",
+    "undo",
+    "unified_exec",
+    "web_search",
+    "web_search_cached",
+    "web_search_request",
+];
+
 const CODEX_MCP_STDIO_UNSUPPORTED_FIELDS: &[&str] =
     &["url", "bearer_token_env_var", "http_headers", "env_http_headers"];
 
@@ -216,6 +282,7 @@ pub fn validate_codex_settings(toml_value: &TomlValue) -> Vec<String> {
             }
 
             validate_nested_codex_field(key.as_str(), value, &mut warnings);
+            validate_deprecated_codex_field(key.as_str(), value, &mut warnings);
         }
     }
 
@@ -235,6 +302,7 @@ fn validate_nested_codex_field(parent_key: &str, value: &TomlValue, warnings: &m
         },
         "sandbox" => Some((KNOWN_SANDBOX_FIELDS, "sandbox", false)),
         "history" => Some((KNOWN_HISTORY_FIELDS, "history", false)),
+        "features" => Some((KNOWN_CODEX_FEATURE_FIELDS, "features", false)),
         _ => None,
     };
 
@@ -245,6 +313,64 @@ fn validate_nested_codex_field(parent_key: &str, value: &TomlValue, warnings: &m
             validate_simple_table(value, known_fields, field_name, warnings);
         }
     }
+}
+
+fn validate_deprecated_codex_field(
+    parent_key: &str,
+    value: &TomlValue,
+    warnings: &mut Vec<String>,
+) {
+    match parent_key {
+        "approval_policy" => {
+            if matches!(value, TomlValue::String(policy) if policy == "on-failure") {
+                warnings.push(
+                    "approval_policy = \"on-failure\" is deprecated; use \"on-request\" or \"never\""
+                        .to_string(),
+                );
+            }
+        },
+        "background_terminal_timeout" => warnings.push(
+            "background_terminal_timeout is deprecated; rename it to background_terminal_max_timeout"
+                .to_string(),
+        ),
+        "disable_response_storage" => warnings.push(
+            "disable_response_storage is a legacy Codex setting and no longer appears in the current config reference"
+                .to_string(),
+        ),
+        "experimental_instructions_file" => warnings.push(
+            "experimental_instructions_file is deprecated; rename it to model_instructions_file"
+                .to_string(),
+        ),
+        "experimental_use_unified_exec_tool" => warnings.push(
+            "experimental_use_unified_exec_tool is a legacy flag; prefer features.unified_exec"
+                .to_string(),
+        ),
+        "instructions" => warnings.push(
+            "instructions is reserved for future use; prefer model_instructions_file or AGENTS.md"
+                .to_string(),
+        ),
+        "features" => validate_deprecated_codex_feature_flags(value, warnings),
+        _ => {},
+    }
+}
+
+fn validate_deprecated_codex_feature_flags(value: &TomlValue, warnings: &mut Vec<String>) {
+    let TomlValue::Table(features) = value else {
+        return;
+    };
+
+    [
+        ("web_search", "web_search"),
+        ("web_search_cached", "web_search"),
+        ("web_search_request", "web_search"),
+    ]
+    .into_iter()
+    .filter(|(field, _)| features.contains_key(*field))
+    .for_each(|(field, replacement)| {
+        warnings.push(format!(
+            "features.{field} is deprecated; prefer the top-level {replacement} setting"
+        ));
+    });
 }
 
 /// Validate model providers which have an additional nesting level

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,39 +262,7 @@ impl Config {
     }
 
     fn skills_dir_has_entries(path: &Path) -> bool {
-        fs::read_dir(path).map(|mut entries| entries.next().is_some()).unwrap_or(false)
-    }
-
-    fn agent_skills_subdir(agent: crate::app_config::Agent) -> &'static str {
-        match agent {
-            crate::app_config::Agent::Claude => "claude",
-            crate::app_config::Agent::ClaudeCode => "claude-code",
-            crate::app_config::Agent::Codex => "codex",
-            crate::app_config::Agent::Gemini => "gemini",
-        }
-    }
-
-    #[must_use]
-    pub fn resolve_skills_source_dir(&self) -> Option<PathBuf> {
-        if let Some(agent) = self.agent {
-            let candidate = self.skills_dir.join(Self::agent_skills_subdir(agent));
-            if candidate.exists() && Self::skills_dir_has_entries(&candidate) {
-                return Some(candidate);
-            }
-        }
-
-        let has_shared_skills =
-            self.skills_dir.exists() && Self::skills_dir_has_entries(&self.skills_dir);
-        if has_shared_skills {
-            return Some(self.skills_dir.clone());
-        }
-
-        let legacy_commands = self.skills_dir.parent()?.join("commands");
-        if legacy_commands.exists() {
-            return Some(legacy_commands);
-        }
-
-        self.skills_dir.exists().then_some(self.skills_dir.clone())
+        fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_some())
     }
 
     #[must_use]
@@ -304,6 +272,16 @@ impl Config {
         }
 
         let candidate = self.skills_dir.parent()?.join("commands").join("gemini");
+        (candidate.exists() && Self::skills_dir_has_entries(&candidate)).then_some(candidate)
+    }
+
+    #[must_use]
+    pub fn resolve_gemini_agents_source_dir(&self) -> Option<PathBuf> {
+        if self.agent != Some(crate::app_config::Agent::Gemini) {
+            return None;
+        }
+
+        let candidate = self.skills_dir.parent()?.join("agents").join("gemini");
         (candidate.exists() && Self::skills_dir_has_entries(&candidate)).then_some(candidate)
     }
 
@@ -333,6 +311,18 @@ impl Config {
         std::env::current_dir().map_err(Into::into)
     }
 
+    /// Return the Claudius configuration root directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the root directory cannot be derived from the
+    /// configured skills path.
+    pub fn config_root_dir(&self) -> anyhow::Result<&Path> {
+        self.skills_dir
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Failed to determine Claudius config root directory"))
+    }
+
     /// Determine the Gemini custom commands target directory.
     ///
     /// # Errors
@@ -344,6 +334,19 @@ impl Config {
         }
 
         Ok(Some(self.deployment_base_dir()?.join(".gemini").join("commands")))
+    }
+
+    /// Determine the Gemini agents target directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the deployment base directory cannot be determined.
+    pub fn gemini_agents_target_dir(&self) -> anyhow::Result<Option<PathBuf>> {
+        if self.agent != Some(crate::app_config::Agent::Gemini) {
+            return Ok(None);
+        }
+
+        Ok(Some(self.deployment_base_dir()?.join(".gemini").join("agents")))
     }
 
     /// Determine the Claude Code subagents target directory.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -78,6 +78,7 @@ struct SourceSurfaceState {
     gemini_skills: Vec<SourceFileMapping>,
     codex_skills: Vec<SourceFileMapping>,
     gemini_commands: Vec<SourceFileMapping>,
+    gemini_agents: Vec<SourceFileMapping>,
     claude_code_agents: Vec<SourceFileMapping>,
 }
 
@@ -150,15 +151,26 @@ pub fn render_report(report: &DoctorReport) -> String {
 
 fn load_source_surface_state(config_dir: &Path) -> Result<SourceSurfaceState> {
     Ok(SourceSurfaceState {
-        shared_skills: collect_shared_skill_mappings(&config_dir.join("skills"))?,
-        legacy_commands: collect_legacy_command_mappings(&config_dir.join("commands"))?,
-        claude_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("claude"))?,
-        claude_code_skills: collect_agent_skill_mappings(
-            &config_dir.join("skills").join("claude-code"),
+        shared_skills: skills::collect_shared_skill_mappings(&config_dir.join("skills"))?,
+        legacy_commands: skills::collect_legacy_command_mappings(&config_dir.join("commands"))?,
+        claude_skills: skills::collect_agent_skill_mappings(
+            &config_dir.join("skills"),
+            Agent::Claude,
         )?,
-        gemini_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("gemini"))?,
-        codex_skills: collect_agent_skill_mappings(&config_dir.join("skills").join("codex"))?,
+        claude_code_skills: skills::collect_agent_skill_mappings(
+            &config_dir.join("skills"),
+            Agent::ClaudeCode,
+        )?,
+        gemini_skills: skills::collect_agent_skill_mappings(
+            &config_dir.join("skills"),
+            Agent::Gemini,
+        )?,
+        codex_skills: skills::collect_agent_skill_mappings(
+            &config_dir.join("skills"),
+            Agent::Codex,
+        )?,
         gemini_commands: collect_tree_if_exists(&config_dir.join("commands").join("gemini"))?,
+        gemini_agents: collect_tree_if_exists(&config_dir.join("agents").join("gemini"))?,
         claude_code_agents: collect_tree_if_exists(&config_dir.join("agents").join("claude-code"))?,
     })
 }
@@ -189,6 +201,7 @@ fn collect_findings(
         config_dir,
         options.agent_filter,
         &source_state.gemini_commands,
+        &source_state.gemini_agents,
         &source_state.claude_code_agents,
         &mut findings,
     );
@@ -312,6 +325,19 @@ fn inspect_gemini_sources(
                 .to_string(),
         });
     }
+
+    let system_defaults = config_dir.join("gemini.system_defaults.json");
+    if system_defaults.exists() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Gemini system defaults source is present.".to_string(),
+            path: Some(system_defaults),
+            detail: None,
+            recommendation:
+                "Sync it with `claudius config sync --global --agent gemini --gemini-system-defaults` when admin defaults change."
+                    .to_string(),
+        });
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -403,6 +429,7 @@ fn inspect_auxiliary_sources(
     config_dir: &Path,
     agent_filter: Option<Agent>,
     gemini_command_mappings: &[SourceFileMapping],
+    gemini_agent_mappings: &[SourceFileMapping],
     claude_code_agent_mappings: &[SourceFileMapping],
     findings: &mut Vec<DoctorFinding>,
 ) {
@@ -414,6 +441,19 @@ fn inspect_auxiliary_sources(
             detail: Some(format!(
                 "{} Gemini command file(s) are ready to sync.",
                 gemini_command_mappings.len()
+            )),
+            recommendation: "Deploy them with `claudius config sync --agent gemini`.".to_string(),
+        });
+    }
+
+    if matches_filter(agent_filter, Agent::Gemini) && !gemini_agent_mappings.is_empty() {
+        findings.push(DoctorFinding {
+            status: DoctorStatus::Supported,
+            summary: "Gemini agent source is present.".to_string(),
+            path: Some(config_dir.join("agents").join("gemini")),
+            detail: Some(format!(
+                "{} Gemini agent file(s) are ready to sync.",
+                gemini_agent_mappings.len()
             )),
             recommendation: "Deploy them with `claudius config sync --agent gemini`.".to_string(),
         });
@@ -483,6 +523,25 @@ fn inspect_unmanaged_targets(
     deployment_base_dir: &Path,
     findings: &mut Vec<DoctorFinding>,
 ) {
+    if matches_filter(agent_filter, Agent::ClaudeCode) {
+        let commands_dir = deployment_base_dir.join(".claude").join("commands");
+        if directory_has_entries(&commands_dir) {
+            findings.push(DoctorFinding {
+                status: DoctorStatus::Unmanaged,
+                summary: "Claude Code slash commands are present in an unmanaged target directory."
+                    .to_string(),
+                path: Some(commands_dir),
+                detail: Some(
+                    "Claude Code still supports .claude/commands, but Claudius does not sync that surface yet."
+                        .to_string(),
+                ),
+                recommendation:
+                    "Keep managing slash commands directly in .claude/commands or migrate shared workflows into Claudius skills."
+                        .to_string(),
+            });
+        }
+    }
+
     if matches_filter(agent_filter, Agent::Gemini) {
         let extensions_dir = deployment_base_dir.join(".gemini").join("extensions");
         if directory_has_entries(&extensions_dir) {
@@ -559,6 +618,16 @@ fn inspect_gemini_targets(
         findings,
         inspect_managed_tree(&gemini_command_target, &source_state.gemini_commands)?,
         "Claudius-managed Gemini commands target has stale deployed files.",
+        config_prune_command(options.global, Agent::Gemini),
+    );
+
+    let gemini_agent_target = gemini_config
+        .gemini_agents_target_dir()?
+        .unwrap_or_else(|| deployment_base_dir.join(".gemini").join("agents"));
+    push_stale_finding(
+        findings,
+        inspect_managed_tree(&gemini_agent_target, &source_state.gemini_agents)?,
+        "Claudius-managed Gemini agents target has stale deployed files.",
         config_prune_command(options.global, Agent::Gemini),
     );
 
@@ -707,76 +776,6 @@ fn collect_tree_if_exists(path: &Path) -> Result<Vec<SourceFileMapping>> {
     crate::asset_sync::collect_directory_tree_mappings(path)
 }
 
-fn collect_agent_skill_mappings(path: &Path) -> Result<Vec<SourceFileMapping>> {
-    skills::collect_skill_mappings(path.exists().then_some(path))
-}
-
-fn collect_shared_skill_mappings(skills_root: &Path) -> Result<Vec<SourceFileMapping>> {
-    if !skills_root.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut mappings = Vec::new();
-    let mut entries = fs::read_dir(skills_root)
-        .with_context(|| format!("Failed to read directory: {}", skills_root.display()))?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-
-    for entry in entries {
-        let path = entry.path();
-        let entry_name = entry.file_name();
-        let entry_name_lossy = entry_name.to_string_lossy();
-        if is_agent_skill_subdir(&entry_name_lossy) {
-            continue;
-        }
-
-        if !path.is_dir() {
-            continue;
-        }
-
-        let skill_name = entry_name_lossy.to_string();
-        let nested = crate::asset_sync::collect_directory_tree_mappings(&path)?;
-        mappings.extend(nested.into_iter().map(|mapping| SourceFileMapping {
-            source_path: mapping.source_path,
-            relative_path: format!("{skill_name}/{}", mapping.relative_path),
-        }));
-    }
-
-    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-    Ok(mappings)
-}
-
-fn collect_legacy_command_mappings(commands_root: &Path) -> Result<Vec<SourceFileMapping>> {
-    if !commands_root.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut mappings = Vec::new();
-    let mut entries = fs::read_dir(commands_root)
-        .with_context(|| format!("Failed to read directory: {}", commands_root.display()))?
-        .collect::<std::result::Result<Vec<_>, _>>()?;
-    entries.sort_by_key(std::fs::DirEntry::file_name);
-
-    for entry in entries {
-        let path = entry.path();
-        if !path.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("md") {
-            continue;
-        }
-
-        let skill_name = path
-            .file_stem()
-            .and_then(|stem| stem.to_str())
-            .ok_or_else(|| anyhow::anyhow!("Invalid legacy command file name"))?
-            .to_string();
-        mappings.push(SourceFileMapping {
-            source_path: path,
-            relative_path: format!("{skill_name}/SKILL.md"),
-        });
-    }
-
-    Ok(mappings)
-}
-
 fn combine_mappings(mapping_sets: &[&[SourceFileMapping]]) -> Vec<SourceFileMapping> {
     let mut combined = mapping_sets
         .iter()
@@ -823,7 +822,7 @@ fn config_prune_command(global: bool, agent: Agent) -> String {
 }
 
 fn directory_has_entries(path: &Path) -> bool {
-    fs::read_dir(path).map(|mut entries| entries.next().is_some()).unwrap_or(false)
+    fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 fn matches_filter(agent_filter: Option<Agent>, candidate: Agent) -> bool {
@@ -841,8 +840,4 @@ fn agent_cli_name(agent: Agent) -> &'static str {
         Agent::Codex => "codex",
         Agent::Gemini => "gemini",
     }
-}
-
-fn is_agent_skill_subdir(name: &str) -> bool {
-    matches!(name, "claude" | "claude-code" | "codex" | "gemini")
 }

--- a/src/gemini_settings.rs
+++ b/src/gemini_settings.rs
@@ -43,10 +43,16 @@ pub struct GeminiSettings {
     pub output: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub billing: Option<Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub advanced: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub admin: Option<Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_policy_paths: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<Value>,
@@ -64,6 +70,9 @@ pub struct GeminiSettings {
     pub mcp: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_paths: Option<Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skills: Option<Value>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +87,9 @@ pub struct GeminiSettings {
 pub const KNOWN_GEMINI_FIELDS: &[&str] = &[
     "$schema",
     "admin",
+    "adminPolicyPaths",
     "advanced",
+    "billing",
     "context",
     "experimental",
     "extensions",
@@ -90,6 +101,7 @@ pub const KNOWN_GEMINI_FIELDS: &[&str] = &[
     "model",
     "modelConfigs",
     "output",
+    "policyPaths",
     "privacy",
     "security",
     "skills",

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use claudius::{
     sync_operations::{
         determine_agent, handle_backup, handle_dry_run, merge_all_configs,
         print_supporting_assets_dry_run, read_configurations, sync_supporting_assets,
-        write_configurations, AgentContext, CodexGlobalSyncOptions,
+        write_configurations, AgentContext, CodexGlobalSyncOptions, ReadConfigResult,
+        SupportingAssetSyncReport,
     },
     template::{
         append_rules_to_context_file, append_template_to_context_file, ensure_rules_directory,
@@ -222,22 +223,13 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
     }
 
     let config = Config::new_with_agent(global, effective_agent)?;
-    let Some(source_dir) = config.resolve_skills_source_dir() else {
-        let skill_targets = determine_skill_sync_targets(&config)?;
-        let reports = skill_targets
-            .iter()
-            .map(|target_dir| {
-                skills::sync_skills_with_options(None, target_dir, SyncBehavior { dry_run, prune })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        print_skill_sync_result(&reports, dry_run);
-        return Ok(());
-    };
+    let source_set =
+        skills::collect_claudius_skill_source_set(config.config_root_dir()?, config.agent)?;
 
-    if source_dir != config.skills_dir {
+    if source_set.includes_legacy_commands {
         println!(
             "Legacy commands directory detected; syncing skills from {}",
-            source_dir.display()
+            config.config_root_dir()?.join("commands").display()
         );
     }
 
@@ -245,8 +237,8 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
     let reports = skill_targets
         .iter()
         .map(|target_dir| {
-            skills::sync_skills_with_options(
-                Some(&source_dir),
+            skills::sync_skill_mappings_with_options(
+                &source_set.mappings,
                 target_dir,
                 SyncBehavior { dry_run, prune },
             )
@@ -274,6 +266,92 @@ fn run_config_sync(args: cli::ConfigSyncArgs, app_config: Option<&AppConfig>) ->
     run_sync(&options, app_config)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SyncFlagSet {
+    scope: Option<claudius::app_config::ClaudeCodeScope>,
+    codex_requirements: bool,
+    codex_managed_config: bool,
+    gemini_system: bool,
+    gemini_system_defaults: bool,
+}
+
+impl SyncFlagSet {
+    fn validate(self, effective_agent: Option<claudius::app_config::Agent>) -> Result<()> {
+        if self.scope.is_some() && effective_agent != Some(claudius::app_config::Agent::ClaudeCode)
+        {
+            anyhow::bail!("--scope is only supported with --agent claude-code");
+        }
+
+        if self.codex_requirements && effective_agent != Some(claudius::app_config::Agent::Codex) {
+            anyhow::bail!("--codex-requirements is only supported with --agent codex");
+        }
+
+        if self.codex_managed_config && effective_agent != Some(claudius::app_config::Agent::Codex)
+        {
+            anyhow::bail!("--codex-managed-config is only supported with --agent codex");
+        }
+
+        if self.gemini_system && effective_agent != Some(claudius::app_config::Agent::Gemini) {
+            anyhow::bail!("--gemini-system is only supported with --agent gemini");
+        }
+
+        if self.gemini_system_defaults
+            && effective_agent != Some(claudius::app_config::Agent::Gemini)
+        {
+            anyhow::bail!("--gemini-system-defaults is only supported with --agent gemini");
+        }
+
+        if self.gemini_system && self.gemini_system_defaults {
+            anyhow::bail!("--gemini-system and --gemini-system-defaults are mutually exclusive");
+        }
+
+        Ok(())
+    }
+
+    fn validate_global_constraints(self, effective_global: bool) -> Result<()> {
+        if self.codex_requirements && !effective_global {
+            anyhow::bail!(
+                "--codex-requirements requires --global (Codex requirements are system-wide)"
+            );
+        }
+
+        if self.codex_managed_config && !effective_global {
+            anyhow::bail!(
+                "--codex-managed-config requires --global (Codex managed_config.toml is system-wide)",
+            );
+        }
+
+        if self.gemini_system && !effective_global {
+            anyhow::bail!(
+                "--gemini-system requires --global (Gemini system settings are system-wide)"
+            );
+        }
+
+        if self.gemini_system_defaults && !effective_global {
+            anyhow::bail!(
+                "--gemini-system-defaults requires --global (Gemini system defaults are system-wide)"
+            );
+        }
+
+        Ok(())
+    }
+
+    fn resolve_target_config(
+        self,
+        target_config: Option<std::path::PathBuf>,
+    ) -> Option<std::path::PathBuf> {
+        target_config.or_else(|| {
+            if self.gemini_system {
+                Some(agent_paths::gemini_cli_system_settings_path())
+            } else if self.gemini_system_defaults {
+                Some(agent_paths::gemini_cli_system_defaults_path())
+            } else {
+                None
+            }
+        })
+    }
+}
+
 fn build_sync_options(
     args: cli::ConfigSyncArgs,
     app_config: Option<&AppConfig>,
@@ -290,36 +368,22 @@ fn build_sync_options(
         codex_requirements,
         codex_managed_config,
         gemini_system,
+        gemini_system_defaults,
     } = args;
-
-    let effective_agent = determine_agent(agent, app_config);
-    validate_sync_agent_flags(
-        effective_agent,
+    let flags = SyncFlagSet {
         scope,
         codex_requirements,
         codex_managed_config,
         gemini_system,
-    )?;
+        gemini_system_defaults,
+    };
 
-    let effective_global = compute_effective_global(global, scope);
-    if codex_requirements && !effective_global {
-        anyhow::bail!(
-            "--codex-requirements requires --global (Codex requirements are system-wide)"
-        );
-    }
+    let effective_agent = determine_agent(agent, app_config);
+    flags.validate(effective_agent)?;
 
-    if codex_managed_config && !effective_global {
-        anyhow::bail!(
-            "--codex-managed-config requires --global (Codex managed_config.toml is system-wide)",
-        );
-    }
-
-    if gemini_system && !effective_global {
-        anyhow::bail!("--gemini-system requires --global (Gemini system settings are system-wide)");
-    }
-
-    let effective_target_config = target_config
-        .or_else(|| gemini_system.then_some(agent_paths::gemini_cli_system_settings_path()));
+    let effective_global = compute_effective_global(global, flags.scope);
+    flags.validate_global_constraints(effective_global)?;
+    let effective_target_config = flags.resolve_target_config(target_config);
 
     Ok(SyncOptions {
         config_path: config,
@@ -329,37 +393,12 @@ fn build_sync_options(
         prune,
         global: effective_global,
         agent_override: agent,
-        claude_code_scope: scope,
-        codex_requirements,
-        codex_managed_config,
-        gemini_system,
+        claude_code_scope: flags.scope,
+        codex_requirements: flags.codex_requirements,
+        codex_managed_config: flags.codex_managed_config,
+        gemini_system: flags.gemini_system,
+        gemini_system_defaults: flags.gemini_system_defaults,
     })
-}
-
-fn validate_sync_agent_flags(
-    effective_agent: Option<claudius::app_config::Agent>,
-    scope: Option<claudius::app_config::ClaudeCodeScope>,
-    codex_requirements: bool,
-    codex_managed_config: bool,
-    gemini_system: bool,
-) -> Result<()> {
-    if scope.is_some() && effective_agent != Some(claudius::app_config::Agent::ClaudeCode) {
-        anyhow::bail!("--scope is only supported with --agent claude-code");
-    }
-
-    if codex_requirements && effective_agent != Some(claudius::app_config::Agent::Codex) {
-        anyhow::bail!("--codex-requirements is only supported with --agent codex");
-    }
-
-    if codex_managed_config && effective_agent != Some(claudius::app_config::Agent::Codex) {
-        anyhow::bail!("--codex-managed-config is only supported with --agent codex");
-    }
-
-    if gemini_system && effective_agent != Some(claudius::app_config::Agent::Gemini) {
-        anyhow::bail!("--gemini-system is only supported with --agent gemini");
-    }
-
-    Ok(())
 }
 
 fn compute_effective_global(
@@ -582,8 +621,14 @@ fn select_codex_managed_config_source(
 fn validate_gemini_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
     let mut warnings = Vec::new();
 
-    let gemini_settings_path = config_dir.join("gemini.settings.json");
-    if gemini_settings_path.exists() {
+    let gemini_settings_paths =
+        [config_dir.join("gemini.settings.json"), config_dir.join("gemini.system_defaults.json")];
+
+    for gemini_settings_path in gemini_settings_paths {
+        if !gemini_settings_path.exists() {
+            continue;
+        }
+
         let content = std::fs::read_to_string(&gemini_settings_path)
             .with_context(|| format!("Failed to read {}", gemini_settings_path.display()))?;
         let json_value: serde_json::Value = serde_json::from_str(&content).with_context(|| {
@@ -601,6 +646,7 @@ fn validate_gemini_sources(config_dir: &std::path::Path) -> Result<Vec<String>> 
     }
 
     warnings.extend(validate_gemini_command_sources(config_dir)?);
+    warnings.extend(validate_gemini_agent_sources(config_dir)?);
 
     Ok(warnings)
 }
@@ -618,6 +664,25 @@ fn validate_gemini_command_sources(config_dir: &std::path::Path) -> Result<Vec<S
                 .warnings
                 .into_iter()
                 .map(|warning| format!("{}: {warning}", command_file.display())),
+        );
+    }
+
+    Ok(warnings)
+}
+
+fn validate_gemini_agent_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
+    let mut warnings = Vec::new();
+    let agents_dir = config_dir.join("agents").join("gemini");
+    let mut agent_files = Vec::new();
+    collect_files_with_extension(&agents_dir, "md", &mut agent_files)?;
+
+    for agent_file in agent_files {
+        let result = claudius::validation::validate_gemini_agent_file(&agent_file)?;
+        warnings.extend(
+            result
+                .warnings
+                .into_iter()
+                .map(|warning| format!("{}: {warning}", agent_file.display())),
         );
     }
 
@@ -663,9 +728,7 @@ fn validate_codex_skill_compatibility(config_dir: &std::path::Path) -> Vec<Strin
 }
 
 fn directory_has_entries(path: &std::path::Path) -> bool {
-    std::fs::read_dir(path)
-        .map(|mut entries| entries.next().is_some())
-        .unwrap_or(false)
+    std::fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 fn collect_files_with_extension(
@@ -878,6 +941,7 @@ struct SyncOptions {
     codex_requirements: bool,
     codex_managed_config: bool,
     gemini_system: bool,
+    gemini_system_defaults: bool,
 }
 
 fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()> {
@@ -890,18 +954,22 @@ fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()>
         && !options.codex_requirements
         && !options.codex_managed_config
         && !options.gemini_system
+        && !options.gemini_system_defaults
         && app_config.is_none_or(|cfg| cfg.default.is_none())
     {
         sync_all_available_agents(options, app_config)
     } else {
         // Single agent sync (current behavior)
         let (agent_context, config, paths) = setup_sync_context(
-            options.agent_override,
+            SyncContextRequest {
+                agent_override: options.agent_override,
+                global: options.global,
+                config_path: options.config_path.clone(),
+                target_config_path: options.target_config_path.clone(),
+                claude_code_scope: options.claude_code_scope,
+                gemini_system_defaults: options.gemini_system_defaults,
+            },
             app_config,
-            options.global,
-            options.config_path.clone(),
-            options.target_config_path.clone(),
-            options.claude_code_scope,
         )?;
 
         // Log configuration paths
@@ -916,6 +984,7 @@ fn run_sync(options: &SyncOptions, app_config: Option<&AppConfig>) -> Result<()>
                 requirements: options.codex_requirements,
                 managed_config: options.codex_managed_config,
             },
+            sync_supporting_assets: !options.gemini_system && !options.gemini_system_defaults,
         };
 
         execute_sync_operation(&config, &paths, agent_context, flags)
@@ -957,12 +1026,15 @@ fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfi
         println!("===============================================");
 
         let (agent_context, config, paths) = setup_sync_context(
-            Some(*agent),
+            SyncContextRequest {
+                agent_override: Some(*agent),
+                global: true,
+                config_path: options.config_path.clone(),
+                target_config_path: options.target_config_path.clone(),
+                claude_code_scope: None,
+                gemini_system_defaults: false,
+            },
             app_config,
-            true,
-            options.config_path.clone(),
-            options.target_config_path.clone(),
-            None,
         )?;
 
         // Log configuration paths
@@ -974,6 +1046,7 @@ fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfi
             dry_run: options.dry_run,
             prune: options.prune,
             codex_global: CodexGlobalSyncOptions::default(),
+            sync_supporting_assets: true,
         };
 
         execute_sync_operation(&config, &paths, agent_context, flags)?;
@@ -985,33 +1058,36 @@ fn sync_all_available_agents(options: &SyncOptions, app_config: Option<&AppConfi
 
 /// Setup sync context with agent and paths
 fn setup_sync_context(
-    agent_override: Option<claudius::app_config::Agent>,
+    request: SyncContextRequest,
     app_config: Option<&AppConfig>,
-    global: bool,
-    config_opt: Option<std::path::PathBuf>,
-    target_config_opt: Option<std::path::PathBuf>,
-    claude_code_scope: Option<claudius::app_config::ClaudeCodeScope>,
 ) -> Result<(AgentContext, Config, SyncPaths)> {
-    let agent = determine_agent(agent_override, app_config);
+    let agent = determine_agent(request.agent_override, app_config);
     if let Some(a) = agent {
         debug!("Using agent: {:?}", a);
     }
 
-    if claude_code_scope.is_some() && agent != Some(claudius::app_config::Agent::ClaudeCode) {
+    if request.claude_code_scope.is_some() && agent != Some(claudius::app_config::Agent::ClaudeCode)
+    {
         anyhow::bail!("--scope is only supported with --agent claude-code");
     }
 
-    let agent_context = AgentContext::new(agent, claude_code_scope);
-    let config = Config::new_with_agent(global, agent)?;
+    let agent_context = AgentContext::new(agent, request.claude_code_scope);
+    let mut config = Config::new_with_agent(request.global, agent)?;
+
+    if request.gemini_system_defaults && agent_context.is_gemini {
+        let config_dir =
+            Config::get_config_dir().context("Failed to determine Claudius config directory")?;
+        config.settings_path = config_dir.join("gemini.system_defaults.json");
+    }
 
     let default_target_config = match agent_context.claude_code_scope {
         Some(claudius::app_config::ClaudeCodeScope::Managed)
-            if agent_context.is_claude_code && global =>
+            if agent_context.is_claude_code && request.global =>
         {
             agent_paths::claude_code_managed_mcp_path()
         },
         Some(claudius::app_config::ClaudeCodeScope::Local)
-            if agent_context.is_claude_code && !global =>
+            if agent_context.is_claude_code && !request.global =>
         {
             let base_dirs = directories::BaseDirs::new()
                 .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
@@ -1021,8 +1097,8 @@ fn setup_sync_context(
     };
 
     let paths = SyncPaths {
-        mcp_servers: config_opt.unwrap_or_else(|| config.mcp_servers_path.clone()),
-        target_config: target_config_opt.unwrap_or(default_target_config),
+        mcp_servers: request.config_path.unwrap_or_else(|| config.mcp_servers_path.clone()),
+        target_config: request.target_config_path.unwrap_or(default_target_config),
     };
 
     Ok((agent_context, config, paths))
@@ -1051,6 +1127,17 @@ struct SyncExecutionFlags {
     dry_run: bool,
     prune: bool,
     codex_global: CodexGlobalSyncOptions,
+    sync_supporting_assets: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SyncContextRequest {
+    agent_override: Option<claudius::app_config::Agent>,
+    global: bool,
+    config_path: Option<std::path::PathBuf>,
+    target_config_path: Option<std::path::PathBuf>,
+    claude_code_scope: Option<claudius::app_config::ClaudeCodeScope>,
+    gemini_system_defaults: bool,
 }
 
 /// Execute the main sync operation
@@ -1060,19 +1147,8 @@ fn execute_sync_operation(
     agent_context: AgentContext,
     flags: SyncExecutionFlags,
 ) -> Result<()> {
-    // Read configurations
     let read_result = read_configurations(config, &paths.mcp_servers, agent_context)?;
-
-    debug!("Reading target configuration");
-    let mut claude_config = if config.is_global && agent_context.is_codex {
-        // For Codex in global mode, don't read from paths.target_config (Codex uses ~/.codex/config.toml).
-        claudius::config::ClaudeConfig { mcp_servers: None, other: HashMap::new() }
-    } else {
-        reader::read_claude_config(&paths.target_config)
-            .context("Failed to read target configuration")?
-    };
-
-    // Process configurations
+    let mut claude_config = load_target_claude_config(config, &paths.target_config, agent_context)?;
     if flags.backup {
         handle_backup(
             config,
@@ -1084,39 +1160,92 @@ fn execute_sync_operation(
     }
     merge_all_configs(&mut claude_config, &read_result, agent_context, config.is_global)?;
 
-    // Output results
+    finalize_sync_operation(config, paths, agent_context, flags, &claude_config, &read_result)
+}
+
+fn load_target_claude_config(
+    config: &Config,
+    target_config: &std::path::Path,
+    agent_context: AgentContext,
+) -> Result<claudius::config::ClaudeConfig> {
+    debug!("Reading target configuration");
+
+    if config.is_global && agent_context.is_codex {
+        return Ok(claudius::config::ClaudeConfig { mcp_servers: None, other: HashMap::new() });
+    }
+
+    reader::read_claude_config(target_config).context("Failed to read target configuration")
+}
+
+fn finalize_sync_operation(
+    config: &Config,
+    paths: &SyncPaths,
+    agent_context: AgentContext,
+    flags: SyncExecutionFlags,
+    claude_config: &claudius::config::ClaudeConfig,
+    read_result: &ReadConfigResult,
+) -> Result<()> {
     if flags.dry_run {
-        let supporting_assets = sync_supporting_assets(
-            config,
-            agent_context,
-            SyncBehavior { dry_run: true, prune: flags.prune },
-        );
-        handle_dry_run(
-            config,
-            &paths.target_config,
-            &claude_config,
-            &read_result,
-            agent_context,
-            flags.codex_global,
-        )?;
-        print_supporting_assets_dry_run(&supporting_assets);
-    } else {
-        write_configurations(
-            config,
-            &claude_config,
-            &paths.target_config,
-            &read_result,
-            agent_context,
-            flags.codex_global,
-        )?;
-        let _ = sync_supporting_assets(
-            config,
-            agent_context,
-            SyncBehavior { dry_run: false, prune: flags.prune },
-        );
+        return run_sync_dry_run(config, paths, agent_context, flags, claude_config, read_result);
+    }
+
+    write_configurations(
+        config,
+        claude_config,
+        &paths.target_config,
+        read_result,
+        agent_context,
+        flags.codex_global,
+    )?;
+    sync_supporting_assets_if_enabled(config, agent_context, flags, false);
+
+    Ok(())
+}
+
+fn run_sync_dry_run(
+    config: &Config,
+    paths: &SyncPaths,
+    agent_context: AgentContext,
+    flags: SyncExecutionFlags,
+    claude_config: &claudius::config::ClaudeConfig,
+    read_result: &ReadConfigResult,
+) -> Result<()> {
+    let supporting_assets = collect_supporting_assets_report(config, agent_context, flags, true);
+
+    handle_dry_run(
+        config,
+        &paths.target_config,
+        claude_config,
+        read_result,
+        agent_context,
+        flags.codex_global,
+    )?;
+
+    if let Some(report) = supporting_assets {
+        print_supporting_assets_dry_run(&report);
     }
 
     Ok(())
+}
+
+fn collect_supporting_assets_report(
+    config: &Config,
+    agent_context: AgentContext,
+    flags: SyncExecutionFlags,
+    dry_run: bool,
+) -> Option<SupportingAssetSyncReport> {
+    flags.sync_supporting_assets.then(|| {
+        sync_supporting_assets(config, agent_context, SyncBehavior { dry_run, prune: flags.prune })
+    })
+}
+
+fn sync_supporting_assets_if_enabled(
+    config: &Config,
+    agent_context: AgentContext,
+    flags: SyncExecutionFlags,
+    dry_run: bool,
+) {
+    let _ = collect_supporting_assets_report(config, agent_context, flags, dry_run);
 }
 
 fn print_skill_sync_result(reports: &[skills::SkillSyncReport], dry_run: bool) {
@@ -1431,7 +1560,7 @@ fn build_installed_rules_list(
     for rule_name in copied_rules {
         let rule_path = relative_rules_path.join(format!("{rule_name}.md"));
         let rule_path_str = rule_path.to_string_lossy().replace('\\', "/");
-        writeln!(&mut rule_list, "- `{rule_path_str}`: {}", rule_name.replace('/', " / "),)
+        writeln!(&mut rule_list, "- `{rule_path_str}`: {}", rule_name.replace('/', " / "))
             .map_err(|e| anyhow::anyhow!("Failed to format rules list: {e}"))?;
     }
 

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,6 +1,9 @@
-use crate::asset_sync::{self, ManagedTreeSyncReport, SourceFileMapping, SyncBehavior};
+use crate::{
+    app_config::Agent,
+    asset_sync::{self, ManagedTreeSyncReport, SourceFileMapping, SyncBehavior},
+};
 use anyhow::{Context, Result};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -12,6 +15,12 @@ pub struct SkillSyncReport {
     pub synced_skills: Vec<String>,
     pub synced_files: Vec<String>,
     pub pruned_files: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillSourceSet {
+    pub mappings: Vec<SourceFileMapping>,
+    pub includes_legacy_commands: bool,
 }
 
 impl SkillSyncReport {
@@ -58,9 +67,23 @@ pub fn sync_skills_with_options(
     behavior: SyncBehavior,
 ) -> Result<SkillSyncReport> {
     let mappings = collect_skill_mappings(source_dir_opt)?;
-    let synced_skills = skill_names_from_mappings(&mappings);
+    sync_skill_mappings_with_options(&mappings, target_dir, behavior)
+}
+
+/// Sync already-collected skill mappings into a target directory.
+///
+/// # Errors
+///
+/// Returns an error if the managed-file manifest cannot be updated or the
+/// target tree cannot be written.
+pub fn sync_skill_mappings_with_options(
+    mappings: &[SourceFileMapping],
+    target_dir: &Path,
+    behavior: SyncBehavior,
+) -> Result<SkillSyncReport> {
+    let synced_skills = skill_names_from_mappings(mappings);
     let ManagedTreeSyncReport { target_dir: synced_target_dir, synced_files, pruned_files } =
-        asset_sync::sync_managed_tree(target_dir, &mappings, behavior)?;
+        asset_sync::sync_managed_tree(target_dir, mappings, behavior)?;
 
     Ok(SkillSyncReport { target_dir: synced_target_dir, synced_skills, synced_files, pruned_files })
 }
@@ -170,6 +193,151 @@ pub fn collect_skill_mappings(source_dir_opt: Option<&Path>) -> Result<Vec<Sourc
     Ok(mappings)
 }
 
+/// Collect shared, legacy, and agent-specific skill mappings from the Claudius
+/// config tree with override precedence applied per skill name.
+///
+/// Precedence order:
+/// 1. legacy `commands/*.md`
+/// 2. shared `skills/<skill>/...`
+/// 3. agent-specific `skills/<agent>/<skill>/...`
+///
+/// A higher-precedence source replaces the full skill directory from a
+/// lower-precedence source.
+///
+/// # Errors
+///
+/// Returns an error if the Claudius skill or command trees cannot be read.
+pub fn collect_claudius_skill_source_set(
+    config_dir: &Path,
+    agent: Option<Agent>,
+) -> Result<SkillSourceSet> {
+    let skills_root = config_dir.join("skills");
+    let commands_root = config_dir.join("commands");
+    let legacy_mappings = collect_legacy_command_mappings(&commands_root)?;
+    let includes_legacy_commands = !legacy_mappings.is_empty();
+    let shared_mappings = collect_shared_skill_mappings(&skills_root)?;
+    let agent_mappings = agent.map_or_else(
+        || Ok(Vec::new()),
+        |selected| collect_agent_skill_mappings(&skills_root, selected),
+    )?;
+
+    let mut merged = BTreeMap::<String, Vec<SourceFileMapping>>::new();
+    extend_skill_groups(&mut merged, legacy_mappings);
+    extend_skill_groups(&mut merged, shared_mappings);
+    extend_skill_groups(&mut merged, agent_mappings);
+
+    let mappings = merged
+        .into_values()
+        .flat_map(std::iter::IntoIterator::into_iter)
+        .collect::<Vec<_>>();
+
+    Ok(SkillSourceSet { mappings, includes_legacy_commands })
+}
+
+/// Collect mappings for shared skills in `skills/`, excluding agent-specific
+/// subdirectories such as `skills/gemini/`.
+///
+/// # Errors
+///
+/// Returns an error if the shared skills tree cannot be read.
+pub fn collect_shared_skill_mappings(skills_root: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !skills_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = fs::read_dir(skills_root)
+        .with_context(|| format!("Failed to read skills directory: {}", skills_root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut mappings = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        let entry_name = entry
+            .file_name()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid skill entry name"))?
+            .to_string();
+
+        if path.is_dir() {
+            if is_agent_skill_subdir(&entry_name) {
+                continue;
+            }
+
+            let skill_files = asset_sync::collect_directory_tree_mappings(&path)?;
+            mappings.extend(skill_files.into_iter().map(|mapping| SourceFileMapping {
+                source_path: mapping.source_path,
+                relative_path: normalize_skill_relative_path(&entry_name, &mapping.relative_path),
+            }));
+            continue;
+        }
+
+        if path.is_file() && path.extension().and_then(|value| value.to_str()) == Some("md") {
+            let skill_name_str = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?;
+            let skill_name = skill_name_str.to_string();
+            mappings.push(SourceFileMapping {
+                source_path: path,
+                relative_path: normalize_skill_relative_path(&skill_name, SKILL_FILE_NAME),
+            });
+        }
+    }
+
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+/// Collect mappings for agent-specific skills under `skills/<agent>/`.
+///
+/// # Errors
+///
+/// Returns an error if the agent-specific skill tree cannot be read.
+pub fn collect_agent_skill_mappings(
+    skills_root: &Path,
+    agent: Agent,
+) -> Result<Vec<SourceFileMapping>> {
+    let candidate = skills_root.join(agent_skill_subdir(agent));
+    collect_skill_mappings(candidate.exists().then_some(candidate.as_path()))
+}
+
+/// Collect mappings for legacy `commands/*.md` fallback skills.
+///
+/// # Errors
+///
+/// Returns an error if the commands directory cannot be read.
+pub fn collect_legacy_command_mappings(commands_root: &Path) -> Result<Vec<SourceFileMapping>> {
+    if !commands_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = fs::read_dir(commands_root)
+        .with_context(|| format!("Failed to read commands directory: {}", commands_root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut mappings = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+
+        let skill_name_str = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?;
+        let skill_name = skill_name_str.to_string();
+        mappings.push(SourceFileMapping {
+            source_path: path,
+            relative_path: normalize_skill_relative_path(&skill_name, SKILL_FILE_NAME),
+        });
+    }
+
+    Ok(mappings)
+}
+
 fn skill_names_from_mappings(mappings: &[SourceFileMapping]) -> Vec<String> {
     mappings
         .iter()
@@ -177,6 +345,40 @@ fn skill_names_from_mappings(mappings: &[SourceFileMapping]) -> Vec<String> {
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
+}
+
+fn extend_skill_groups(
+    groups: &mut BTreeMap<String, Vec<SourceFileMapping>>,
+    mappings: Vec<SourceFileMapping>,
+) {
+    let mut grouped = BTreeMap::<String, Vec<SourceFileMapping>>::new();
+    for mapping in mappings {
+        let skill_name = mapping
+            .relative_path
+            .split('/')
+            .next()
+            .expect("skill mappings always contain a top-level directory")
+            .to_string();
+        grouped.entry(skill_name).or_default().push(mapping);
+    }
+
+    for (skill_name, mut group_mappings) in grouped {
+        group_mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        groups.insert(skill_name, group_mappings);
+    }
+}
+
+fn agent_skill_subdir(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "claude",
+        Agent::ClaudeCode => "claude-code",
+        Agent::Codex => "codex",
+        Agent::Gemini => "gemini",
+    }
+}
+
+pub fn is_agent_skill_subdir(name: &str) -> bool {
+    matches!(name, "claude" | "claude-code" | "codex" | "gemini")
 }
 
 fn normalize_skill_relative_path(skill_name: &str, suffix: &str) -> String {
@@ -296,6 +498,55 @@ mod tests {
 
         assert_eq!(report.pruned_files, vec!["review/SKILL.md".to_string()]);
         assert!(!target_dir.join("review").exists());
+    }
+
+    #[test]
+    fn test_collect_shared_skill_mappings_skips_agent_subdirs() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let skills_dir = temp_dir.path().join("skills");
+        let shared_dir = skills_dir.join("shared");
+        let gemini_dir = skills_dir.join("gemini").join("agent-only");
+
+        fs::create_dir_all(&shared_dir).expect("Failed to create shared skill");
+        fs::create_dir_all(&gemini_dir).expect("Failed to create gemini skill");
+        fs::write(shared_dir.join(SKILL_FILE_NAME), "# Shared").expect("Failed to write shared");
+        fs::write(gemini_dir.join(SKILL_FILE_NAME), "# Gemini").expect("Failed to write gemini");
+
+        let mappings =
+            collect_shared_skill_mappings(&skills_dir).expect("shared skill mappings should load");
+        let relative_paths =
+            mappings.iter().map(|mapping| mapping.relative_path.clone()).collect::<Vec<_>>();
+
+        assert_eq!(relative_paths, vec!["shared/SKILL.md".to_string()]);
+    }
+
+    #[test]
+    fn test_collect_claudius_skill_source_set_prefers_agent_specific_over_shared_and_legacy() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let config_dir = temp_dir.path().join("claudius");
+        let shared_dir = config_dir.join("skills").join("review");
+        let agent_dir = config_dir.join("skills").join("gemini").join("review");
+        let commands_dir = config_dir.join("commands");
+
+        fs::create_dir_all(&shared_dir).expect("Failed to create shared dir");
+        fs::create_dir_all(&agent_dir).expect("Failed to create agent dir");
+        fs::create_dir_all(&commands_dir).expect("Failed to create commands dir");
+
+        fs::write(commands_dir.join("review.md"), "# Legacy").expect("Failed to write legacy");
+        fs::write(shared_dir.join(SKILL_FILE_NAME), "# Shared").expect("Failed to write shared");
+        fs::write(agent_dir.join(SKILL_FILE_NAME), "# Agent").expect("Failed to write agent");
+
+        let source_set = collect_claudius_skill_source_set(&config_dir, Some(Agent::Gemini))
+            .expect("skill source set should load");
+        let first_mapping = source_set.mappings.first().expect("expected a mapping");
+
+        assert!(source_set.includes_legacy_commands);
+        assert_eq!(source_set.mappings.len(), 1);
+        assert_eq!(first_mapping.relative_path, "review/SKILL.md");
+        assert_eq!(
+            fs::read_to_string(&first_mapping.source_path).expect("source should read"),
+            "# Agent"
+        );
     }
 
     #[test]

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -1462,6 +1462,9 @@ pub fn sync_supporting_assets(
     if let Some(asset) = sync_gemini_commands_if_exists(config, behavior) {
         report.push(asset);
     }
+    if let Some(asset) = sync_gemini_agents_if_exists(config, behavior) {
+        report.push(asset);
+    }
     if let Some(asset) = sync_claude_code_agents_if_exists(config, agent_context, behavior) {
         report.push(asset);
     }
@@ -1489,20 +1492,14 @@ fn sync_skills_if_exists(
         return None;
     }
 
-    let source_dir = config.resolve_skills_source_dir();
-
-    if let Some(path) = source_dir.as_ref().filter(|path| **path != config.skills_dir) {
-        warn!("Legacy commands directory detected; syncing skills from {}", path.display());
-    }
-
+    let source_set = collect_skill_source_set(config)?;
+    log_skill_source_details(config, &source_set);
     debug!("Syncing skills");
-    if let Some(path) = &source_dir {
-        debug!("Source: {}", path.display());
-    }
+    debug!("Source mappings: {}", source_set.mappings.len());
     debug!("Target: {}", config.skills_target_dir.display());
 
-    match skills::sync_skills_with_options(
-        source_dir.as_deref(),
+    match skills::sync_skill_mappings_with_options(
+        &source_set.mappings,
         &config.skills_target_dir,
         behavior,
     ) {
@@ -1527,6 +1524,34 @@ fn sync_skills_if_exists(
     }
 }
 
+fn collect_skill_source_set(config: &Config) -> Option<skills::SkillSourceSet> {
+    match config.config_root_dir().and_then(|config_root| {
+        skills::collect_claudius_skill_source_set(config_root, config.agent)
+    }) {
+        Ok(source_set) => Some(source_set),
+        Err(e) => {
+            warn!("Failed to collect skill sources: {}", e);
+            None
+        },
+    }
+}
+
+fn log_skill_source_details(config: &Config, source_set: &skills::SkillSourceSet) {
+    if !source_set.includes_legacy_commands {
+        return;
+    }
+
+    match config.config_root_dir() {
+        Ok(config_root) => warn!(
+            "Legacy commands directory detected; syncing skills from {}",
+            config_root.join("commands").display()
+        ),
+        Err(e) => {
+            warn!("Legacy commands directory detected but config root is unavailable: {e}");
+        },
+    }
+}
+
 fn sync_gemini_commands_if_exists(
     config: &Config,
     behavior: SyncBehavior,
@@ -1544,6 +1569,29 @@ fn sync_gemini_commands_if_exists(
     sync_directory_tree_if_exists(
         "Gemini command",
         "Gemini commands",
+        source_dir.as_deref(),
+        &target_dir,
+        behavior,
+    )
+}
+
+fn sync_gemini_agents_if_exists(
+    config: &Config,
+    behavior: SyncBehavior,
+) -> Option<SupportingAssetReport> {
+    let source_dir = config.resolve_gemini_agents_source_dir();
+    let target_dir = match config.gemini_agents_target_dir() {
+        Ok(Some(path)) => path,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!("Failed to determine Gemini agents target directory: {}", e);
+            return None;
+        },
+    };
+
+    sync_directory_tree_if_exists(
+        "Gemini agent",
+        "Gemini agents",
         source_dir.as_deref(),
         &target_dir,
         behavior,

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -48,7 +48,7 @@ struct GeminiCommandFile {
 }
 
 #[derive(Debug, Deserialize)]
-struct ClaudeCodeSubagentFrontmatter {
+struct MarkdownAgentFrontmatter {
     name: String,
     description: String,
     #[serde(flatten)]
@@ -284,11 +284,54 @@ pub fn validate_claude_code_subagent_file<P: AsRef<Path>>(path: P) -> Result<Val
         anyhow::anyhow!("Failed to extract Markdown body from {}", path_ref.display())
     })?;
 
-    let metadata: ClaudeCodeSubagentFrontmatter =
+    let metadata: MarkdownAgentFrontmatter =
         serde_yaml::from_str(frontmatter).with_context(|| {
             format!("Failed to parse Claude Code subagent frontmatter: {}", path_ref.display())
         })?;
 
+    Ok(validate_markdown_agent_metadata(&metadata, body))
+}
+
+/// Validates a Gemini custom agent definition file.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Unable to read the file
+/// - The file is missing YAML frontmatter
+/// - The YAML frontmatter is invalid
+/// - Required metadata fields are missing or have invalid types
+pub fn validate_gemini_agent_file<P: AsRef<Path>>(path: P) -> Result<ValidationResult> {
+    let path_ref = path.as_ref();
+    let content = fs::read_to_string(path_ref)
+        .with_context(|| format!("Failed to read Gemini agent file: {}", path_ref.display()))?;
+
+    let captures = YAML_FRONTMATTER_RE.captures(&content).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Gemini agent file must start with YAML frontmatter delimited by ---: {}",
+            path_ref.display()
+        )
+    })?;
+
+    let frontmatter = captures.get(1).map(|capture| capture.as_str()).ok_or_else(|| {
+        anyhow::anyhow!("Failed to extract YAML frontmatter from {}", path_ref.display())
+    })?;
+    let body = captures.get(2).map(|capture| capture.as_str()).ok_or_else(|| {
+        anyhow::anyhow!("Failed to extract Markdown body from {}", path_ref.display())
+    })?;
+
+    let metadata: MarkdownAgentFrontmatter =
+        serde_yaml::from_str(frontmatter).with_context(|| {
+            format!("Failed to parse Gemini agent frontmatter: {}", path_ref.display())
+        })?;
+
+    Ok(validate_markdown_agent_metadata(&metadata, body))
+}
+
+fn validate_markdown_agent_metadata(
+    metadata: &MarkdownAgentFrontmatter,
+    body: &str,
+) -> ValidationResult {
     let mut warnings = Vec::new();
     if metadata.name.trim().is_empty() {
         warnings.push("Required frontmatter field 'name' should not be empty".to_string());
@@ -297,10 +340,10 @@ pub fn validate_claude_code_subagent_file<P: AsRef<Path>>(path: P) -> Result<Val
         warnings.push("Required frontmatter field 'description' should not be empty".to_string());
     }
     if body.trim().is_empty() {
-        warnings.push("Subagent Markdown body should not be empty".to_string());
+        warnings.push("Agent Markdown body should not be empty".to_string());
     }
 
-    Ok(ValidationResult { warnings })
+    ValidationResult { warnings }
 }
 
 /// Prompt user to continue after a warning

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -54,6 +54,13 @@ impl TestFixture {
         Ok(self)
     }
 
+    /// Create a test `gemini.system_defaults.json` file.
+    pub fn with_gemini_system_defaults(&self, content: &str) -> std::io::Result<&Self> {
+        let path = self.config.join("gemini.system_defaults.json");
+        fs::write(path, content)?;
+        Ok(self)
+    }
+
     /// Create a test claude.settings.json file
     pub fn with_claude_settings(&self, content: &str) -> std::io::Result<&Self> {
         let path = self.config.join("claude.settings.json");
@@ -78,11 +85,35 @@ impl TestFixture {
         Ok(self)
     }
 
+    /// Create an agent-specific skill directory with SKILL.md.
+    pub fn with_agent_skill(
+        &self,
+        agent: &str,
+        name: &str,
+        content: &str,
+    ) -> std::io::Result<&Self> {
+        let skills_root = self.config.join("skills").join(agent);
+        let skill_path = skills_root.join(name);
+        fs::create_dir_all(&skill_path)?;
+        let path = skill_path.join("SKILL.md");
+        fs::write(path, content)?;
+        Ok(self)
+    }
+
     /// Create a Gemini custom command TOML file.
     pub fn with_gemini_command(&self, name: &str, content: &str) -> std::io::Result<&Self> {
         let commands_dir = self.config.join("commands").join("gemini");
         fs::create_dir_all(&commands_dir)?;
         let path = commands_dir.join(format!("{name}.toml"));
+        fs::write(path, content)?;
+        Ok(self)
+    }
+
+    /// Create a Gemini agent definition file.
+    pub fn with_gemini_agent(&self, name: &str, content: &str) -> std::io::Result<&Self> {
+        let agents_dir = self.config.join("agents").join("gemini");
+        fs::create_dir_all(&agents_dir)?;
+        let path = agents_dir.join(format!("{name}.md"));
         fs::write(path, content)?;
         Ok(self)
     }

--- a/tests/integration/agent_assets_test.rs
+++ b/tests/integration/agent_assets_test.rs
@@ -70,6 +70,63 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_sync_gemini_syncs_custom_agents() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture
+            .with_gemini_agent(
+                "reviewer",
+                "---\nname: reviewer\ndescription: Review Gemini workflows\n---\nFocus on Gemini-specific regressions.",
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success();
+
+        assert!(fixture.project_file_exists(".gemini/agents/reviewer.md"));
+        let agent = fixture
+            .read_project_file(".gemini/agents/reviewer.md")
+            .expect("Gemini agent should be readable");
+        assert!(agent.contains("Focus on Gemini-specific regressions."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_sync_gemini_syncs_shared_and_agent_specific_skills() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture.with_skill("shared-skill", "# Shared Skill").unwrap();
+        fixture.with_agent_skill("gemini", "gemini-skill", "# Gemini Skill").unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success();
+
+        assert!(fixture.project_file_exists(".gemini/skills/shared-skill/SKILL.md"));
+        assert!(fixture.project_file_exists(".gemini/skills/gemini-skill/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_sync_claude_code_syncs_subagents() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();
@@ -184,5 +241,48 @@ mod tests {
 
         assert!(!fixture.project_file_exists(".claude/agents/reviewer.md"));
         assert!(fixture.project_file_exists(".claude/agents/manual.md"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_sync_gemini_prune_removes_only_managed_agents() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture
+            .with_gemini_agent(
+                "reviewer",
+                "---\nname: reviewer\ndescription: Review Gemini workflows\n---\nFocus on Gemini-specific regressions.",
+            )
+            .unwrap();
+
+        let mut initial_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        initial_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success();
+
+        fs::remove_file(fixture.config.join("agents").join("gemini").join("reviewer.md")).unwrap();
+        fs::create_dir_all(fixture.project.join(".gemini").join("agents")).unwrap();
+        fs::write(fixture.project.join(".gemini").join("agents").join("manual.md"), "manual")
+            .unwrap();
+
+        let mut prune_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        prune_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini", "--prune"])
+            .assert()
+            .success();
+
+        assert!(!fixture.project_file_exists(".gemini/agents/reviewer.md"));
+        assert!(fixture.project_file_exists(".gemini/agents/manual.md"));
     }
 }

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -18,9 +18,18 @@ mod tests {
         fixture.with_settings(r#"{"apiKeyHelper":"legacy-helper"}"#).unwrap();
         fixture.with_skill("shared-skill", "# Shared Skill").unwrap();
         fixture
+            .with_gemini_system_defaults(r#"{"billing":{"project":"shared-project"}}"#)
+            .unwrap();
+        fixture
             .with_gemini_command(
                 "review",
                 "description = \"Review the current diff\"\nprompt = \"Review this change set.\"",
+            )
+            .unwrap();
+        fixture
+            .with_gemini_agent(
+                "triage",
+                "---\nname: triage\ndescription: Triage Gemini issues\n---\nFocus on Gemini-specific issues.",
             )
             .unwrap();
         fixture
@@ -41,7 +50,9 @@ mod tests {
             .success()
             .stdout(predicate::str::contains("SUPPORTED"))
             .stdout(predicate::str::contains("Shared skills source is present."))
+            .stdout(predicate::str::contains("Gemini system defaults source is present."))
             .stdout(predicate::str::contains("Gemini custom command source is present."))
+            .stdout(predicate::str::contains("Gemini agent source is present."))
             .stdout(predicate::str::contains("Claude Code subagent source is present."))
             .stdout(predicate::str::contains("LEGACY"))
             .stdout(predicate::str::contains(
@@ -68,6 +79,12 @@ mod tests {
                 "description = \"Review the current diff\"\nprompt = \"Review this change set.\"",
             )
             .unwrap();
+        fixture
+            .with_gemini_agent(
+                "triage",
+                "---\nname: triage\ndescription: Triage Gemini issues\n---\nFocus on Gemini-specific issues.",
+            )
+            .unwrap();
 
         let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
         sync.current_dir(&fixture.project)
@@ -79,6 +96,7 @@ mod tests {
 
         fs::remove_file(fixture.config.join("commands").join("gemini").join("review.toml"))
             .unwrap();
+        fs::remove_file(fixture.config.join("agents").join("gemini").join("triage.md")).unwrap();
         fs::create_dir_all(fixture.project.join(".gemini").join("extensions").join("sample"))
             .unwrap();
         fs::write(
@@ -108,7 +126,38 @@ mod tests {
             .stdout(predicate::str::contains(
                 "Claudius-managed Gemini commands target has stale deployed files.",
             ))
+            .stdout(predicate::str::contains(
+                "Claudius-managed Gemini agents target has stale deployed files.",
+            ))
             .stdout(predicate::str::contains("claudius config sync --agent gemini --prune"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_reports_unmanaged_claude_code_slash_commands() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::create_dir_all(fixture.project.join(".claude").join("commands")).unwrap();
+        fs::write(
+            fixture.project.join(".claude").join("commands").join("review.md"),
+            "# Review command",
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--agent", "claude-code"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("UNMANAGED"))
+            .stdout(predicate::str::contains(
+                "Claude Code slash commands are present in an unmanaged target directory.",
+            ))
+            .stdout(predicate::str::contains(".claude/commands"));
     }
 
     #[test]

--- a/tests/integration/gemini_system_settings_test.rs
+++ b/tests/integration/gemini_system_settings_test.rs
@@ -64,6 +64,21 @@ mod tests {
             r#"{"mcpServers":{"filesystem":{"command":"node","args":["server.js"],"env":{}}}}"#,
         )?;
         fs::write(claudius_dir.join("gemini.settings.json"), r#"{"general":{"vimMode":true}}"#)?;
+        fs::create_dir_all(claudius_dir.join("skills").join("shared-skill"))?;
+        fs::create_dir_all(claudius_dir.join("commands").join("gemini"))?;
+        fs::create_dir_all(claudius_dir.join("agents").join("gemini"))?;
+        fs::write(
+            claudius_dir.join("skills").join("shared-skill").join("SKILL.md"),
+            "# Shared Skill",
+        )?;
+        fs::write(
+            claudius_dir.join("commands").join("gemini").join("review.toml"),
+            "description = \"Review\"\nprompt = \"Review\"",
+        )?;
+        fs::write(
+            claudius_dir.join("agents").join("gemini").join("triage.md"),
+            "---\nname: triage\ndescription: Triage Gemini issues\n---\nFocus on Gemini-specific issues.",
+        )?;
 
         let system_settings_path =
             temp_dir.path().join("etc").join("gemini-cli").join("settings.json");
@@ -86,6 +101,18 @@ mod tests {
         anyhow::ensure!(
             !home_dir.join(".gemini").join("settings.json").exists(),
             "Did not expect user settings file to be written when --gemini-system is set",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("skills").exists(),
+            "Did not expect user Gemini skills to be synced when --gemini-system is set",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("commands").exists(),
+            "Did not expect user Gemini commands to be synced when --gemini-system is set",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("agents").exists(),
+            "Did not expect user Gemini agents to be synced when --gemini-system is set",
         );
 
         let content = fs::read_to_string(&system_settings_path)?;
@@ -202,6 +229,125 @@ mod tests {
                 .iter()
                 .any(|name| name.to_string_lossy().starts_with("settings.json.backup.")),
             "Expected Gemini system settings backup to exist",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_gemini_system_defaults_sync_writes_system_defaults_file() -> Result<()> {
+        let _env_guard = EnvGuard::new();
+
+        let temp_dir = TempDir::new()?;
+        let config_dir = temp_dir.path().join("config");
+        let home_dir = temp_dir.path().join("home");
+        let claudius_dir = config_dir.join("claudius");
+
+        fs::create_dir_all(&config_dir)?;
+        fs::create_dir_all(&home_dir)?;
+        fs::create_dir_all(&claudius_dir)?;
+
+        std::env::set_var("XDG_CONFIG_HOME", &config_dir);
+        std::env::set_var("HOME", &home_dir);
+
+        fs::write(claudius_dir.join("mcpServers.json"), r#"{"mcpServers":{}}"#)?;
+        fs::write(
+            claudius_dir.join("gemini.system_defaults.json"),
+            r#"{"billing":{"project":"shared-project"}}"#,
+        )?;
+        fs::create_dir_all(claudius_dir.join("skills").join("shared-skill"))?;
+        fs::create_dir_all(claudius_dir.join("commands").join("gemini"))?;
+        fs::create_dir_all(claudius_dir.join("agents").join("gemini"))?;
+        fs::write(
+            claudius_dir.join("skills").join("shared-skill").join("SKILL.md"),
+            "# Shared Skill",
+        )?;
+        fs::write(
+            claudius_dir.join("commands").join("gemini").join("review.toml"),
+            "description = \"Review\"\nprompt = \"Review\"",
+        )?;
+        fs::write(
+            claudius_dir.join("agents").join("gemini").join("triage.md"),
+            "---\nname: triage\ndescription: Triage Gemini issues\n---\nFocus on Gemini-specific issues.",
+        )?;
+
+        let system_defaults_path =
+            temp_dir.path().join("etc").join("gemini-cli").join("system-defaults.json");
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_claudius"))
+            .env("GEMINI_CLI_SYSTEM_DEFAULTS_PATH", &system_defaults_path)
+            .args(["config", "sync", "--global", "--agent", "gemini", "--gemini-system-defaults"])
+            .output()?;
+
+        if !output.status.success() {
+            eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            anyhow::bail!("sync command failed");
+        }
+
+        anyhow::ensure!(
+            system_defaults_path.exists(),
+            "Expected Gemini system defaults file to be written",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("skills").exists(),
+            "Did not expect user Gemini skills to be synced when --gemini-system-defaults is set",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("commands").exists(),
+            "Did not expect user Gemini commands to be synced when --gemini-system-defaults is set",
+        );
+        anyhow::ensure!(
+            !home_dir.join(".gemini").join("agents").exists(),
+            "Did not expect user Gemini agents to be synced when --gemini-system-defaults is set",
+        );
+
+        let content = fs::read_to_string(&system_defaults_path)?;
+        anyhow::ensure!(content.contains("\"billing\""));
+        anyhow::ensure!(content.contains("shared-project"));
+        anyhow::ensure!(content.contains("\"mcpServers\""));
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_gemini_system_flags_are_mutually_exclusive() -> Result<()> {
+        let _env_guard = EnvGuard::new();
+
+        let temp_dir = TempDir::new()?;
+        let config_dir = temp_dir.path().join("config");
+        let home_dir = temp_dir.path().join("home");
+        let claudius_dir = config_dir.join("claudius");
+
+        fs::create_dir_all(&config_dir)?;
+        fs::create_dir_all(&home_dir)?;
+        fs::create_dir_all(&claudius_dir)?;
+
+        std::env::set_var("XDG_CONFIG_HOME", &config_dir);
+        std::env::set_var("HOME", &home_dir);
+
+        fs::write(claudius_dir.join("mcpServers.json"), r#"{"mcpServers":{}}"#)?;
+        fs::write(claudius_dir.join("gemini.settings.json"), r"{}")?;
+        fs::write(claudius_dir.join("gemini.system_defaults.json"), r"{}")?;
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_claudius"))
+            .args([
+                "config",
+                "sync",
+                "--global",
+                "--agent",
+                "gemini",
+                "--gemini-system",
+                "--gemini-system-defaults",
+            ])
+            .output()?;
+
+        anyhow::ensure!(!output.status.success(), "Expected sync command to fail");
+        anyhow::ensure!(
+            String::from_utf8_lossy(&output.stderr).contains("mutually exclusive"),
+            "Expected mutual exclusion error in stderr",
         );
 
         Ok(())

--- a/tests/integration/init_test.rs
+++ b/tests/integration/init_test.rs
@@ -68,9 +68,13 @@ mod tests {
         assert!(config_dir.join("codex.requirements.toml").exists());
         assert!(config_dir.join("codex.managed_config.toml").exists());
         assert!(config_dir.join("gemini.settings.json").exists());
+        assert!(config_dir.join("gemini.system_defaults.json").exists());
         assert!(config_dir.join("settings.json").exists());
         assert!(config_dir.join("skills").exists());
         assert!(config_dir.join("skills/example/SKILL.md").exists());
+        assert!(config_dir.join("commands/gemini").exists());
+        assert!(config_dir.join("agents/gemini").exists());
+        assert!(config_dir.join("agents/claude-code").exists());
         assert!(config_dir.join("rules").exists());
         assert!(config_dir.join("rules/example.md").exists());
 

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -121,6 +121,44 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_skills_sync_gemini_combines_shared_and_agent_specific_skills() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_skill("shared-skill", "# Shared Skill").unwrap();
+        fixture.with_agent_skill("gemini", "gemini-skill", "# Gemini Skill").unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut initial_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        initial_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "gemini"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Legacy commands directory detected").not());
+
+        assert!(fixture.project_file_exists(".gemini/skills/shared-skill/SKILL.md"));
+        assert!(fixture.project_file_exists(".gemini/skills/gemini-skill/SKILL.md"));
+
+        fs::remove_dir_all(fixture.config.join("skills").join("gemini").join("gemini-skill"))
+            .unwrap();
+
+        let mut prune_sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        prune_sync
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "gemini", "--prune"])
+            .assert()
+            .success();
+
+        assert!(fixture.project_file_exists(".gemini/skills/shared-skill/SKILL.md"));
+        assert!(!fixture.project_file_exists(".gemini/skills/gemini-skill/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
     fn test_skills_sync_global() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -113,6 +113,27 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_validate_gemini_agent_missing_frontmatter_fails() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_agent("triage", "Focus on Gemini-specific regressions.")
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "gemini"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("must start with YAML frontmatter delimited by ---"));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_validate_claude_code_subagent_missing_frontmatter_fails() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();
@@ -148,6 +169,81 @@ mod tests {
             .success()
             .stdout(predicate::str::contains(
                 "Codex skills sync remains experimental and publishes to both .codex/skills and .agents/skills for compatibility",
+            ));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_gemini_system_defaults_supports_current_fields() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_system_defaults(
+                r#"{
+  "billing": {"project": "shared-project"},
+  "policyPaths": ["/etc/gemini-cli/policy.json"],
+  "adminPolicyPaths": ["/etc/gemini-cli/admin-policy.json"]
+}"#,
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "gemini"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Configuration validation passed"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_warns_on_deprecated_codex_fields() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(
+            fixture.config.join("codex.settings.toml"),
+            r#"
+model = "gpt-5.5"
+approval_policy = "on-failure"
+instructions = "Use this project policy"
+experimental_instructions_file = "legacy.md"
+background_terminal_timeout = 1000
+experimental_use_unified_exec_tool = true
+
+[features]
+web_search = true
+"#,
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("approval_policy = \"on-failure\" is deprecated"))
+            .stdout(predicate::str::contains(
+                "instructions is reserved for future use; prefer model_instructions_file or AGENTS.md",
+            ))
+            .stdout(predicate::str::contains(
+                "experimental_instructions_file is deprecated; rename it to model_instructions_file",
+            ))
+            .stdout(predicate::str::contains(
+                "background_terminal_timeout is deprecated; rename it to background_terminal_max_timeout",
+            ))
+            .stdout(predicate::str::contains(
+                "experimental_use_unified_exec_tool is a legacy flag; prefer features.unified_exec",
+            ))
+            .stdout(predicate::str::contains(
+                "features.web_search is deprecated; prefer the top-level web_search setting",
             ));
     }
 


### PR DESCRIPTION
## Summary
- add managed Gemini surfaces for system defaults and custom agents, and document/init/validate them consistently
- harden skills sync to merge shared and agent-specific skills with correct precedence and safer prune behavior
- align doctor reporting with the managed surfaces and remove misleading legacy-command warnings

## Details
- add `--gemini-system-defaults` support, target path resolution, bootstrap templates, and validation coverage
- sync Gemini custom agents into `.gemini/agents` and report stale/unmanaged surfaces in `config doctor`
- rework skill source collection so shared skills and agent overrides are merged instead of treated as mutually exclusive sources
- refactor sync execution flow to keep clippy clean and align MSRV metadata with the current Rust toolchain

## Review Focus
- verify Gemini `--gemini-system` and `--gemini-system-defaults` only touch system targets and do not sync user-level `skills`, `commands`, or `agents`
- verify skills precedence is now `commands/*.md < shared skills < agent-specific skills`, and that `--prune` removes only Claudius-managed outputs
- verify `config doctor`, `config validate`, bootstrap defaults, and docs all describe the same managed surfaces

## Testing
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test`