### PR TITLE
fix(sync): clear stale MCP transport fields

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -4,7 +4,7 @@ use crate::config::{ClaudeConfig, McpServersConfig, Settings};
 use crate::json_merge::deep_merge_json_maps;
 use anyhow::Result;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasher;
 
 pub mod strategy;
@@ -18,6 +18,25 @@ pub struct MergeConflict {
     pub existing_value: String,
     pub new_value: String,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpTransport {
+    Remote,
+    Stdio,
+}
+
+const MCP_JSON_REMOTE_ONLY_EXTRA_FIELDS: &[&str] = &[
+    "bearerTokenEnvVar",
+    "bearer_token_env_var",
+    "envHttpHeaders",
+    "env_http_headers",
+    "httpHeaders",
+    "http_headers",
+    "queryParams",
+    "query_params",
+];
+
+const MCP_JSON_STDIO_ONLY_EXTRA_FIELDS: &[&str] = &["cwd"];
 
 /// Detect conflicts between existing and new MCP server configurations
 pub fn detect_mcp_conflicts<S>(
@@ -102,9 +121,24 @@ pub fn merge_configs(
         },
         MergeStrategy::InteractiveMerge => {
             let existing = claude_config.mcp_servers.get_or_insert_with(HashMap::new);
+            let mut auto_merged = HashSet::new();
+
+            for (name, config) in new_servers {
+                let Some(existing_config) = existing.get_mut(name) else {
+                    continue;
+                };
+
+                if has_transport_specific_conflict(existing_config, config) {
+                    merge_transport_specific_server(existing_config, config);
+                    auto_merged.insert(name.clone());
+                }
+            }
 
             // Detect conflicts
-            let conflicts = detect_mcp_conflicts(existing, new_servers);
+            let conflicts = detect_mcp_conflicts(existing, new_servers)
+                .into_iter()
+                .filter(|(name, _)| !auto_merged.contains(name))
+                .collect::<Vec<_>>();
 
             // Resolve each conflict interactively
             for (name, conflict) in conflicts {
@@ -119,6 +153,10 @@ pub fn merge_configs(
 
             // Add new servers that don't conflict
             for (name, config) in new_servers {
+                if auto_merged.contains(name) {
+                    continue;
+                }
+
                 if !existing.contains_key(name) {
                     existing.insert(name.clone(), config.clone());
                 }
@@ -127,6 +165,95 @@ pub fn merge_configs(
     }
 
     Ok(())
+}
+
+fn transport_for_mcp_server(server: &crate::config::McpServerConfig) -> Option<McpTransport> {
+    if server.url.is_some() {
+        Some(McpTransport::Remote)
+    } else if server.command.is_some() {
+        Some(McpTransport::Stdio)
+    } else {
+        None
+    }
+}
+
+fn has_transport_specific_conflict(
+    existing: &crate::config::McpServerConfig,
+    overlay: &crate::config::McpServerConfig,
+) -> bool {
+    match transport_for_mcp_server(overlay) {
+        Some(McpTransport::Remote) => {
+            existing.command.is_some()
+                || !existing.args.is_empty()
+                || !existing.env.is_empty()
+                || contains_any_key(&existing.extra, MCP_JSON_STDIO_ONLY_EXTRA_FIELDS)
+        },
+        Some(McpTransport::Stdio) => {
+            existing.url.is_some()
+                || existing.server_type.is_some()
+                || !existing.headers.is_empty()
+                || contains_any_key(&existing.extra, MCP_JSON_REMOTE_ONLY_EXTRA_FIELDS)
+        },
+        None => false,
+    }
+}
+
+fn merge_transport_specific_server(
+    existing: &mut crate::config::McpServerConfig,
+    overlay: &crate::config::McpServerConfig,
+) {
+    strip_transport_specific_fields(existing, overlay);
+
+    if let Some(command) = overlay.command.as_ref() {
+        existing.command = Some(command.clone());
+        existing.args = overlay.args.clone();
+        existing.env = overlay.env.clone();
+    }
+
+    if let Some(url) = overlay.url.as_ref() {
+        existing.url = Some(url.clone());
+
+        if overlay.server_type.is_some() {
+            existing.server_type.clone_from(&overlay.server_type);
+        }
+
+        overlay.headers.iter().for_each(|(key, value)| {
+            existing.headers.insert(key.clone(), value.clone());
+        });
+    }
+
+    deep_merge_json_maps(&mut existing.extra, &overlay.extra);
+}
+
+fn strip_transport_specific_fields(
+    existing: &mut crate::config::McpServerConfig,
+    overlay: &crate::config::McpServerConfig,
+) {
+    match transport_for_mcp_server(overlay) {
+        Some(McpTransport::Remote) => {
+            existing.command = None;
+            existing.args.clear();
+            existing.env.clear();
+            remove_keys(&mut existing.extra, MCP_JSON_STDIO_ONLY_EXTRA_FIELDS);
+        },
+        Some(McpTransport::Stdio) => {
+            existing.url = None;
+            existing.server_type = None;
+            existing.headers.clear();
+            remove_keys(&mut existing.extra, MCP_JSON_REMOTE_ONLY_EXTRA_FIELDS);
+        },
+        None => {},
+    }
+}
+
+fn contains_any_key(map: &HashMap<String, Value>, keys: &[&str]) -> bool {
+    keys.iter().any(|key| map.contains_key(*key))
+}
+
+fn remove_keys(map: &mut HashMap<String, Value>, keys: &[&str]) {
+    keys.iter().for_each(|key| {
+        map.remove(*key);
+    });
 }
 
 /// Detect conflicts in settings

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -1198,13 +1198,13 @@ fn build_codex_settings_for_global(
 
     if let Some(source_settings) = codex_settings {
         if let Some(source_mcp_servers) = source_settings.mcp_servers.as_ref() {
-            deep_merge_toml_maps(&mut merged_mcp_servers, source_mcp_servers);
+            merge_mcp_server_toml_maps(&mut merged_mcp_servers, source_mcp_servers);
         }
     }
 
     if let Some(ref new_mcp_servers) = claude_config.mcp_servers {
         let new_toml_servers = convert_mcp_to_toml(new_mcp_servers);
-        deep_merge_toml_maps(&mut merged_mcp_servers, &new_toml_servers);
+        merge_mcp_server_toml_maps(&mut merged_mcp_servers, &new_toml_servers);
     }
 
     codex_to_write.mcp_servers = (!merged_mcp_servers.is_empty()).then_some(merged_mcp_servers);
@@ -1365,7 +1365,7 @@ fn write_codex_project_local(
     if let Some(ref mcp_servers) = claude_config.mcp_servers {
         let new_toml_servers = convert_mcp_to_toml(mcp_servers);
         let mut merged_mcp_servers = codex_to_write.mcp_servers.take().unwrap_or_default();
-        deep_merge_toml_maps(&mut merged_mcp_servers, &new_toml_servers);
+        merge_mcp_server_toml_maps(&mut merged_mcp_servers, &new_toml_servers);
         codex_to_write.mcp_servers = (!merged_mcp_servers.is_empty()).then_some(merged_mcp_servers);
     }
 
@@ -1426,6 +1426,60 @@ fn deep_merge_toml_maps(
                 target.insert(key.clone(), value.clone());
             },
         }
+    }
+}
+
+const MCP_TOML_REMOTE_ONLY_FIELDS: &[&str] =
+    &["url", "bearer_token_env_var", "http_headers", "env_http_headers", "query_params"];
+
+const MCP_TOML_STDIO_ONLY_FIELDS: &[&str] = &["command", "args", "env", "cwd"];
+
+fn merge_mcp_server_toml_maps(
+    target: &mut HashMap<String, TomlValue>,
+    overlay: &HashMap<String, TomlValue>,
+) {
+    for (key, value) in overlay {
+        match target.get_mut(key) {
+            Some(existing) => merge_mcp_server_toml_value(existing, value),
+            None => {
+                target.insert(key.clone(), value.clone());
+            },
+        }
+    }
+}
+
+fn merge_mcp_server_toml_value(target: &mut TomlValue, overlay: &TomlValue) {
+    match (target, overlay) {
+        (TomlValue::Table(target_table), TomlValue::Table(overlay_table)) => {
+            strip_mcp_transport_keys(target_table, overlay_table);
+
+            for (key, overlay_value) in overlay_table {
+                match target_table.get_mut(key) {
+                    Some(existing_value) => deep_merge_toml_value(existing_value, overlay_value),
+                    None => {
+                        target_table.insert(key.clone(), overlay_value.clone());
+                    },
+                }
+            }
+        },
+        (target_value, overlay_value) => {
+            *target_value = overlay_value.clone();
+        },
+    }
+}
+
+fn strip_mcp_transport_keys(
+    target_table: &mut toml::map::Map<String, TomlValue>,
+    overlay_table: &toml::map::Map<String, TomlValue>,
+) {
+    if overlay_table.contains_key("url") {
+        MCP_TOML_STDIO_ONLY_FIELDS.iter().for_each(|key| {
+            target_table.remove(*key);
+        });
+    } else if overlay_table.contains_key("command") {
+        MCP_TOML_REMOTE_ONLY_FIELDS.iter().for_each(|key| {
+            target_table.remove(*key);
+        });
     }
 }
 

--- a/tests/integration/codex_sync_test.rs
+++ b/tests/integration/codex_sync_test.rs
@@ -1179,4 +1179,77 @@ args = ["cmd"]
 
         Ok(())
     }
+
+    #[test]
+    #[serial]
+    fn test_codex_global_sync_replaces_stale_stdio_fields_for_remote_server() -> Result<()> {
+        let _env_guard = EnvGuard::new();
+
+        let temp_dir = TempDir::new()?;
+        let config_dir = temp_dir.path().join("config");
+        let home_dir = temp_dir.path().join("home");
+        let claudius_dir = config_dir.join("claudius");
+        let codex_dir = home_dir.join(".codex");
+
+        fs::create_dir_all(&config_dir)?;
+        fs::create_dir_all(&home_dir)?;
+        fs::create_dir_all(&claudius_dir)?;
+        fs::create_dir_all(&codex_dir)?;
+
+        std::env::set_var("XDG_CONFIG_HOME", &config_dir);
+        std::env::set_var("HOME", &home_dir);
+
+        fs::write(
+            claudius_dir.join("mcpServers.json"),
+            r#"{
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp"
+    }
+  }
+}"#,
+        )?;
+
+        fs::write(
+            codex_dir.join("config.toml"),
+            r#"model = "gpt-5"
+
+[mcp_servers.notion]
+command = "bash"
+args = ["-lc", "old"]
+startup_timeout_sec = 30
+"#,
+        )?;
+
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_claudius"))
+            .args(["config", "sync", "--global", "--agent", "codex"])
+            .output()?;
+
+        if !output.status.success() {
+            eprintln!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            anyhow::bail!("sync command failed");
+        }
+
+        let config_content = fs::read_to_string(codex_dir.join("config.toml"))?;
+        let parsed: toml::Value = toml::from_str(&config_content)?;
+        let notion = parsed
+            .get("mcp_servers")
+            .and_then(|servers| servers.get("notion"))
+            .and_then(toml::Value::as_table)
+            .ok_or_else(|| anyhow::anyhow!("notion MCP server was not written"))?;
+
+        anyhow::ensure!(
+            notion.get("url").and_then(toml::Value::as_str) == Some("https://mcp.notion.com/mcp"),
+            "remote url should be written"
+        );
+        anyhow::ensure!(
+            notion.get("startup_timeout_sec").and_then(toml::Value::as_integer) == Some(30),
+            "common MCP fields should be preserved"
+        );
+        anyhow::ensure!(notion.get("command").is_none(), "stale stdio command should be removed");
+        anyhow::ensure!(notion.get("args").is_none(), "stale stdio args should be removed");
+
+        Ok(())
+    }
 }

--- a/tests/integration/settings_test.rs
+++ b/tests/integration/settings_test.rs
@@ -343,6 +343,66 @@ agent = "claude-code"
 
     #[test]
     #[serial]
+    fn test_sync_claude_code_global_replaces_stale_stdio_transport_fields() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_mcp_servers(
+                r#"{
+        "mcpServers": {
+            "notion": {
+                "type": "http",
+                "url": "https://mcp.notion.com/mcp"
+            }
+        }
+    }"#,
+            )
+            .unwrap();
+
+        fixture
+            .with_existing_global_config(
+                r#"{
+        "mcpServers": {
+            "notion": {
+                "command": "bash",
+                "args": ["-lc", "old"],
+                "env": {
+                    "KEEP": "1"
+                },
+                "startupTimeoutSec": 30
+            }
+        }
+    }"#,
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "sync"])
+            .arg("--global")
+            .arg("--agent")
+            .arg("claude-code")
+            .assert()
+            .success();
+
+        let content = fixture.read_home_file(".claude.json").unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let notion = json.get("mcpServers").and_then(|servers| servers.get("notion")).unwrap();
+
+        assert_eq!(
+            notion.get("url"),
+            Some(&serde_json::Value::String("https://mcp.notion.com/mcp".to_string()))
+        );
+        assert_eq!(notion.get("type"), Some(&serde_json::Value::String("http".to_string())));
+        assert!(notion.get("command").is_none());
+        assert_eq!(notion.get("startupTimeoutSec"), Some(&serde_json::Value::Number(30.into())));
+    }
+
+    #[test]
+    #[serial]
     fn test_sync_claude_code_global_backup_creates_two_backups() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();


### PR DESCRIPTION
## Summary
- clear stale stdio-only fields when Codex MCP servers are migrated to remote transport
- auto-normalize Claude Code MCP server entries when the source transport changes
- add regression coverage for both Codex TOML sync and Claude Code JSON sync

## Verification
- `nix develop --command cargo test test_codex_global_sync_replaces_stale_stdio_fields_for_remote_server`
- `nix develop --command cargo test test_sync_claude_code_global_replaces_stale_stdio_transport_fields`
- `nix develop --command cargo test merge::tests::test_merge_configs_`

## Notes
- `nix develop --command cargo test` still fails in existing `secrets` tests because the current environment expects 1Password service-account configuration; this change does not touch that area.