### PR TITLE
feat: default Codex skills to official agents path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,8 +110,10 @@ Project Directory (default):
 │   ├── settings.json          # Project-local Claude Code settings (when using --agent claude-code)
 │   ├── agents/                # Project-local Claude Code subagents
 │   └── skills/                # Project-local skills (Claude)
+├── .agents/
+│   └── skills/                # Project-local skills (Codex, default)
 ├── .codex/
-│   └── skills/                # Project-local skills (Codex, experimental)
+│   └── skills/                # Project-local Codex compatibility skills (optional)
 ├── .gemini/
 │   ├── settings.json          # Project-local Gemini settings + MCP servers (when using --agent gemini)
 │   ├── commands/              # Project-local Gemini commands
@@ -124,7 +126,7 @@ Global targets (--global):
 ├── Claude Code: ~/.claude.json + ~/.claude/settings.json
 ├── Codex: ~/.codex/config.toml
 ├── Gemini: ~/.gemini/settings.json + /etc/gemini-cli/settings.json + /etc/gemini-cli/system-defaults.json
-└── Skills: ~/.claude/skills (Claude), ~/.gemini/skills (Gemini), ~/.codex/skills (Codex, experimental)
+└── Skills: ~/.claude/skills (Claude), ~/.gemini/skills (Gemini), ~/.agents/skills (Codex, default), ~/.codex/skills (Codex compatibility)
 ```
 
 ### Data Flow
@@ -193,7 +195,7 @@ Synchronize configurations to target files.
 **Project-local mode (default):**
 - Claude Desktop (`--agent claude`): MCP servers → `./.mcp.json`
 - Claude Code (`--agent claude-code`): MCP servers → `./.mcp.json`, settings → `./.claude/settings.json`, skills → `./.claude/skills/`
-- Codex (`--agent codex`): settings + MCP servers → `./.codex/config.toml` (skills are experimental)
+- Codex (`--agent codex`): settings + MCP servers → `./.codex/config.toml`
 - Gemini (`--agent gemini`): settings + MCP servers → `./.gemini/settings.json`, commands → `./.gemini/commands/`, agents → `./.gemini/agents/`, skills → `./.gemini/skills/`
 
 **Global mode (--global):**
@@ -203,7 +205,7 @@ Synchronize configurations to target files.
 - Gemini (`--agent gemini`) → `~/.gemini/settings.json`
 - Gemini system settings (`--gemini-system`) → `/etc/gemini-cli/settings.json`
 - Gemini system defaults (`--gemini-system-defaults`) → `/etc/gemini-cli/system-defaults.json`
-- Skills → `~/.claude/skills/` (Claude), `~/.gemini/skills/` (Gemini), `~/.codex/skills/` (Codex, experimental)
+- Skills → `~/.claude/skills/` (Claude), `~/.gemini/skills/` (Gemini), `~/.agents/skills/` (Codex, default), `~/.codex/skills/` (Codex compatibility)
 
 ```bash
 # Basic sync (project-local: .mcp.json + .claude/settings.json)
@@ -233,8 +235,8 @@ claudius skills sync --agent gemini
 # Sync Gemini system defaults
 claudius config sync --global --agent gemini --gemini-system-defaults
 
-# Codex skills are experimental and must be explicitly enabled
-claudius skills sync --agent codex --enable-codex-skills
+# Sync Codex skills to the official .agents/skills target
+claudius skills sync --agent codex
 ```
 
 ### `claudius context append`
@@ -421,7 +423,8 @@ export CLAUDIUS_SECRET_PATH='/${CLAUDIUS_SECRET_BASE}api'  # Results in: /prodap
 ### Skills (skills/<skill>/SKILL.md)
 Skill definitions stored in individual directories.
 Deployed to `~/.claude/skills/` (Claude) or `~/.gemini/skills/` (Gemini), preserving the
-directory structure. Codex skills are experimental and require explicit opt-in.
+directory structure. Codex skills default to `~/.agents/skills/`, with optional
+compatibility copies to `~/.codex/skills/`.
 Claude Code still honors legacy `~/.claude/commands` slash commands, but skills are
 recommended. Claudius does not currently sync `.claude/commands`, so skills remain the
 cross-agent managed path.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Claudius does not treat every target surface equally. Current support levels are
 | --- | --- | --- | --- |
 | Claude Desktop | Global `claude_desktop_config.json` MCP sync, project-local `.mcp.json` MCP sync | Entire Claude Desktop target is legacy / best-effort | Extensions, Connectors, and other UI-managed app surfaces |
 | Claude Code | Project, local, user, and managed MCP/settings files; `.claude/agents`; skills; context files | Legacy `settings.json` source alias | Slash commands in `.claude/commands`; non-file-based product features |
-| Codex | User and admin TOML config files; context files | Experimental skills; compatibility sync to `.agents/skills` | Cloud-managed enterprise policies, macOS MDM payloads, and other non-file-based product features |
+| Codex | User and admin TOML config files; context files; skills via `.agents/skills` | Optional compatibility copies to `.codex/skills` | Cloud-managed enterprise policies, macOS MDM payloads, and other non-file-based product features |
 | Gemini | User, system, and system-default settings; `.gemini/commands`; `.gemini/agents`; skills; context files | OS-specific system path handling | Gemini extensions and custom sandbox profiles |
 
 Prefer `--agent claude-code`, `--agent codex`, or `--agent gemini` for actively managed surfaces. Use `--agent claude` only when you specifically need the legacy Claude Desktop JSON target.
@@ -319,7 +319,7 @@ This command highlights:
 - `best-effort` legacy compatibility targets such as Claude Desktop JSON sync
 - `legacy` source layouts such as `settings.json` and `commands/*.md`
 - `unmanaged` surfaces such as Gemini extensions
-- `experimental` Codex skill sync surfaces
+- `legacy` Codex compatibility skill targets
 - stale deployed assets tracked by Claudius manifests
 
 ```bash
@@ -356,14 +356,14 @@ claudius skills sync --dry-run --prune
 # Remove stale deployed skill files that Claudius previously published
 claudius skills sync --prune
 
-# Codex skills are experimental and must be explicitly enabled.
+# Codex skills use the official .agents/skills target by default.
 # Target selection is driven by ~/.config/claudius/config.toml:
 #
 # [codex]
-# skill-target = "auto"   # auto | codex | agents | both
+# skill-target = "auto"   # auto | agents | both | codex
 #
-# `auto` currently syncs to both .codex/skills and .agents/skills for compatibility.
-claudius skills sync --agent codex --enable-codex-skills
+# `auto` publishes to .agents/skills. Use `both` only for compatibility.
+claudius skills sync --agent codex
 ```
 
 
@@ -635,16 +635,17 @@ claudius config sync
 ```
 
 Skills are deployed to `~/.claude/skills/` (Claude / Claude Code) or `~/.gemini/skills/`
-(Gemini), preserving the directory structure. Codex skills are experimental and require
-explicit opt-in. Configure Codex target selection in `~/.config/claudius/config.toml`:
+(Gemini), preserving the directory structure. Codex skills default to the official
+`~/.agents/skills/` search path. Configure optional Codex compatibility output in
+`~/.config/claudius/config.toml`:
 
 ```toml
 [codex]
-skill-target = "auto" # auto | codex | agents | both
+skill-target = "auto" # auto | agents | both | codex
 ```
 
-Today `auto` remains compatibility-oriented and publishes to both `~/.codex/skills/`
-and `~/.agents/skills/`.
+`auto` and `agents` publish to `~/.agents/skills/`. Use `both` only when you still
+need compatibility copies in `~/.codex/skills/`.
 
 By default, skill and auxiliary file sync is non-destructive. Use `--prune` to remove
 stale files that Claudius previously deployed. Pruning only touches files tracked in

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -54,14 +54,14 @@ pub enum ClaudeCodeScope {
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum CodexSkillTargetMode {
-    /// Keep following Claudius's compatibility default for Codex skills.
+    /// Follow Claudius's default Codex skill target (`.agents/skills`).
     #[default]
     Auto,
-    /// Publish only to the Codex-native skills directory.
+    /// Publish only to the legacy `.codex/skills` directory.
     Codex,
-    /// Publish only to the compatibility `.agents/skills` directory.
+    /// Publish only to the official `.agents/skills` directory.
     Agents,
-    /// Publish to both Codex-native and compatibility directories.
+    /// Publish to both the official `.agents/skills` and legacy `.codex/skills` directories.
     Both,
 }
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -70,8 +70,10 @@ const EXAMPLE_CONFIG: &str = r#"# Claudius Configuration File
 # context-file = "CONTEXT.md"  # Custom context file name (overrides agent defaults)
 
 # [codex]
-# Configure experimental Codex skills target selection
-# skill-target = "auto"  # Options: "auto", "codex", "agents", "both"
+# Configure Codex skills target selection
+# skill-target = "auto"  # Options: "auto", "agents", "both", "codex"
+# "auto" follows the official .agents/skills search path.
+# "both" also writes compatibility copies to .codex/skills.
 
 # [secret-manager]
 # Configure a secret manager to resolve environment variables

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,7 +151,7 @@ This command:
        - commands/gemini/ -> .gemini/commands
        - agents/gemini/ -> .gemini/agents
        - agents/claude-code/ -> .claude/agents
-       - Codex skills stay explicit via `claudius skills sync --agent codex --enable-codex-skills`
+       - Codex skills stay explicit via `claudius skills sync --agent codex`
 
 Note: `--agent claude` is retained for legacy Claude Desktop JSON workflows.
 For actively managed CLI surfaces, prefer `claude-code`, `codex`, or `gemini`.
@@ -205,7 +205,7 @@ to report situations such as:
   • Claude Desktop JSON targets being used as legacy / best-effort surfaces
   • unmanaged Claude Code slash commands in .claude/commands
   • unmanaged Gemini extensions in the selected deployment context
-  • experimental Codex skill sync surfaces
+  • legacy Codex compatibility skill targets in .codex/skills
   • stale deployed assets that no longer exist in the source tree
 
 Use --global to inspect global deployment targets under $HOME.
@@ -222,13 +222,13 @@ pub enum SkillsCommands {
 This command copies skills from your skills/ directory into \
 the agent's skills directory, ensuring all skills are up to date.
 
-Codex skills remain experimental and require `--enable-codex-skills`.
 Choose the Codex target behavior in $XDG_CONFIG_HOME/claudius/config.toml:
 
   [codex]
-  skill-target = \"auto\"   # auto | codex | agents | both
+  skill-target = \"auto\"   # auto | agents | both | codex
 
-`auto` currently publishes to both .codex/skills and .agents/skills for compatibility.")]
+`auto` publishes to the official .agents/skills path.
+Use `both` only if you still need compatibility copies in .codex/skills.")]
     Sync(SkillsSyncArgs),
 }
 
@@ -471,11 +471,8 @@ pub struct SkillsSyncArgs {
     #[arg(short, long, value_enum, help = "Agent to use: claude, claude-code, codex, or gemini")]
     pub agent: Option<crate::app_config::Agent>,
 
-    /// Enable Codex skills sync (experimental)
-    #[arg(
-        long,
-        help = "Enable Codex skills sync (experimental; Codex CLI skills path may change)"
-    )]
+    /// Deprecated no-op kept for backward compatibility
+    #[arg(long, help = "Deprecated: Codex skills sync is enabled by default")]
     pub enable_codex_skills: bool,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,10 +246,10 @@ impl Config {
         Ok(match agent {
             Some(crate::app_config::Agent::Gemini) => base_dir.join(".gemini").join("skills"),
             Some(crate::app_config::Agent::Codex) => match Self::load_codex_skill_target_mode()? {
-                CodexSkillTargetMode::Agents => base_dir.join(".agents").join("skills"),
+                CodexSkillTargetMode::Codex => base_dir.join(".codex").join("skills"),
                 CodexSkillTargetMode::Auto
-                | CodexSkillTargetMode::Codex
-                | CodexSkillTargetMode::Both => base_dir.join(".codex").join("skills"),
+                | CodexSkillTargetMode::Agents
+                | CodexSkillTargetMode::Both => base_dir.join(".agents").join("skills"),
             },
             _ => base_dir.join(".claude").join("skills"),
         })
@@ -373,10 +373,12 @@ impl Config {
         }
 
         Ok(match Self::load_codex_skill_target_mode()? {
-            CodexSkillTargetMode::Auto | CodexSkillTargetMode::Both => {
-                Some(self.deployment_base_dir()?.join(".agents").join("skills"))
+            CodexSkillTargetMode::Both => {
+                Some(self.deployment_base_dir()?.join(".codex").join("skills"))
             },
-            CodexSkillTargetMode::Codex | CodexSkillTargetMode::Agents => None,
+            CodexSkillTargetMode::Auto
+            | CodexSkillTargetMode::Codex
+            | CodexSkillTargetMode::Agents => None,
         })
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -353,7 +353,7 @@ fn inspect_skill_sources(
     findings: &mut Vec<DoctorFinding>,
 ) {
     let shared_skills_path = config_dir.join("skills");
-    if !shared_skill_mappings.is_empty() && agent_filter != Some(Agent::Codex) {
+    if !shared_skill_mappings.is_empty() {
         findings.push(DoctorFinding {
             status: DoctorStatus::Supported,
             summary: "Shared skills source is present.".to_string(),
@@ -390,6 +390,14 @@ fn inspect_skill_sources(
         gemini_skill_mappings,
         "Gemini-specific skills source is present.",
     );
+    push_agent_skill_finding(
+        findings,
+        agent_filter,
+        Agent::Codex,
+        config_dir.join("skills").join("codex"),
+        codex_skill_mappings,
+        "Codex-specific skills source is present.",
+    );
 
     if !legacy_command_mappings.is_empty() && agent_filter != Some(Agent::Gemini) {
         findings.push(DoctorFinding {
@@ -401,26 +409,6 @@ fn inspect_skill_sources(
                 legacy_command_mappings.len()
             )),
             recommendation: "Move each commands/*.md file into skills/<name>/SKILL.md.".to_string(),
-        });
-    }
-
-    if should_report_codex_experimental(
-        agent_filter,
-        shared_skill_mappings,
-        codex_skill_mappings,
-        legacy_command_mappings,
-    ) {
-        findings.push(DoctorFinding {
-            status: DoctorStatus::Experimental,
-            summary: "Codex skill sync remains in experimental compatibility mode.".to_string(),
-            path: Some(config_dir.join("skills").join("codex")),
-            detail: Some(
-                "Codex skill sync still uses opt-in publishing and compatibility targets."
-                    .to_string(),
-            ),
-            recommendation:
-                "Use `claudius skills sync --agent codex --enable-codex-skills` only when you need Codex skills."
-                    .to_string(),
         });
     }
 }
@@ -691,17 +679,15 @@ fn inspect_codex_targets(
 
         if had_managed_files || !source_state.codex_skills.is_empty() {
             findings.push(DoctorFinding {
-                status: DoctorStatus::Experimental,
-                summary:
-                    "Codex compatibility skills target is present for experimental sync."
-                        .to_string(),
+                status: DoctorStatus::BestEffort,
+                summary: "Codex legacy compatibility skills target is enabled.".to_string(),
                 path: Some(compat_target),
                 detail: Some(
-                    "Claudius still publishes Codex skills to both .codex/skills and .agents/skills for compatibility."
+                    "Claudius is publishing compatibility copies to .codex/skills in addition to the official .agents/skills target."
                         .to_string(),
                 ),
                 recommendation:
-                    "Keep Codex skills opt-in and expect compatibility targets to evolve."
+                    "Prefer the default .agents/skills target unless you still need legacy Codex compatibility copies."
                         .to_string(),
             });
         }
@@ -753,21 +739,6 @@ fn push_stale_finding(
     });
 }
 
-fn should_report_codex_experimental(
-    agent_filter: Option<Agent>,
-    shared_skill_mappings: &[SourceFileMapping],
-    codex_skill_mappings: &[SourceFileMapping],
-    legacy_command_mappings: &[SourceFileMapping],
-) -> bool {
-    if agent_filter == Some(Agent::Codex) {
-        return !shared_skill_mappings.is_empty()
-            || !codex_skill_mappings.is_empty()
-            || !legacy_command_mappings.is_empty();
-    }
-
-    !codex_skill_mappings.is_empty()
-}
-
 fn collect_tree_if_exists(path: &Path) -> Result<Vec<SourceFileMapping>> {
     if !path.exists() {
         return Ok(Vec::new());
@@ -803,9 +774,6 @@ fn skill_prune_command(global: bool, selected_agent: Option<Agent>) -> String {
     }
     if let Some(agent_name) = selected_agent {
         parts.push(format!("--agent {}", agent_cli_name(agent_name)));
-        if agent_name == Agent::Codex {
-            parts.push("--enable-codex-skills".to_string());
-        }
     }
     parts.push("--prune".to_string());
     parts.join(" ")

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,9 +217,8 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
 
     let effective_agent = determine_agent(agent, app_config);
 
-    if effective_agent == Some(claudius::app_config::Agent::Codex) && !enable_codex_skills {
-        println!("Codex skills sync is experimental. Re-run with --enable-codex-skills.");
-        return Ok(());
+    if effective_agent == Some(claudius::app_config::Agent::Codex) && enable_codex_skills {
+        println!("Warning: --enable-codex-skills is deprecated and no longer required.");
     }
 
     let config = Config::new_with_agent(global, effective_agent)?;
@@ -574,8 +573,6 @@ fn validate_codex_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
         }
     }
 
-    warnings.extend(validate_codex_skill_compatibility(config_dir));
-
     Ok(warnings)
 }
 
@@ -706,29 +703,6 @@ fn validate_claude_code_subagent_sources(config_dir: &std::path::Path) -> Result
     }
 
     Ok(warnings)
-}
-
-fn validate_codex_skill_compatibility(config_dir: &std::path::Path) -> Vec<String> {
-    let skills_dir = config_dir.join("skills");
-    let legacy_commands_dir = config_dir.join("commands");
-
-    [
-        skills_dir.join("codex"),
-        skills_dir,
-        legacy_commands_dir,
-    ]
-    .iter()
-    .find(|path| path.exists() && directory_has_entries(path))
-    .map_or_else(Vec::new, |path| {
-        vec![format!(
-            "{}: Codex skills sync remains experimental and publishes to both .codex/skills and .agents/skills for compatibility",
-            path.display()
-        )]
-    })
-}
-
-fn directory_has_entries(path: &std::path::Path) -> bool {
-    std::fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 fn collect_files_with_extension(

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -1478,7 +1478,9 @@ fn sync_skills_if_exists(
     behavior: SyncBehavior,
 ) -> Option<SupportingAssetReport> {
     if config.agent == Some(Agent::Codex) {
-        debug!("Skipping Codex skills sync (experimental; use `claudius skills sync --enable-codex-skills`)");
+        debug!(
+            "Skipping Codex skills during config sync; use `claudius skills sync --agent codex`"
+        );
         return None;
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 use toml::Value as TomlValue;
 
-use crate::app_config::{AppConfig, SecretManagerType};
+use crate::app_config::{AppConfig, CodexSkillTargetMode, SecretManagerType};
 use crate::config::Settings;
 use crate::gemini_settings::{validate_gemini_settings, GeminiSettings};
 
@@ -32,6 +32,18 @@ pub fn validate_app_config(config: &AppConfig) -> ValidationResult {
             warnings.push(
                 "[secret-manager.onepassword] is configured but [secret-manager].type is not \"1password\"; these settings will be ignored".to_string(),
             );
+        }
+    }
+
+    if let Some(codex) = &config.codex {
+        match codex.skill_target {
+            Some(CodexSkillTargetMode::Codex) => warnings.push(
+                "[codex].skill-target = \"codex\" publishes only to the legacy .codex/skills path; prefer \"agents\" (or leave it unset) for the official Codex search path".to_string(),
+            ),
+            Some(CodexSkillTargetMode::Both) => warnings.push(
+                "[codex].skill-target = \"both\" also publishes compatibility copies to .codex/skills; prefer \"agents\" (or leave it unset) unless you still need the legacy path".to_string(),
+            ),
+            Some(CodexSkillTargetMode::Auto | CodexSkillTargetMode::Agents) | None => {},
         }
     }
 
@@ -369,7 +381,8 @@ pub fn prompt_continue() -> Result<bool> {
 mod tests {
     use super::*;
     use crate::app_config::{
-        OnePasswordConfig, OnePasswordMode, SecretManagerConfig, SecretManagerType,
+        CodexConfig, CodexSkillTargetMode, OnePasswordConfig, OnePasswordMode, SecretManagerConfig,
+        SecretManagerType,
     };
     use serde_json::json;
     use std::fs;
@@ -413,6 +426,19 @@ mod tests {
 
         let result = validate_app_config(&config);
         assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_validate_app_config_warns_when_codex_skill_target_uses_legacy_path() {
+        let config = AppConfig {
+            secret_manager: None,
+            default: None,
+            codex: Some(CodexConfig { skill_target: Some(CodexSkillTargetMode::Both) }),
+        };
+
+        let result = validate_app_config(&config);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings.first().is_some_and(|warning| warning.contains(".codex/skills")));
     }
 
     #[test]

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_config_doctor_global_reports_best_effort_and_experimental_surfaces() {
+    fn test_config_doctor_global_reports_best_effort_surfaces() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();
 
@@ -177,7 +177,7 @@ mod tests {
         sync.current_dir(&fixture.project)
             .env("XDG_CONFIG_HOME", fixture.config_home())
             .env("HOME", fixture.home_dir())
-            .args(["skills", "sync", "--global", "--agent", "codex", "--enable-codex-skills"])
+            .args(["skills", "sync", "--global", "--agent", "codex"])
             .assert()
             .success();
 
@@ -193,10 +193,7 @@ mod tests {
                 "Claude Desktop JSON target is present as a legacy / best-effort surface.",
             ))
             .stdout(predicate::str::contains("claude_desktop_config.json"))
-            .stdout(predicate::str::contains("EXPERIMENTAL"))
-            .stdout(predicate::str::contains(
-                "Codex skill sync remains in experimental compatibility mode.",
-            ))
-            .stdout(predicate::str::contains(".agents/skills"));
+            .stdout(predicate::str::contains("Codex-specific skills source is present."))
+            .stdout(predicate::str::contains("EXPERIMENTAL").not());
     }
 }

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -53,7 +53,7 @@ mod tests {
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&fixture.project)
             .env("XDG_CONFIG_HOME", fixture.config_home())
-            .args(["skills", "sync", "--agent", "codex", "--enable-codex-skills"])
+            .args(["skills", "sync", "--agent", "codex"])
             .assert()
             .success();
 
@@ -191,12 +191,12 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_skills_sync_codex_auto_targets_both_project_local() {
+    fn test_skills_sync_codex_auto_targets_agents_project_local() {
         let _env_guard = EnvGuard::new();
         let fixture = run_codex_skill_sync("auto");
 
-        assert!(fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
         assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
+        assert!(!fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
     }
 
     #[test]
@@ -225,7 +225,28 @@ mod tests {
         let _env_guard = EnvGuard::new();
         let fixture = run_codex_skill_sync("both");
 
+        assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
         assert!(fixture.project_file_exists(".codex/skills/codex-test/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_codex_accepts_deprecated_enable_flag() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_skill("codex-test", "# Codex Skill").unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "codex", "--enable-codex-skills"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("deprecated and no longer required"));
+
         assert!(fixture.project_file_exists(".agents/skills/codex-test/SKILL.md"));
     }
 

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -153,12 +153,13 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_config_validate_codex_skills_emit_compatibility_warning() {
+    fn test_config_validate_codex_compat_target_mode_warns() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();
 
         fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
-        fixture.with_skill("shared-skill", "# Shared Skill").unwrap();
+        std::fs::write(fixture.config.join("config.toml"), "[codex]\nskill-target = \"both\"\n")
+            .unwrap();
 
         let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
         cmd.current_dir(&fixture.project)
@@ -168,7 +169,7 @@ mod tests {
             .assert()
             .success()
             .stdout(predicate::str::contains(
-                "Codex skills sync remains experimental and publishes to both .codex/skills and .agents/skills for compatibility",
+                "[codex].skill-target = \"both\" also publishes compatibility copies to .codex/skills",
             ));
     }
 

--- a/tests/unit/config_agent_test.rs
+++ b/tests/unit/config_agent_test.rs
@@ -110,8 +110,8 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
-        assert_eq!(auto.skills_target_dir, codex_target);
-        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), Some(agents_target.clone()));
+        assert_eq!(auto.skills_target_dir, agents_target);
+        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
         let codex_only = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
@@ -125,8 +125,8 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
         let both = Config::new_with_agent(false, Some(Agent::Codex)).unwrap();
-        assert_eq!(both.skills_target_dir, codex_target);
-        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
+        assert_eq!(both.skills_target_dir, agents_target);
+        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(codex_target));
     }
 
     #[test]
@@ -148,8 +148,8 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"auto\"\n").unwrap();
         let auto = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
-        assert_eq!(auto.skills_target_dir, codex_target);
-        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), Some(agents_target.clone()));
+        assert_eq!(auto.skills_target_dir, agents_target);
+        assert_eq!(auto.codex_compat_skills_target_dir().unwrap(), None);
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"codex\"\n").unwrap();
         let codex_only = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
@@ -163,8 +163,8 @@ mod tests {
 
         fs::write(config_dir.join("config.toml"), "[codex]\nskill-target = \"both\"\n").unwrap();
         let both = Config::new_with_agent(true, Some(Agent::Codex)).unwrap();
-        assert_eq!(both.skills_target_dir, codex_target);
-        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(agents_target));
+        assert_eq!(both.skills_target_dir, agents_target);
+        assert_eq!(both.codex_compat_skills_target_dir().unwrap(), Some(codex_target));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- switch Codex skill sync defaults to the official `.agents/skills` target
- keep `.codex/skills` only as an optional compatibility copy and deprecate `--enable-codex-skills` into a no-op
- update doctor, validation, bootstrap text, and documentation to reflect the new Codex skills contract

## Testing
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test`