### PR TITLE
feat(skills): add canonical multi-agent skill renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ $XDG_CONFIG_HOME/claudius/     # or ~/.config/claudius/
 │   │   ├── scripts/           # Optional shared resources
 │   │   ├── references/
 │   │   ├── assets/
-│   │   ├── targets/           # Optional target-specific body snippets
+│   │   ├── targets/           # Optional target-specific body overrides / fragments
+│   │   │   ├── <agent>.md
 │   │   │   ├── <agent>.prepend.md
 │   │   │   └── <agent>.append.md
 │   │   └── SKILL.md           # Legacy passthrough format (supported)
@@ -202,7 +203,8 @@ Creates default:
 Synchronize configurations to target files.
 
 Deprecated full override skill directories under `skills/<agent>/<skill>/` still sync for
-Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync.
+Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync and
+recommends `claudius skills migrate`.
 Codex surfaces the same warning via `claudius skills sync --agent codex`.
 
 **Project-local mode (default):**
@@ -257,7 +259,28 @@ Synchronize skills into the selected agent's skills directory.
 
 Deprecated full override directories under `skills/<agent>/<skill>/` still deploy for
 compatibility, but Claudius warns on every sync and recommends canonical target overlays
-in `skill.yaml`.
+in `skill.yaml`. Use `claudius skills migrate` to convert supported overrides automatically.
+
+### `claudius skills migrate`
+Convert deprecated full override directories under `skills/<agent>/<skill>/` into canonical
+shared skill targets.
+
+Claudius updates `skills/<skill>/skill.yaml`, writes `targets/<agent>.md` when the old body
+differs from the shared instructions, and then removes the deprecated override directory.
+The command is intentionally conservative: shared skills must already be canonical, extra
+override resources are rejected, and conflicting canonical target body files must be resolved
+manually first.
+
+```bash
+# Migrate every deprecated override tree
+claudius skills migrate
+
+# Migrate only Claude Code overrides
+claudius skills migrate --agent claude-code
+
+# Preview the migration without changing files
+claudius skills migrate --dry-run
+```
 
 ### `claudius context append`
 Append rules or templates to CLAUDE.md.
@@ -444,8 +467,8 @@ export CLAUDIUS_SECRET_PATH='/${CLAUDIUS_SECRET_BASE}api'  # Results in: /prodap
 Preferred canonical skill definitions use `skills/<skill>/skill.yaml` plus
 `skills/<skill>/instructions.md`. Optional `scripts/`, `references/`, and
 `assets/` directories are copied as shared resources, and optional
-`targets/<agent>.prepend.md` / `targets/<agent>.append.md` files can adjust the
-body per agent.
+`targets/<agent>.md` or `targets/<agent>.prepend.md` /
+`targets/<agent>.append.md` files can adjust the body per agent.
 
 Legacy passthrough skill definitions stored as `skills/<skill>/SKILL.md` are
 still supported.
@@ -459,7 +482,8 @@ cross-agent managed path.
 To override a shared skill for a specific agent, you can still place it under
 `~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude,
 claude-code, gemini, codex), but this full-directory override path is
-deprecated. Prefer canonical target overlays.
+deprecated. Prefer canonical target overlays and use `claudius skills migrate`
+to convert supported deprecated overrides automatically.
 
 ### Migration: commands → skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,18 @@ $XDG_CONFIG_HOME/claudius/     # or ~/.config/claudius/
 │   └── claude-code/           # Claude Code subagents (*.md)
 ├── skills/                    # Skills (shared + agent-specific)
 │   ├── <skill>/               # Shared skill
-│   │   └── SKILL.md           # Skill definition
+│   │   ├── skill.yaml         # Canonical metadata (preferred)
+│   │   ├── instructions.md    # Canonical instructions (preferred)
+│   │   ├── scripts/           # Optional shared resources
+│   │   ├── references/
+│   │   ├── assets/
+│   │   ├── targets/           # Optional target-specific body snippets
+│   │   │   ├── <agent>.prepend.md
+│   │   │   └── <agent>.append.md
+│   │   └── SKILL.md           # Legacy passthrough format (supported)
 │   └── <agent>/               # Optional agent override (claude, claude-code, gemini, codex)
 │       └── <skill>/           # Agent-specific skill
-│           └── SKILL.md
+│           └── SKILL.md       # Deprecated full override compatibility path
 └── rules/                     # CLAUDE.md templates
     └── *.md                   # Rule files (markdown)
 ```
@@ -186,7 +194,8 @@ Creates default:
 - `commands/gemini/` for Gemini custom commands
 - `agents/gemini/` for Gemini custom agents
 - `agents/claude-code/` for Claude Code subagents
-- `skills/example/SKILL.md` - Example skill
+- `skills/example/skill.yaml` - Example canonical skill metadata
+- `skills/example/instructions.md` - Example canonical skill instructions
 - `rules/example.md` - Example CLAUDE.md rule
 
 ### `claudius config sync`
@@ -420,8 +429,15 @@ export CLAUDIUS_SECRET_PATH='/${CLAUDIUS_SECRET_BASE}api'  # Results in: /prodap
 }
 ```
 
-### Skills (skills/<skill>/SKILL.md)
-Skill definitions stored in individual directories.
+### Skills
+Preferred canonical skill definitions use `skills/<skill>/skill.yaml` plus
+`skills/<skill>/instructions.md`. Optional `scripts/`, `references/`, and
+`assets/` directories are copied as shared resources, and optional
+`targets/<agent>.prepend.md` / `targets/<agent>.append.md` files can adjust the
+body per agent.
+
+Legacy passthrough skill definitions stored as `skills/<skill>/SKILL.md` are
+still supported.
 Deployed to `~/.claude/skills/` (Claude) or `~/.gemini/skills/` (Gemini), preserving the
 directory structure. Codex skills default to `~/.agents/skills/`, with optional
 compatibility copies to `~/.codex/skills/`.
@@ -429,19 +445,22 @@ Claude Code still honors legacy `~/.claude/commands` slash commands, but skills 
 recommended. Claudius does not currently sync `.claude/commands`, so skills remain the
 cross-agent managed path.
 
-To override a shared skill for a specific agent, place it under
-`~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude, claude-code, gemini, codex).
+To override a shared skill for a specific agent, you can still place it under
+`~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude,
+claude-code, gemini, codex), but this full-directory override path is
+deprecated. Prefer canonical target overlays.
 
 ### Migration: commands → skills
 
 If you previously stored slash commands in `commands/*.md`, move them into skills:
 
 ```bash
-# Example: migrate a legacy command to a skill
+# Example: quick compatibility migration from a legacy command to a passthrough skill
 mkdir -p ~/.config/claudius/skills/my-command
 mv ~/.config/claudius/commands/my-command.md ~/.config/claudius/skills/my-command/SKILL.md
 
-# Then sync
+# Then sync. For long-term maintenance, split the skill into skill.yaml +
+# instructions.md afterward.
 claudius skills sync
 ```
 
@@ -486,9 +505,9 @@ Template files for CLAUDE.md content. Can contain:
    - Environment variable support
 
 4. **Skills Module** - Skill management
-   - Skill directory processing
-   - Skill deployment to Claude directory
-   - Preserves SKILL.md file names
+   - Canonical skill loading and rendering
+   - Legacy skill passthrough compatibility
+   - Skill deployment to agent-native directories
 
 5. **Template Module** - CLAUDE.md management
    - Rule application from templates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,10 @@ Creates default:
 ### `claudius config sync`
 Synchronize configurations to target files.
 
+Deprecated full override skill directories under `skills/<agent>/<skill>/` still sync for
+Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync.
+Codex surfaces the same warning via `claudius skills sync --agent codex`.
+
 **Project-local mode (default):**
 - Claude Desktop (`--agent claude`): MCP servers → `./.mcp.json`
 - Claude Code (`--agent claude-code`): MCP servers → `./.mcp.json`, settings → `./.claude/settings.json`, skills → `./.claude/skills/`
@@ -247,6 +251,13 @@ claudius config sync --global --agent gemini --gemini-system-defaults
 # Sync Codex skills to the official .agents/skills target
 claudius skills sync --agent codex
 ```
+
+### `claudius skills sync`
+Synchronize skills into the selected agent's skills directory.
+
+Deprecated full override directories under `skills/<agent>/<skill>/` still deploy for
+compatibility, but Claudius warns on every sync and recommends canonical target overlays
+in `skill.yaml`.
 
 ### `claudius context append`
 Append rules or templates to CLAUDE.md.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ claudius --list-commands
    - (Optional) Edit `~/.config/claudius/codex.managed_config.toml` for Codex admin-managed defaults
    - Edit `~/.config/claudius/gemini.settings.json` to configure Gemini settings
    - (Optional) Edit `~/.config/claudius/gemini.system_defaults.json` for Gemini system defaults
-   - Add skills to `~/.config/claudius/skills/` (one directory per skill with `SKILL.md`)
+   - Add skills to `~/.config/claudius/skills/` (preferred: one directory per skill with `skill.yaml` + `instructions.md`; legacy `SKILL.md` passthrough is still supported)
    - (Optional) Add Gemini commands to `~/.config/claudius/commands/gemini/*.toml`
    - (Optional) Add Gemini agents to `~/.config/claudius/agents/gemini/*.md`
    - (Optional) Add Claude Code subagents to `~/.config/claudius/agents/claude-code/*.md`
@@ -216,7 +216,8 @@ This creates:
 - `commands/gemini/` for Gemini custom commands
 - `agents/gemini/` for Gemini custom agents
 - `agents/claude-code/` for Claude Code subagents
-- `skills/example/SKILL.md` - Example skill
+- `skills/example/skill.yaml` - Example canonical skill metadata
+- `skills/example/instructions.md` - Example canonical skill instructions
 - `rules/example.md` - Example context file rule template
 
 ### `claudius config sync`
@@ -463,10 +464,18 @@ Features:
 ├── settings.json      # Legacy alias for claude.settings.json (backward compatible)
 ├── skills/            # Skills (shared + agent-specific)
 │   ├── <skill>/       # Shared skill
-│   │   └── SKILL.md   # Skill definition
+│   │   ├── skill.yaml # Canonical metadata (preferred)
+│   │   ├── instructions.md # Canonical instructions (preferred)
+│   │   ├── scripts/   # Optional shared resources
+│   │   ├── references/
+│   │   ├── assets/
+│   │   ├── targets/   # Optional target-specific body snippets
+│   │   │   ├── <agent>.prepend.md
+│   │   │   └── <agent>.append.md
+│   │   └── SKILL.md   # Legacy passthrough format (supported)
 │   └── <agent>/       # Optional agent override (claude, claude-code, gemini, codex)
 │       └── <skill>/   # Agent-specific skill
-│           └── SKILL.md
+│           └── SKILL.md # Deprecated full override compatibility path
 ├── commands/
 │   └── gemini/       # Gemini custom commands
 │       └── *.toml
@@ -622,17 +631,38 @@ service-account-token-path = "~/.config/op/service-accounts/headless-linux-cli.t
 Create skills in `~/.config/claudius/skills/`:
 
 ```bash
-# Create a skill
+# Create a canonical skill
 mkdir -p ~/.config/claudius/skills/my-skill
-cat <<'EOF' > ~/.config/claudius/skills/my-skill/SKILL.md
+cat <<'EOF' > ~/.config/claudius/skills/my-skill/skill.yaml
+version: 1
+name: my-skill
+description: Describe when to use this skill.
+targets:
+  claude-code:
+    invocation: manual
+  codex:
+    invocation: manual
+EOF
+cat <<'EOF' > ~/.config/claudius/skills/my-skill/instructions.md
 # My Skill
 
-Skill definition goes here.
+Skill instructions go here.
 EOF
 
 # Skills are synced automatically
 claudius config sync
 ```
+
+Preferred canonical skills use `skill.yaml` for portable metadata and
+`instructions.md` for the shared Markdown body. Optional `scripts/`,
+`references/`, and `assets/` directories are copied as-is. If you need
+agent-specific body differences, add `targets/<agent>.prepend.md` and/or
+`targets/<agent>.append.md`.
+
+Legacy passthrough skills with top-level `SKILL.md` remain supported. Full
+agent override directories under `skills/<agent>/<skill>/SKILL.md` also remain
+supported for compatibility, but they are deprecated in favor of canonical
+target overlays.
 
 Skills are deployed to `~/.claude/skills/` (Claude / Claude Code) or `~/.gemini/skills/`
 (Gemini), preserving the directory structure. Codex skills default to the official
@@ -651,8 +681,11 @@ By default, skill and auxiliary file sync is non-destructive. Use `--prune` to r
 stale files that Claudius previously deployed. Pruning only touches files tracked in
 Claudius-managed target trees and leaves unrelated files alone.
 
-To override a shared skill for a specific agent, place it under
-`~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude, claude-code, gemini, codex).
+To override a shared skill for a specific agent, you can still place it under
+`~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude,
+claude-code, gemini, codex), but this full-directory override path is
+deprecated. Prefer target-specific overlays in `skill.yaml` and optional
+`targets/<agent>.prepend.md` / `targets/<agent>.append.md` files.
 
 When present, `claudius config sync` also deploys:
 - `~/.config/claudius/commands/gemini/*.toml` → `.gemini/commands/` or `~/.gemini/commands/`
@@ -670,11 +703,12 @@ Claude Code still supports `.claude/commands/*.md`, but Claudius does not sync t
 surface yet. Skills keep a single cross-agent source of truth inside Claudius.
 
 ```bash
-# Example: migrate a legacy command to a skill
+# Example: quick compatibility migration from a legacy command to a passthrough skill
 mkdir -p ~/.config/claudius/skills/my-command
 mv ~/.config/claudius/commands/my-command.md ~/.config/claudius/skills/my-command/SKILL.md
 
-# Then sync
+# Then sync. For long-term maintenance, split the skill into skill.yaml +
+# instructions.md afterward.
 claudius skills sync
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ This creates:
 Synchronize all agent configurations to target files.
 When present, Claudius also syncs Gemini custom commands, Gemini custom agents, and Claude Code subagents.
 Claude Desktop sync is retained as a legacy / best-effort path for JSON-based workflows. Claudius does not manage Claude Desktop Extensions or Connectors.
+Deprecated full override skill directories under `skills/<agent>/<skill>/` still sync for
+Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync.
+Codex surfaces the same warning via `claudius skills sync --agent codex`.
 
 **Project-local mode (default):**
 - Claude (`--agent claude`, legacy / best-effort Desktop-compatible target): MCP servers → `./.mcp.json`
@@ -337,6 +340,9 @@ claudius config doctor --global
 ### `claudius skills sync`
 
 Synchronize skills into the selected agent's skills directory.
+Deprecated full override directories under `skills/<agent>/<skill>/` still deploy for
+compatibility, but Claudius warns on every sync and recommends canonical target overlays
+in `skill.yaml`.
 
 ```bash
 # Sync skills to project-local .claude/skills/ (default: Claude)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ Synchronize all agent configurations to target files.
 When present, Claudius also syncs Gemini custom commands, Gemini custom agents, and Claude Code subagents.
 Claude Desktop sync is retained as a legacy / best-effort path for JSON-based workflows. Claudius does not manage Claude Desktop Extensions or Connectors.
 Deprecated full override skill directories under `skills/<agent>/<skill>/` still sync for
-Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync.
+Claude Code and Gemini compatibility, but Claudius emits migration warnings during sync and
+recommends `claudius skills migrate`.
 Codex surfaces the same warning via `claudius skills sync --agent codex`.
 
 **Project-local mode (default):**
@@ -342,7 +343,7 @@ claudius config doctor --global
 Synchronize skills into the selected agent's skills directory.
 Deprecated full override directories under `skills/<agent>/<skill>/` still deploy for
 compatibility, but Claudius warns on every sync and recommends canonical target overlays
-in `skill.yaml`.
+in `skill.yaml`. Use `claudius skills migrate` to convert supported overrides automatically.
 
 ```bash
 # Sync skills to project-local .claude/skills/ (default: Claude)
@@ -371,6 +372,28 @@ claudius skills sync --prune
 #
 # `auto` publishes to .agents/skills. Use `both` only for compatibility.
 claudius skills sync --agent codex
+```
+
+### `claudius skills migrate`
+
+Convert deprecated full override directories under `skills/<agent>/<skill>/` into canonical
+shared skill targets.
+
+Claudius updates `skills/<skill>/skill.yaml`, writes `targets/<agent>.md` when the old body
+differs from the shared instructions, and then removes the deprecated override directory.
+The command is intentionally conservative: shared skills must already be canonical, extra
+override resources are rejected, and conflicting canonical target body files must be resolved
+manually first.
+
+```bash
+# Migrate every deprecated override tree
+claudius skills migrate
+
+# Migrate only Claude Code overrides
+claudius skills migrate --agent claude-code
+
+# Preview the migration without changing files
+claudius skills migrate --dry-run
 ```
 
 
@@ -475,7 +498,8 @@ Features:
 │   │   ├── scripts/   # Optional shared resources
 │   │   ├── references/
 │   │   ├── assets/
-│   │   ├── targets/   # Optional target-specific body snippets
+│   │   ├── targets/   # Optional target-specific body overrides / fragments
+│   │   │   ├── <agent>.md
 │   │   │   ├── <agent>.prepend.md
 │   │   │   └── <agent>.append.md
 │   │   └── SKILL.md   # Legacy passthrough format (supported)
@@ -662,8 +686,8 @@ claudius config sync
 Preferred canonical skills use `skill.yaml` for portable metadata and
 `instructions.md` for the shared Markdown body. Optional `scripts/`,
 `references/`, and `assets/` directories are copied as-is. If you need
-agent-specific body differences, add `targets/<agent>.prepend.md` and/or
-`targets/<agent>.append.md`.
+agent-specific body differences, add `targets/<agent>.md` for a full override or
+`targets/<agent>.prepend.md` / `targets/<agent>.append.md` for smaller fragments.
 
 Legacy passthrough skills with top-level `SKILL.md` remain supported. Full
 agent override directories under `skills/<agent>/<skill>/SKILL.md` also remain
@@ -691,7 +715,8 @@ To override a shared skill for a specific agent, you can still place it under
 `~/.config/claudius/skills/<agent>/<skill>/SKILL.md` (agents: claude,
 claude-code, gemini, codex), but this full-directory override path is
 deprecated. Prefer target-specific overlays in `skill.yaml` and optional
-`targets/<agent>.prepend.md` / `targets/<agent>.append.md` files.
+`targets/<agent>.md` or fragment files. Use `claudius skills migrate` to convert
+supported deprecated overrides automatically.
 
 When present, `claudius config sync` also deploys:
 - `~/.config/claudius/commands/gemini/*.toml` → `.gemini/commands/` or `~/.gemini/commands/`

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -30,10 +30,21 @@ const DEFAULT_SETTINGS: &str = r#"{
 }
 "#;
 
-/// Example skill template
-const EXAMPLE_SKILL: &str = r"# Example Skill
+/// Example canonical skill definition template
+const EXAMPLE_SKILL_DEFINITION: &str = r#"version: 1
+name: example
+description: Example skill scaffold created by `claudius config init`.
+targets:
+  claude-code:
+    invocation: manual
+  codex:
+    invocation: manual
+"#;
 
-This is an example Claude Code skill.
+/// Example canonical skill instructions template
+const EXAMPLE_SKILL_INSTRUCTIONS: &str = r#"# Example Skill
+
+This is an example canonical skill.
 
 ## Usage
 
@@ -41,8 +52,8 @@ Describe how and when to use this skill.
 
 ## Implementation
 
-Replace this content with your actual skill definition.
-";
+Replace this content with your actual skill instructions.
+"#;
 
 /// Example rule template
 const EXAMPLE_RULE: &str = r"# Example Rule
@@ -368,8 +379,21 @@ fn init_skills_directory(config_dir: &Path, force: bool) -> Result<()> {
     let example_skill_dir = skills_dir.join("example");
     create_directory(&example_skill_dir, force)?;
 
-    let example_skill_path = example_skill_dir.join("SKILL.md");
-    create_file_if_needed(&example_skill_path, EXAMPLE_SKILL, force, "example skill")
+    let example_skill_definition_path = example_skill_dir.join("skill.yaml");
+    create_file_if_needed(
+        &example_skill_definition_path,
+        EXAMPLE_SKILL_DEFINITION,
+        force,
+        "example skill definition",
+    )?;
+
+    let example_skill_instructions_path = example_skill_dir.join("instructions.md");
+    create_file_if_needed(
+        &example_skill_instructions_path,
+        EXAMPLE_SKILL_INSTRUCTIONS,
+        force,
+        "example skill instructions",
+    )
 }
 
 /// Initialize rules directory with example
@@ -538,7 +562,8 @@ mod tests {
                 "settings.json",
                 "config.toml",
                 "skills",
-                "skills/example/SKILL.md",
+                "skills/example/skill.yaml",
+                "skills/example/instructions.md",
                 "commands/gemini",
                 "agents/gemini",
                 "agents/claude-code",
@@ -641,7 +666,8 @@ mod tests {
         assert!(!rules_dir.join("custom.md").exists());
 
         // Verify example files exist
-        assert!(skills_dir.join("example/SKILL.md").exists());
+        assert!(skills_dir.join("example/skill.yaml").exists());
+        assert!(skills_dir.join("example/instructions.md").exists());
         assert!(rules_dir.join("example.md").exists());
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,6 +253,26 @@ Examples:
   claudius skills validate --strict")]
     Validate(SkillsValidateArgs),
 
+    /// Migrate deprecated full override directories into canonical target overlays
+    #[command(
+        long_about = "Migrate deprecated full override directories into canonical shared skills.
+
+This command converts `skills/<agent>/<skill>/SKILL.md` into:
+  • target-specific metadata stored under `targets.<agent>` in `skill.yaml`
+  • optional `targets/<agent>.md` body overrides when the deprecated override body differs
+
+Automatic migration is intentionally conservative:
+  • the shared skill must already be canonical (`skills/<skill>/skill.yaml`)
+  • additional override resources besides `SKILL.md` are rejected
+  • conflicting existing canonical target body fragments must be resolved manually first
+
+Examples:
+  claudius skills migrate
+  claudius skills migrate --agent claude-code
+  claudius skills migrate --dry-run"
+    )]
+    Migrate(SkillsMigrateArgs),
+
     /// Render skills for an agent into a directory for inspection or tests
     #[command(
         long_about = "Render skills for an agent into a directory without touching native agent locations.
@@ -534,6 +554,17 @@ pub struct SkillsRenderArgs {
     /// Remove stale rendered files that Claudius previously generated in the output directory
     #[arg(long)]
     pub prune: bool,
+}
+
+#[derive(Args, Debug, Clone, Copy)]
+pub struct SkillsMigrateArgs {
+    /// Migrate overrides for a single agent instead of all deprecated override trees
+    #[arg(short, long, value_enum)]
+    pub agent: Option<crate::app_config::Agent>,
+
+    /// Preview migration writes and removals without changing files
+    #[arg(short, long)]
+    pub dry_run: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ Prefer Claude Code, Codex, or Gemini when you need actively managed surfaces.
         - gemini.settings.json: Gemini settings (optional)
         - gemini.system_defaults.json: Gemini CLI system defaults (optional)
         - settings.json: Legacy Claude settings (backward compatible)
-        - skills/: Shared and agent-specific skills (preferred: skill.yaml + instructions.md; legacy SKILL.md still supported)
+        - skills/: Shared skills plus deprecated agent override compatibility paths (preferred: skill.yaml + instructions.md; legacy SKILL.md still supported)
         - commands/gemini/: Gemini custom commands (*.toml)
         - agents/gemini/: Gemini custom agents (*.md)
         - agents/claude-code/: Claude Code subagents (*.md)
@@ -103,7 +103,7 @@ pub enum ConfigCommands {
       • gemini.settings.json - Gemini settings template
       • gemini.system_defaults.json - Gemini CLI system defaults template
       • settings.json - Legacy Claude settings (backward compatible)
-      • skills/ - Directory for shared and agent-specific skills
+      • skills/ - Directory for shared skills and deprecated agent override compatibility paths
       • commands/gemini/ - Gemini custom commands (*.toml)
       • agents/gemini/ - Gemini custom agents (*.md)
       • agents/claude-code/ - Claude Code subagents (*.md)
@@ -152,6 +152,10 @@ This command:
        - agents/gemini/ -> .gemini/agents
        - agents/claude-code/ -> .claude/agents
        - Codex skills stay explicit via `claudius skills sync --agent codex`
+
+Deprecated full override directories under `skills/<agent>/<skill>/` still sync for
+compatibility, but Claudius warns during sync and recommends canonical target overlays
+in `skill.yaml` instead.
 
 Note: `--agent claude` is retained for legacy Claude Desktop JSON workflows.
 For actively managed CLI surfaces, prefer `claude-code`, `codex`, or `gemini`.
@@ -228,7 +232,10 @@ Choose the Codex target behavior in $XDG_CONFIG_HOME/claudius/config.toml:
   skill-target = \"auto\"   # auto | agents | both | codex
 
 `auto` publishes to the official .agents/skills path.
-Use `both` only if you still need compatibility copies in .codex/skills.")]
+Use `both` only if you still need compatibility copies in .codex/skills.
+
+Deprecated full override directories under `skills/<agent>/<skill>/` still work during sync,
+but Claudius emits warnings and recommends canonical target overlays in `skill.yaml`.")]
     Sync(SkillsSyncArgs),
 
     /// Validate canonical and legacy skills without deploying them

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -214,7 +214,7 @@ Use --agent to focus on a single agent surface."
     Doctor(ConfigDoctorArgs),
 }
 
-#[derive(Subcommand, Debug, Clone, Copy)]
+#[derive(Subcommand, Debug)]
 pub enum SkillsCommands {
     /// Synchronize skills into agent directories
     #[command(long_about = "Synchronize skills into agent directories.
@@ -230,6 +230,33 @@ Choose the Codex target behavior in $XDG_CONFIG_HOME/claudius/config.toml:
 `auto` publishes to the official .agents/skills path.
 Use `both` only if you still need compatibility copies in .codex/skills.")]
     Sync(SkillsSyncArgs),
+
+    /// Validate canonical and legacy skills without deploying them
+    #[command(long_about = "Validate Claudius skills without writing deployment targets.
+
+This command:
+  • loads shared, legacy, and agent-specific skill sources
+  • validates canonical skill.yaml definitions and required files
+  • renders the selected agent view to catch schema/rendering failures early
+  • warns about deprecated full override directories and metadata that will be dropped
+
+Examples:
+  claudius skills validate
+  claudius skills validate --agent codex
+  claudius skills validate --strict")]
+    Validate(SkillsValidateArgs),
+
+    /// Render skills for an agent into a directory for inspection or tests
+    #[command(
+        long_about = "Render skills for an agent into a directory without touching native agent locations.
+
+This command is useful for debugging render output, golden tests, and schema review.
+
+Examples:
+  claudius skills render --agent claude-code --output /tmp/claude-skills
+  claudius skills render --agent codex --output /tmp/codex-skills --prune"
+    )]
+    Render(SkillsRenderArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -474,6 +501,32 @@ pub struct SkillsSyncArgs {
     /// Deprecated no-op kept for backward compatibility
     #[arg(long, help = "Deprecated: Codex skills sync is enabled by default")]
     pub enable_codex_skills: bool,
+}
+
+#[derive(Args, Debug, Clone, Copy)]
+pub struct SkillsValidateArgs {
+    /// Validate a specific agent view instead of all supported skill render targets
+    #[arg(short, long, value_enum)]
+    pub agent: Option<crate::app_config::Agent>,
+
+    /// Treat warnings as errors
+    #[arg(long)]
+    pub strict: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SkillsRenderArgs {
+    /// Specify the agent (defaults to the configured default agent or Claude)
+    #[arg(short, long, value_enum)]
+    pub agent: Option<crate::app_config::Agent>,
+
+    /// Output directory for rendered skills
+    #[arg(short, long, value_hint = clap::ValueHint::DirPath)]
+    pub output: PathBuf,
+
+    /// Remove stale rendered files that Claudius previously generated in the output directory
+    #[arg(long)]
+    pub prune: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ Prefer Claude Code, Codex, or Gemini when you need actively managed surfaces.
         - gemini.settings.json: Gemini settings (optional)
         - gemini.system_defaults.json: Gemini CLI system defaults (optional)
         - settings.json: Legacy Claude settings (backward compatible)
-        - skills/: Shared and agent-specific skills (directories with SKILL.md)
+        - skills/: Shared and agent-specific skills (preferred: skill.yaml + instructions.md; legacy SKILL.md still supported)
         - commands/gemini/: Gemini custom commands (*.toml)
         - agents/gemini/: Gemini custom agents (*.md)
         - agents/claude-code/: Claude Code subagents (*.md)

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -435,7 +435,9 @@ fn inspect_skill_sources(
                 "{} legacy command file(s) still rely on commands/*.md fallback.",
                 legacy_command_mappings.len()
             )),
-            recommendation: "Move each commands/*.md file into skills/<name>/SKILL.md.".to_string(),
+            recommendation:
+                "Move each commands/*.md file into a skill directory, preferably skills/<name>/skill.yaml + instructions.md (or skills/<name>/SKILL.md for passthrough compatibility)."
+                    .to_string(),
         });
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -5,9 +5,26 @@ use crate::asset_sync::{inspect_managed_tree, ManagedTreeInspection, SourceFileM
 use crate::config::Config;
 use crate::skills;
 use anyhow::{Context, Result};
+use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+static YAML_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?s)\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\z")
+        .expect("frontmatter regex should compile")
+});
+
+const CLAUDE_ONLY_SKILL_KEYS: &[&str] = &[
+    "disable-model-invocation",
+    "user-invocable",
+    "allowed-tools",
+    "arguments",
+    "argument-hint",
+    "agent",
+    "context",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DoctorStatus {
@@ -398,6 +415,16 @@ fn inspect_skill_sources(
         codex_skill_mappings,
         "Codex-specific skills source is present.",
     );
+    inspect_deprecated_agent_skill_overrides(
+        config_dir,
+        agent_filter,
+        claude_skill_mappings,
+        claude_code_skill_mappings,
+        gemini_skill_mappings,
+        codex_skill_mappings,
+        findings,
+    );
+    inspect_shared_legacy_skill_metadata_leakage(config_dir, agent_filter, findings);
 
     if !legacy_command_mappings.is_empty() && agent_filter != Some(Agent::Gemini) {
         findings.push(DoctorFinding {
@@ -410,6 +437,184 @@ fn inspect_skill_sources(
             )),
             recommendation: "Move each commands/*.md file into skills/<name>/SKILL.md.".to_string(),
         });
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn inspect_deprecated_agent_skill_overrides(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    claude_skill_mappings: &[SourceFileMapping],
+    claude_code_skill_mappings: &[SourceFileMapping],
+    gemini_skill_mappings: &[SourceFileMapping],
+    codex_skill_mappings: &[SourceFileMapping],
+    findings: &mut Vec<DoctorFinding>,
+) {
+    push_deprecated_override_finding(
+        findings,
+        agent_filter,
+        Agent::Claude,
+        config_dir.join("skills").join("claude"),
+        claude_skill_mappings,
+    );
+    push_deprecated_override_finding(
+        findings,
+        agent_filter,
+        Agent::ClaudeCode,
+        config_dir.join("skills").join("claude-code"),
+        claude_code_skill_mappings,
+    );
+    push_deprecated_override_finding(
+        findings,
+        agent_filter,
+        Agent::Gemini,
+        config_dir.join("skills").join("gemini"),
+        gemini_skill_mappings,
+    );
+    push_deprecated_override_finding(
+        findings,
+        agent_filter,
+        Agent::Codex,
+        config_dir.join("skills").join("codex"),
+        codex_skill_mappings,
+    );
+}
+
+fn push_deprecated_override_finding(
+    findings: &mut Vec<DoctorFinding>,
+    agent_filter: Option<Agent>,
+    agent: Agent,
+    path: PathBuf,
+    mappings: &[SourceFileMapping],
+) {
+    if !matches_filter(agent_filter, agent) || mappings.is_empty() {
+        return;
+    }
+
+    findings.push(DoctorFinding {
+        status: DoctorStatus::Legacy,
+        summary: format!(
+            "{} full override skill directories are still in use.",
+            doctor_agent_label(agent)
+        ),
+        path: Some(path),
+        detail: Some(format!(
+            "{} file(s) are being sourced from skills/{}/... instead of canonical overlays.",
+            mappings.len(),
+            doctor_agent_subdir(agent)
+        )),
+        recommendation:
+            "Migrate these overrides into shared skill.yaml target overlays and keep shared resources in one canonical skill tree."
+                .to_string(),
+    });
+}
+
+fn inspect_shared_legacy_skill_metadata_leakage(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    findings: &mut Vec<DoctorFinding>,
+) {
+    if agent_filter.is_some_and(|agent| agent != Agent::Codex) {
+        return;
+    }
+
+    let skills_root = config_dir.join("skills");
+    if !skills_root.exists() {
+        return;
+    }
+
+    let Ok(entries) = fs::read_dir(&skills_root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let entry_name = entry.file_name();
+        let Some(entry_name) = entry_name.to_str() else {
+            continue;
+        };
+
+        if path.is_dir() {
+            if skills::is_agent_skill_subdir(entry_name) || path.join("skill.yaml").exists() {
+                continue;
+            }
+
+            let skill_file = path.join("SKILL.md");
+            if shared_legacy_skill_contains_claude_only_metadata(&skill_file) {
+                findings.push(DoctorFinding {
+                    status: DoctorStatus::Legacy,
+                    summary:
+                        "Shared legacy skill contains Claude-specific metadata that Codex rendering will drop."
+                            .to_string(),
+                    path: Some(skill_file),
+                    detail: Some(format!(
+                        "Skill `{}` still uses Claude-specific frontmatter keys in a shared SKILL.md.",
+                        entry_name
+                    )),
+                    recommendation:
+                        "Migrate this skill to canonical skill.yaml or move Claude-only metadata into a Claude-specific target overlay."
+                            .to_string(),
+                });
+            }
+            continue;
+        }
+
+        if path.is_file()
+            && path.extension().and_then(|value| value.to_str()) == Some("md")
+            && shared_legacy_skill_contains_claude_only_metadata(&path)
+        {
+            findings.push(DoctorFinding {
+                status: DoctorStatus::Legacy,
+                summary:
+                    "Shared legacy skill contains Claude-specific metadata that Codex rendering will drop."
+                        .to_string(),
+                path: Some(path),
+                detail: Some(format!(
+                    "Legacy skill `{}` still uses Claude-specific frontmatter keys in a shared Markdown file.",
+                    entry_name.trim_end_matches(".md")
+                )),
+                recommendation:
+                    "Migrate this skill to canonical skill.yaml or move Claude-only metadata into a Claude-specific target overlay."
+                        .to_string(),
+            });
+        }
+    }
+}
+
+fn shared_legacy_skill_contains_claude_only_metadata(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(captures) = YAML_FRONTMATTER_RE.captures(&content) else {
+        return false;
+    };
+    let Some(frontmatter_text) = captures.get(1).map(|capture| capture.as_str()) else {
+        return false;
+    };
+    let Ok(frontmatter) = serde_yaml::from_str::<YamlMapping>(frontmatter_text) else {
+        return false;
+    };
+
+    CLAUDE_ONLY_SKILL_KEYS
+        .iter()
+        .any(|key| frontmatter.contains_key(YamlValue::String((*key).to_string())))
+}
+
+fn doctor_agent_label(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "Claude",
+        Agent::ClaudeCode => "Claude Code",
+        Agent::Codex => "Codex",
+        Agent::Gemini => "Gemini",
+    }
+}
+
+fn doctor_agent_subdir(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "claude",
+        Agent::ClaudeCode => "claude-code",
+        Agent::Codex => "codex",
+        Agent::Gemini => "gemini",
     }
 }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -506,7 +506,7 @@ fn push_deprecated_override_finding(
             doctor_agent_subdir(agent)
         )),
         recommendation:
-            "Migrate these overrides into shared skill.yaml target overlays and keep shared resources in one canonical skill tree."
+            "Run `claudius skills migrate` for these overrides, then keep shared resources and per-agent metadata in one canonical skill tree."
                 .to_string(),
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ fn dispatch_command(command: cli::Commands, app_config: Option<&AppConfig>) -> R
         cli::Commands::Skills(subcommand) => match subcommand {
             cli::SkillsCommands::Sync(args) => run_sync_skills(args, app_config),
             cli::SkillsCommands::Validate(args) => run_validate_skills(args),
+            cli::SkillsCommands::Migrate(args) => run_migrate_skills(args),
             cli::SkillsCommands::Render(args) => run_render_skills(args, app_config),
         },
         cli::Commands::Context(subcommand) => match subcommand {
@@ -274,6 +275,48 @@ fn run_validate_skills(args: cli::SkillsValidateArgs) -> Result<()> {
             "Skills validation produced {} warning(s) under --strict",
             report.warnings.len()
         );
+    }
+
+    Ok(())
+}
+
+fn run_migrate_skills(args: cli::SkillsMigrateArgs) -> Result<()> {
+    let config_dir = Config::get_config_dir().context("Failed to determine Claudius config dir")?;
+    let report = skills::migrate_deprecated_agent_overrides(&config_dir, args.agent, args.dry_run)?;
+
+    if report.migrated_overrides.is_empty() {
+        println!(
+            "No deprecated full override skill directories found under {}",
+            config_dir.display()
+        );
+        return Ok(());
+    }
+
+    if args.dry_run {
+        println!(
+            "Dry-run: would migrate {} deprecated full override skill director(ies).",
+            report.migrated_overrides.len()
+        );
+    } else {
+        println!(
+            "Migrated {} deprecated full override skill director(ies).",
+            report.migrated_overrides.len()
+        );
+    }
+
+    println!("Overrides:");
+    for override_path in &report.migrated_overrides {
+        println!("  - {override_path}");
+    }
+
+    println!("Updated files:");
+    for path in &report.updated_files {
+        println!("  - {}", path.display());
+    }
+
+    println!("Removed directories:");
+    for path in &report.removed_directories {
+        println!("  - {}", path.display());
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,8 @@ fn dispatch_command(command: cli::Commands, app_config: Option<&AppConfig>) -> R
         },
         cli::Commands::Skills(subcommand) => match subcommand {
             cli::SkillsCommands::Sync(args) => run_sync_skills(args, app_config),
+            cli::SkillsCommands::Validate(args) => run_validate_skills(args),
+            cli::SkillsCommands::Render(args) => run_render_skills(args, app_config),
         },
         cli::Commands::Context(subcommand) => match subcommand {
             cli::ContextCommands::Append(args) => run_append_context(
@@ -231,6 +233,9 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
             config.config_root_dir()?.join("commands").display()
         );
     }
+    for warning in &source_set.warnings {
+        println!("Warning: {warning}");
+    }
 
     let skill_targets = determine_skill_sync_targets(&config)?;
     let reports = skill_targets
@@ -245,6 +250,66 @@ fn run_sync_skills(args: cli::SkillsSyncArgs, app_config: Option<&AppConfig>) ->
         .collect::<Result<Vec<_>>>()?;
 
     print_skill_sync_result(&reports, dry_run);
+    Ok(())
+}
+
+fn run_validate_skills(args: cli::SkillsValidateArgs) -> Result<()> {
+    let config_dir = Config::get_config_dir().context("Failed to determine Claudius config dir")?;
+    let report = skills::validate_claudius_skill_sources(&config_dir, args.agent)?;
+
+    println!("Skills validation succeeded for {}", config_dir.display());
+
+    if report.warnings.is_empty() {
+        println!("No skill warnings detected.");
+        return Ok(());
+    }
+
+    println!("Warnings:");
+    for warning in &report.warnings {
+        println!("  - {warning}");
+    }
+
+    if args.strict {
+        anyhow::bail!(
+            "Skills validation produced {} warning(s) under --strict",
+            report.warnings.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn run_render_skills(args: cli::SkillsRenderArgs, app_config: Option<&AppConfig>) -> Result<()> {
+    let effective_agent = determine_agent(args.agent, app_config);
+    let config_dir = Config::get_config_dir().context("Failed to determine Claudius config dir")?;
+    let source_set = skills::collect_claudius_skill_source_set(&config_dir, effective_agent)?;
+
+    for warning in &source_set.warnings {
+        println!("Warning: {warning}");
+    }
+
+    let report = skills::sync_skill_mappings_with_options(
+        &source_set.mappings,
+        &args.output,
+        SyncBehavior { dry_run: false, prune: args.prune },
+    )?;
+
+    println!(
+        "Rendered {} skill(s) for {} into {}",
+        report.synced_skills.len(),
+        effective_agent.map_or("claude", |agent| match agent {
+            claudius::app_config::Agent::Claude => "claude",
+            claudius::app_config::Agent::ClaudeCode => "claude-code",
+            claudius::app_config::Agent::Codex => "codex",
+            claudius::app_config::Agent::Gemini => "gemini",
+        }),
+        report.target_dir.display(),
+    );
+
+    if !report.pruned_files.is_empty() {
+        println!("Pruned {} stale rendered file(s).", report.pruned_files.len());
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,6 +517,7 @@ fn collect_config_validation_warnings(
 
     warnings.extend(validate_mcp_server_sources(config_dir)?);
     warnings.extend(validate_agent_sources(config_dir, effective_agent)?);
+    warnings.extend(skills::validate_claudius_skill_sources(config_dir, effective_agent)?.warnings);
 
     Ok(warnings)
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -3,7 +3,7 @@ use crate::{
     asset_sync::{self, ManagedTreeSyncReport, SourceFileMapping, SyncBehavior},
 };
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -24,6 +24,18 @@ const CLAUDE_ONLY_FRONTMATTER_KEYS: &[&str] = &[
     "agent",
     "context",
 ];
+const LEGACY_CORE_FRONTMATTER_KEYS: &[&str] = &["name", "description"];
+const CLAUDE_FAMILY_MIGRATION_FRONTMATTER_KEYS: &[&str] = &[
+    "disable-model-invocation",
+    "user-invocable",
+    "allowed-tools",
+    "arguments",
+    "argument-hint",
+    "agent",
+    "context",
+];
+const CODEX_MIGRATION_FRONTMATTER_KEYS: &[&str] =
+    &["disable-model-invocation", "interface", "dependencies"];
 
 static YAML_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
     regex::Regex::new(r"(?s)\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\z")
@@ -51,6 +63,14 @@ pub struct SkillValidationReport {
     pub warnings: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillMigrationReport {
+    pub migrated_overrides: Vec<String>,
+    pub updated_files: Vec<PathBuf>,
+    pub removed_directories: Vec<PathBuf>,
+    pub dry_run: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum SkillSourceOrigin {
     LegacyCommand,
@@ -73,7 +93,7 @@ struct SkillCandidate {
     origin: SkillSourceOrigin,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum SkillTargetName {
     Claude,
@@ -82,47 +102,50 @@ enum SkillTargetName {
     Gemini,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum SkillInvocationMode {
     Auto,
     Manual,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct CanonicalSkillDefinition {
     version: u8,
     name: String,
     description: String,
-    #[serde(default = "default_instructions_file")]
+    #[serde(
+        default = "default_instructions_file",
+        skip_serializing_if = "is_default_instructions_file"
+    )]
     instructions_file: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     targets: BTreeMap<SkillTargetName, SkillTargetOverlay>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 struct SkillTargetOverlay {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     invocation: Option<SkillInvocationMode>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     disable_model_invocation: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     user_invocable: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     allowed_tools: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     arguments: Option<YamlValue>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     argument_hint: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     context: Option<YamlValue>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     agent: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     interface: Option<YamlValue>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     dependencies: Option<YamlValue>,
 }
 
@@ -145,6 +168,19 @@ struct RenderedSkillBundle {
     name: String,
     generated_files: Vec<RenderedTextFile>,
     resource_mappings: Vec<SourceFileMapping>,
+}
+
+#[derive(Debug, Clone)]
+struct DeprecatedOverrideCandidate {
+    agent: Agent,
+    candidate: SkillCandidate,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedSkillMigration {
+    migrated_overrides: Vec<String>,
+    updated_files: Vec<(PathBuf, String)>,
+    removed_directories: Vec<PathBuf>,
 }
 
 impl SkillSyncReport {
@@ -216,6 +252,10 @@ fn default_instructions_file() -> String {
     DEFAULT_CANONICAL_INSTRUCTIONS_FILE.to_string()
 }
 
+fn is_default_instructions_file(value: &str) -> bool {
+    value == DEFAULT_CANONICAL_INSTRUCTIONS_FILE
+}
+
 /// Validate Claudius skills by loading and rendering them for the selected
 /// agent(s) without writing deployment targets.
 ///
@@ -236,6 +276,695 @@ pub fn validate_claudius_skill_sources(
     }
 
     Ok(SkillValidationReport { warnings: warnings.into_iter().collect() })
+}
+
+/// Migrate deprecated `skills/<agent>/<skill>/SKILL.md` override directories
+/// into canonical shared `skill.yaml` target overlays plus optional
+/// `targets/<agent>.md` body overrides.
+///
+/// # Errors
+///
+/// Returns an error if a deprecated override cannot be represented safely in
+/// the canonical format or if the shared skill is not already canonical.
+pub fn migrate_deprecated_agent_overrides(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+    dry_run: bool,
+) -> Result<SkillMigrationReport> {
+    let skills_root = config_dir.join("skills");
+    let candidates = discover_deprecated_override_candidates(&skills_root, agent_filter)?;
+
+    if candidates.is_empty() {
+        return Ok(SkillMigrationReport {
+            migrated_overrides: Vec::new(),
+            updated_files: Vec::new(),
+            removed_directories: Vec::new(),
+            dry_run,
+        });
+    }
+
+    let plans = plan_deprecated_override_migrations(&skills_root, &candidates)?;
+
+    if !dry_run {
+        apply_planned_skill_migrations(&plans)?;
+        prune_empty_agent_override_dirs(&skills_root)?;
+    }
+
+    Ok(SkillMigrationReport {
+        migrated_overrides: plans.iter().flat_map(|plan| plan.migrated_overrides.clone()).collect(),
+        updated_files: plans
+            .iter()
+            .flat_map(|plan| plan.updated_files.iter().map(|(path, _)| path.clone()))
+            .collect(),
+        removed_directories: plans
+            .iter()
+            .flat_map(|plan| plan.removed_directories.clone())
+            .collect(),
+        dry_run,
+    })
+}
+
+fn discover_deprecated_override_candidates(
+    skills_root: &Path,
+    agent_filter: Option<Agent>,
+) -> Result<Vec<DeprecatedOverrideCandidate>> {
+    let mut candidates = validation_agents(agent_filter)
+        .into_iter()
+        .map(|agent| {
+            let agent_root = skills_root.join(agent_skill_subdir(agent));
+            let skill_candidates = collect_skill_candidates_in_directory(
+                &agent_root,
+                SkillSourceOrigin::AgentOverride,
+                false,
+            )?;
+
+            Ok(skill_candidates
+                .into_iter()
+                .map(|candidate| DeprecatedOverrideCandidate { agent, candidate })
+                .collect::<Vec<_>>())
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+    candidates.sort_by(|left, right| {
+        left.candidate
+            .name
+            .cmp(&right.candidate.name)
+            .then_with(|| agent_skill_subdir(left.agent).cmp(agent_skill_subdir(right.agent)))
+    });
+    Ok(candidates)
+}
+
+fn plan_deprecated_override_migrations(
+    skills_root: &Path,
+    candidates: &[DeprecatedOverrideCandidate],
+) -> Result<Vec<PlannedSkillMigration>> {
+    let mut grouped = BTreeMap::<String, Vec<DeprecatedOverrideCandidate>>::new();
+    for candidate in candidates {
+        grouped
+            .entry(candidate.candidate.name.clone())
+            .or_default()
+            .push(candidate.clone());
+    }
+
+    grouped
+        .into_iter()
+        .map(|(skill_name, grouped_candidates)| {
+            plan_skill_migration(skills_root, &skill_name, &grouped_candidates)
+        })
+        .collect()
+}
+
+fn plan_skill_migration(
+    skills_root: &Path,
+    skill_name: &str,
+    candidates: &[DeprecatedOverrideCandidate],
+) -> Result<PlannedSkillMigration> {
+    let shared_candidate = canonical_shared_skill_candidate(skills_root, skill_name)?;
+    let shared_root = shared_candidate.path.clone();
+    let mut definition = load_canonical_skill_definition(&shared_candidate)?;
+    let base_instructions_path = shared_root.join(&definition.instructions_file);
+    let base_instructions = fs::read_to_string(&base_instructions_path)
+        .with_context(|| format!("Failed to read {}", base_instructions_path.display()))?;
+
+    let mut migrated_overrides = Vec::new();
+    let mut updated_files = Vec::new();
+    let mut removed_directories = Vec::new();
+
+    for candidate in candidates {
+        if candidate.candidate.kind != SkillCandidateKind::LegacyDirectory {
+            anyhow::bail!(
+                "skills/{}/{} uses {:?}; automatic migration currently supports only full override directories containing {}",
+                agent_skill_subdir(candidate.agent),
+                candidate.candidate.name,
+                candidate.candidate.kind,
+                SKILL_FILE_NAME,
+            );
+        }
+
+        let planned_body_override = plan_single_override_body_migration(
+            &shared_root,
+            &definition,
+            &base_instructions,
+            candidate,
+        )?;
+        merge_single_override_metadata(&mut definition, candidate)?;
+
+        if let Some(body_override) = planned_body_override {
+            updated_files.push(body_override);
+        }
+
+        migrated_overrides.push(format!(
+            "skills/{}/{}",
+            agent_skill_subdir(candidate.agent),
+            candidate.candidate.name
+        ));
+        removed_directories.push(candidate.candidate.path.clone());
+    }
+
+    updated_files.insert(
+        0,
+        (shared_root.join(CANONICAL_SKILL_FILE_NAME), serialize_yaml_struct(&definition)?),
+    );
+
+    Ok(PlannedSkillMigration { migrated_overrides, updated_files, removed_directories })
+}
+
+fn canonical_shared_skill_candidate(
+    skills_root: &Path,
+    skill_name: &str,
+) -> Result<SkillCandidate> {
+    let path = skills_root.join(skill_name);
+    let canonical_path = path.join(CANONICAL_SKILL_FILE_NAME);
+    let legacy_path = path.join(SKILL_FILE_NAME);
+
+    match (canonical_path.exists(), legacy_path.exists()) {
+        (true, false) => Ok(SkillCandidate {
+            name: skill_name.to_string(),
+            path,
+            kind: SkillCandidateKind::CanonicalDirectory,
+            origin: SkillSourceOrigin::Shared,
+        }),
+        (false, true) => anyhow::bail!(
+            "Shared skill `{skill_name}` is still legacy (`skills/{skill_name}/{SKILL_FILE_NAME}`); migrate it to canonical skill.yaml before removing deprecated full overrides."
+        ),
+        (false, false) => anyhow::bail!(
+            "Shared canonical skill `{skill_name}` does not exist under skills/{skill_name}; create it before migrating deprecated full overrides."
+        ),
+        (true, true) => anyhow::bail!(
+            "Shared skill `{skill_name}` contains both {} and {}; resolve that mixed format before migration.",
+            CANONICAL_SKILL_FILE_NAME,
+            SKILL_FILE_NAME,
+        ),
+    }
+}
+
+fn plan_single_override_body_migration(
+    shared_root: &Path,
+    definition: &CanonicalSkillDefinition,
+    _base_instructions: &str,
+    candidate: &DeprecatedOverrideCandidate,
+) -> Result<Option<(PathBuf, String)>> {
+    let override_files = asset_sync::collect_directory_tree_mappings(&candidate.candidate.path)?;
+    let extra_files = override_files
+        .into_iter()
+        .map(|mapping| mapping.relative_path)
+        .filter(|relative_path| relative_path != SKILL_FILE_NAME)
+        .collect::<Vec<_>>();
+    if !extra_files.is_empty() {
+        anyhow::bail!(
+            "skills/{}/{} contains additional files ({}) that automatic migration cannot place canonically; migrate those resources manually first.",
+            agent_skill_subdir(candidate.agent),
+            candidate.candidate.name,
+            extra_files.join(", "),
+        );
+    }
+
+    let skill_path = candidate.candidate.path.join(SKILL_FILE_NAME);
+    let document = parse_legacy_skill_document(&skill_path)?;
+    if let Some(parse_warning) = document.parse_warning {
+        anyhow::bail!(
+            "skills/{}/{} cannot be migrated automatically: {}",
+            agent_skill_subdir(candidate.agent),
+            candidate.candidate.name,
+            parse_warning,
+        );
+    }
+
+    let target_name = canonical_target_for_agent(candidate.agent);
+    let override_body = normalize_skill_body_text(&document.body);
+    let rendered_target_body = normalize_skill_body_text(&load_canonical_instructions(
+        shared_root,
+        definition,
+        target_name,
+    )?);
+    if override_body == rendered_target_body {
+        return Ok(None);
+    }
+
+    let conflicting_body_artifacts = existing_target_body_artifacts(shared_root, target_name);
+    if !conflicting_body_artifacts.is_empty() {
+        anyhow::bail!(
+            "skills/{}/{} already has canonical target body artifacts ({}) and the rendered instructions differ from the deprecated override; merge the body manually before retrying migration.",
+            agent_skill_subdir(candidate.agent),
+            candidate.candidate.name,
+            conflicting_body_artifacts
+                .iter()
+                .map(|path| path.strip_prefix(shared_root).unwrap_or(path).display().to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+
+    Ok(Some((
+        shared_root
+            .join("targets")
+            .join(format!("{}.md", target_name_label(target_name))),
+        format_markdown_body_override(&override_body),
+    )))
+}
+
+fn merge_single_override_metadata(
+    definition: &mut CanonicalSkillDefinition,
+    candidate: &DeprecatedOverrideCandidate,
+) -> Result<()> {
+    let skill_path = candidate.candidate.path.join(SKILL_FILE_NAME);
+    let document = parse_legacy_skill_document(&skill_path)?;
+    if let Some(parse_warning) = document.parse_warning {
+        anyhow::bail!(
+            "skills/{}/{} cannot be migrated automatically: {}",
+            agent_skill_subdir(candidate.agent),
+            candidate.candidate.name,
+            parse_warning,
+        );
+    }
+
+    let Some(frontmatter) = document.frontmatter.as_ref() else {
+        return Ok(());
+    };
+
+    validate_legacy_override_core_metadata(frontmatter, definition, candidate)?;
+    let migrated_overlay = extract_target_overlay_from_legacy(
+        frontmatter,
+        candidate.agent,
+        &candidate.candidate.name,
+    )?;
+
+    if skill_target_overlay_is_empty(&migrated_overlay) {
+        return Ok(());
+    }
+
+    let target_name = canonical_target_for_agent(candidate.agent);
+    let target_overlay = definition.targets.entry(target_name).or_default();
+    merge_target_overlay(
+        target_overlay,
+        migrated_overlay,
+        &format!("skills/{}/{}", agent_skill_subdir(candidate.agent), candidate.candidate.name),
+    )?;
+
+    if skill_target_overlay_is_empty(target_overlay) {
+        definition.targets.remove(&target_name);
+    }
+
+    Ok(())
+}
+
+fn validate_legacy_override_core_metadata(
+    frontmatter: &YamlMapping,
+    definition: &CanonicalSkillDefinition,
+    candidate: &DeprecatedOverrideCandidate,
+) -> Result<()> {
+    let override_name =
+        optional_string_frontmatter_value(frontmatter, "name").with_context(|| {
+            format!(
+                "skills/{}/{}/{} has invalid `name`",
+                agent_skill_subdir(candidate.agent),
+                candidate.candidate.name,
+                SKILL_FILE_NAME
+            )
+        })?;
+    if let Some(name) = override_name {
+        if name != definition.name {
+            anyhow::bail!(
+                "skills/{}/{} declares name `{}` but the shared canonical skill is `{}`; migrate the core skill metadata first.",
+                agent_skill_subdir(candidate.agent),
+                candidate.candidate.name,
+                name,
+                definition.name,
+            );
+        }
+    }
+
+    let override_description = optional_string_frontmatter_value(frontmatter, "description")
+        .with_context(|| {
+            format!(
+                "skills/{}/{}/{} has invalid `description`",
+                agent_skill_subdir(candidate.agent),
+                candidate.candidate.name,
+                SKILL_FILE_NAME
+            )
+        })?;
+    if let Some(description) = override_description {
+        if description != definition.description {
+            anyhow::bail!(
+                "skills/{}/{} declares description `{}` but the shared canonical skill uses `{}`; move shared metadata into skill.yaml before migration.",
+                agent_skill_subdir(candidate.agent),
+                candidate.candidate.name,
+                description,
+                definition.description,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_target_overlay_from_legacy(
+    frontmatter: &YamlMapping,
+    agent: Agent,
+    skill_name: &str,
+) -> Result<SkillTargetOverlay> {
+    match agent {
+        Agent::Claude | Agent::ClaudeCode | Agent::Gemini => {
+            validate_supported_frontmatter_keys(
+                frontmatter,
+                skill_name,
+                agent,
+                CLAUDE_FAMILY_MIGRATION_FRONTMATTER_KEYS,
+            )?;
+
+            Ok(SkillTargetOverlay {
+                invocation: None,
+                disable_model_invocation: optional_bool_frontmatter_value(
+                    frontmatter,
+                    "disable-model-invocation",
+                )
+                .with_context(|| {
+                    format!(
+                        "skills/{}/{skill_name}/{} has invalid `disable-model-invocation`",
+                        agent_skill_subdir(agent),
+                        SKILL_FILE_NAME,
+                    )
+                })?,
+                user_invocable: optional_bool_frontmatter_value(frontmatter, "user-invocable")
+                    .with_context(|| {
+                        format!(
+                            "skills/{}/{skill_name}/{} has invalid `user-invocable`",
+                            agent_skill_subdir(agent),
+                            SKILL_FILE_NAME,
+                        )
+                    })?,
+                allowed_tools: optional_string_list_frontmatter_value(frontmatter, "allowed-tools")
+                    .with_context(|| {
+                        format!(
+                            "skills/{}/{skill_name}/{} has invalid `allowed-tools`",
+                            agent_skill_subdir(agent),
+                            SKILL_FILE_NAME,
+                        )
+                    })?,
+                arguments: optional_yaml_frontmatter_value(frontmatter, "arguments"),
+                argument_hint: optional_string_frontmatter_value(frontmatter, "argument-hint")
+                    .with_context(|| {
+                        format!(
+                            "skills/{}/{skill_name}/{} has invalid `argument-hint`",
+                            agent_skill_subdir(agent),
+                            SKILL_FILE_NAME,
+                        )
+                    })?,
+                context: optional_yaml_frontmatter_value(frontmatter, "context"),
+                agent: optional_string_frontmatter_value(frontmatter, "agent").with_context(
+                    || {
+                        format!(
+                            "skills/{}/{skill_name}/{} has invalid `agent`",
+                            agent_skill_subdir(agent),
+                            SKILL_FILE_NAME,
+                        )
+                    },
+                )?,
+                interface: None,
+                dependencies: None,
+            })
+        },
+        Agent::Codex => {
+            validate_supported_frontmatter_keys(
+                frontmatter,
+                skill_name,
+                agent,
+                CODEX_MIGRATION_FRONTMATTER_KEYS,
+            )?;
+
+            let invocation =
+                match optional_bool_frontmatter_value(frontmatter, "disable-model-invocation")
+                    .with_context(|| {
+                        format!(
+                            "skills/{}/{skill_name}/{} has invalid `disable-model-invocation`",
+                            agent_skill_subdir(agent),
+                            SKILL_FILE_NAME,
+                        )
+                    })? {
+                    Some(true) => Some(SkillInvocationMode::Manual),
+                    _ => None,
+                };
+
+            Ok(SkillTargetOverlay {
+                invocation,
+                disable_model_invocation: None,
+                user_invocable: None,
+                allowed_tools: None,
+                arguments: None,
+                argument_hint: None,
+                context: None,
+                agent: None,
+                interface: optional_yaml_frontmatter_value(frontmatter, "interface"),
+                dependencies: optional_yaml_frontmatter_value(frontmatter, "dependencies"),
+            })
+        },
+    }
+}
+
+fn validate_supported_frontmatter_keys(
+    frontmatter: &YamlMapping,
+    skill_name: &str,
+    agent: Agent,
+    supported_keys: &[&str],
+) -> Result<()> {
+    let allowed_keys = LEGACY_CORE_FRONTMATTER_KEYS
+        .iter()
+        .chain(supported_keys.iter())
+        .copied()
+        .collect::<BTreeSet<_>>();
+
+    let unsupported_keys = frontmatter
+        .keys()
+        .filter_map(YamlValue::as_str)
+        .filter(|key| !allowed_keys.contains(key))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    if unsupported_keys.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "skills/{}/{skill_name}/{} uses frontmatter keys ({}) that cannot be migrated automatically for {}; move them into shared canonical metadata or migrate this override manually.",
+        agent_skill_subdir(agent),
+        SKILL_FILE_NAME,
+        unsupported_keys.join(", "),
+        agent_label(agent),
+    )
+}
+
+fn optional_bool_frontmatter_value(frontmatter: &YamlMapping, key: &str) -> Result<Option<bool>> {
+    frontmatter
+        .get(yaml_key(key))
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| anyhow::anyhow!("expected `{key}` to be a boolean"))
+        })
+        .transpose()
+}
+
+fn optional_string_frontmatter_value(
+    frontmatter: &YamlMapping,
+    key: &str,
+) -> Result<Option<String>> {
+    frontmatter
+        .get(yaml_key(key))
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| anyhow::anyhow!("expected `{key}` to be a string"))
+        })
+        .transpose()
+}
+
+fn optional_string_list_frontmatter_value(
+    frontmatter: &YamlMapping,
+    key: &str,
+) -> Result<Option<Vec<String>>> {
+    frontmatter
+        .get(yaml_key(key))
+        .map(|value| {
+            serde_yaml::from_value::<Vec<String>>(value.clone()).map_err(|error| {
+                anyhow::anyhow!("expected `{key}` to be a list of strings: {error}")
+            })
+        })
+        .transpose()
+}
+
+fn optional_yaml_frontmatter_value(frontmatter: &YamlMapping, key: &str) -> Option<YamlValue> {
+    frontmatter.get(yaml_key(key)).cloned()
+}
+
+fn merge_target_overlay(
+    existing: &mut SkillTargetOverlay,
+    incoming: SkillTargetOverlay,
+    context: &str,
+) -> Result<()> {
+    merge_optional_overlay_field(
+        &mut existing.invocation,
+        incoming.invocation,
+        "invocation",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.disable_model_invocation,
+        incoming.disable_model_invocation,
+        "disable-model-invocation",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.user_invocable,
+        incoming.user_invocable,
+        "user-invocable",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.allowed_tools,
+        incoming.allowed_tools,
+        "allowed-tools",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.arguments,
+        incoming.arguments,
+        "arguments",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.argument_hint,
+        incoming.argument_hint,
+        "argument-hint",
+        context,
+    )?;
+    merge_optional_overlay_field(&mut existing.context, incoming.context, "context", context)?;
+    merge_optional_overlay_field(&mut existing.agent, incoming.agent, "agent", context)?;
+    merge_optional_overlay_field(
+        &mut existing.interface,
+        incoming.interface,
+        "interface",
+        context,
+    )?;
+    merge_optional_overlay_field(
+        &mut existing.dependencies,
+        incoming.dependencies,
+        "dependencies",
+        context,
+    )?;
+    Ok(())
+}
+
+fn merge_optional_overlay_field<T>(
+    existing: &mut Option<T>,
+    incoming: Option<T>,
+    field_name: &str,
+    context: &str,
+) -> Result<()>
+where
+    T: PartialEq,
+{
+    let Some(incoming_value) = incoming else {
+        return Ok(());
+    };
+
+    match existing {
+        Some(existing_value) if *existing_value != incoming_value => anyhow::bail!(
+            "{context} conflicts with the existing canonical `{field_name}` target overlay value; merge that field manually."
+        ),
+        Some(_) => Ok(()),
+        None => {
+            *existing = Some(incoming_value);
+            Ok(())
+        },
+    }
+}
+
+fn skill_target_overlay_is_empty(overlay: &SkillTargetOverlay) -> bool {
+    overlay.invocation.is_none()
+        && overlay.disable_model_invocation.is_none()
+        && overlay.user_invocable.is_none()
+        && overlay.allowed_tools.is_none()
+        && overlay.arguments.is_none()
+        && overlay.argument_hint.is_none()
+        && overlay.context.is_none()
+        && overlay.agent.is_none()
+        && overlay.interface.is_none()
+        && overlay.dependencies.is_none()
+}
+
+fn existing_target_body_artifacts(skill_root: &Path, target_name: SkillTargetName) -> Vec<PathBuf> {
+    let targets_dir = skill_root.join("targets");
+    [
+        targets_dir.join(format!("{}.md", target_name_label(target_name))),
+        targets_dir.join(format!("{}.prepend.md", target_name_label(target_name))),
+        targets_dir.join(format!("{}.append.md", target_name_label(target_name))),
+    ]
+    .into_iter()
+    .filter(|path| path.exists())
+    .collect()
+}
+
+fn normalize_skill_body_text(text: &str) -> String {
+    let normalized = text.replace("\r\n", "\n");
+    let without_frontmatter_spacing = normalized.strip_prefix('\n').unwrap_or(&normalized);
+    without_frontmatter_spacing.trim_end().to_string()
+}
+
+fn format_markdown_body_override(body: &str) -> String {
+    if body.is_empty() {
+        String::new()
+    } else {
+        format!("{body}\n")
+    }
+}
+
+fn serialize_yaml_struct<T: Serialize>(value: &T) -> Result<String> {
+    let serialized = serde_yaml::to_string(value).context("Failed to serialize YAML")?;
+    Ok(serialized.strip_prefix("---\n").unwrap_or(&serialized).to_string())
+}
+
+fn apply_planned_skill_migrations(plans: &[PlannedSkillMigration]) -> Result<()> {
+    for plan in plans {
+        for (path, content) in &plan.updated_files {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create {}", parent.display()))?;
+            }
+            fs::write(path, content)
+                .with_context(|| format!("Failed to write {}", path.display()))?;
+        }
+    }
+
+    for plan in plans {
+        for path in &plan.removed_directories {
+            fs::remove_dir_all(path)
+                .with_context(|| format!("Failed to remove {}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn prune_empty_agent_override_dirs(skills_root: &Path) -> Result<()> {
+    for agent in validation_agents(None) {
+        let agent_dir = skills_root.join(agent_skill_subdir(agent));
+        if !agent_dir.exists() {
+            continue;
+        }
+
+        let mut entries = fs::read_dir(&agent_dir)
+            .with_context(|| format!("Failed to read {}", agent_dir.display()))?;
+        if entries.next().is_none() {
+            fs::remove_dir(&agent_dir)
+                .with_context(|| format!("Failed to remove {}", agent_dir.display()))?;
+        }
+    }
+
+    Ok(())
 }
 
 fn validation_agents(agent_filter: Option<Agent>) -> Vec<Agent> {
@@ -632,7 +1361,7 @@ fn collect_canonical_target_entry_warnings(
         .collect::<std::result::Result<Vec<_>, _>>()?;
     entries.sort_by_key(std::fs::DirEntry::file_name);
 
-    Ok(entries
+    let mut warnings = entries
         .into_iter()
         .filter_map(|entry| {
             let entry_name = entry.file_name().to_str()?.to_string();
@@ -645,7 +1374,33 @@ fn collect_canonical_target_entry_warnings(
                 format_canonical_target_entries(&allowed_entries),
             ))
         })
-        .collect())
+        .collect::<Vec<_>>();
+
+    warnings.extend(
+        [
+            SkillTargetName::Claude,
+            SkillTargetName::ClaudeCode,
+            SkillTargetName::Codex,
+            SkillTargetName::Gemini,
+        ]
+        .into_iter()
+        .filter_map(|target| {
+            let label = target_name_label(target);
+            let full_override = targets_dir.join(format!("{label}.md"));
+            let prepend = targets_dir.join(format!("{label}.prepend.md"));
+            let append = targets_dir.join(format!("{label}.append.md"));
+
+            if !full_override.exists() || (!prepend.exists() && !append.exists()) {
+                return None;
+            }
+
+            Some(format!(
+                "Canonical skill `{skill_name}` defines `targets/{label}.md` together with prepend/append fragments; the full override takes precedence and the fragments will be ignored."
+            ))
+        }),
+    );
+
+    Ok(warnings)
 }
 
 fn allowed_canonical_top_level_entries(definition: &CanonicalSkillDefinition) -> BTreeSet<String> {
@@ -668,7 +1423,7 @@ fn allowed_canonical_target_entries() -> BTreeSet<String> {
     .into_iter()
     .flat_map(|target| {
         let label = target_name_label(target);
-        [format!("{label}.prepend.md"), format!("{label}.append.md")]
+        [format!("{label}.md"), format!("{label}.prepend.md"), format!("{label}.append.md")]
     })
     .collect()
 }
@@ -706,6 +1461,14 @@ fn load_canonical_instructions(
     definition: &CanonicalSkillDefinition,
     target_name: SkillTargetName,
 ) -> Result<String> {
+    let direct_override_path = skill_root
+        .join("targets")
+        .join(format!("{}.md", target_name_label(target_name)));
+    if direct_override_path.exists() {
+        return fs::read_to_string(&direct_override_path)
+            .with_context(|| format!("Failed to read {}", direct_override_path.display()));
+    }
+
     let instructions_path = skill_root.join(&definition.instructions_file);
     let mut body = fs::read_to_string(&instructions_path)
         .with_context(|| format!("Failed to read {}", instructions_path.display()))?;
@@ -1250,7 +2013,7 @@ pub fn collect_claudius_skill_source_set(
     for candidate in &candidates {
         if candidate.origin == SkillSourceOrigin::AgentOverride {
             warnings.insert(format!(
-                "Deprecated full agent override directory detected for skill `{}` under skills/{}/{}; prefer canonical target overlays in skill.yaml.",
+                "Deprecated full agent override directory detected for skill `{}` under skills/{}/{}; prefer canonical target overlays in skill.yaml and migrate it with `claudius skills migrate`.",
                 candidate.name,
                 agent_skill_subdir(render_agent),
                 candidate.name,

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 use tempfile::TempDir;
 
@@ -432,6 +432,7 @@ fn render_canonical_skill_bundle(
     warnings: &mut BTreeSet<String>,
 ) -> Result<RenderedSkillBundle> {
     let definition = load_canonical_skill_definition(candidate)?;
+    warnings.extend(collect_canonical_layout_warnings(&candidate.path, &definition)?);
     let target_name = canonical_target_for_agent(render_agent);
     let target_overlay = definition.targets.get(&target_name).cloned().unwrap_or_default();
     let instructions = load_canonical_instructions(&candidate.path, &definition, target_name)?;
@@ -524,7 +525,180 @@ fn load_canonical_skill_definition(candidate: &SkillCandidate) -> Result<Canonic
         );
     }
 
+    validate_canonical_instructions_file(&candidate.path, &definition)?;
+    validate_canonical_reserved_directories(&candidate.path, &definition.name)?;
+
     Ok(definition)
+}
+
+fn validate_canonical_instructions_file(
+    skill_root: &Path,
+    definition: &CanonicalSkillDefinition,
+) -> Result<()> {
+    let definition_path = skill_root.join(CANONICAL_SKILL_FILE_NAME);
+    let instructions_file = Path::new(&definition.instructions_file);
+    let mut components = instructions_file.components();
+
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => {},
+        _ => anyhow::bail!(
+            "Canonical skill {} must define instructions_file as a single file name within the skill directory",
+            definition_path.display(),
+        ),
+    }
+
+    let instructions_path = skill_root.join(&definition.instructions_file);
+    if !instructions_path.is_file() {
+        anyhow::bail!(
+            "Canonical skill {} declares instructions_file `{}` but {} is not a regular file",
+            definition_path.display(),
+            definition.instructions_file,
+            instructions_path.display(),
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_canonical_reserved_directories(skill_root: &Path, skill_name: &str) -> Result<()> {
+    for dir_name in SKILL_RESOURCE_DIRS.iter().copied().chain(std::iter::once("targets")) {
+        let path = skill_root.join(dir_name);
+        if path.exists() && !path.is_dir() {
+            anyhow::bail!(
+                "Canonical skill `{skill_name}` expects `{dir_name}` to be a directory when present: {}",
+                path.display(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_canonical_layout_warnings(
+    skill_root: &Path,
+    definition: &CanonicalSkillDefinition,
+) -> Result<Vec<String>> {
+    let allowed_entries = allowed_canonical_top_level_entries(definition);
+    let mut warnings = Vec::new();
+    let mut entries = fs::read_dir(skill_root)
+        .with_context(|| {
+            format!("Failed to read canonical skill directory: {}", skill_root.display())
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    for entry in entries {
+        let entry_name = entry
+            .file_name()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid canonical skill entry name"))?
+            .to_string();
+
+        if entry_name.starts_with('.') {
+            continue;
+        }
+
+        if allowed_entries.contains(&entry_name) {
+            if entry_name == "targets" {
+                warnings.extend(collect_canonical_target_entry_warnings(
+                    &skill_root.join("targets"),
+                    &definition.name,
+                )?);
+            }
+            continue;
+        }
+
+        warnings.push(format!(
+            "Canonical skill `{}` contains unsupported top-level entry `{entry_name}`; only {} are rendered, so this entry will be ignored.",
+            definition.name,
+            format_canonical_top_level_entries(&allowed_entries),
+        ));
+    }
+
+    Ok(warnings)
+}
+
+fn collect_canonical_target_entry_warnings(
+    targets_dir: &Path,
+    skill_name: &str,
+) -> Result<Vec<String>> {
+    if !targets_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let allowed_entries = allowed_canonical_target_entries();
+    let mut entries = fs::read_dir(targets_dir)
+        .with_context(|| format!("Failed to read targets directory: {}", targets_dir.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    Ok(entries
+        .into_iter()
+        .filter_map(|entry| {
+            let entry_name = entry.file_name().to_str()?.to_string();
+            if entry_name.starts_with('.') || allowed_entries.contains(&entry_name) {
+                return None;
+            }
+
+            Some(format!(
+                "Canonical skill `{skill_name}` contains unsupported targets entry `targets/{entry_name}`; keep per-agent metadata in skill.yaml and limit Markdown fragments to {}.",
+                format_canonical_target_entries(&allowed_entries),
+            ))
+        })
+        .collect())
+}
+
+fn allowed_canonical_top_level_entries(definition: &CanonicalSkillDefinition) -> BTreeSet<String> {
+    let mut entries = BTreeSet::from([
+        CANONICAL_SKILL_FILE_NAME.to_string(),
+        definition.instructions_file.clone(),
+        "targets".to_string(),
+    ]);
+    entries.extend(SKILL_RESOURCE_DIRS.iter().map(|dir_name| (*dir_name).to_string()));
+    entries
+}
+
+fn allowed_canonical_target_entries() -> BTreeSet<String> {
+    [
+        SkillTargetName::Claude,
+        SkillTargetName::ClaudeCode,
+        SkillTargetName::Codex,
+        SkillTargetName::Gemini,
+    ]
+    .into_iter()
+    .flat_map(|target| {
+        let label = target_name_label(target);
+        [format!("{label}.prepend.md"), format!("{label}.append.md")]
+    })
+    .collect()
+}
+
+fn format_canonical_top_level_entries(entries: &BTreeSet<String>) -> String {
+    entries
+        .iter()
+        .map(|entry| {
+            if entry == CANONICAL_SKILL_FILE_NAME || is_markdown_file_name(entry) {
+                format!("`{entry}`")
+            } else {
+                format!("`{entry}/`")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_canonical_target_entries(entries: &BTreeSet<String>) -> String {
+    entries
+        .iter()
+        .map(|entry| format!("`targets/{entry}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn is_markdown_file_name(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
 }
 
 fn load_canonical_instructions(

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -3,11 +3,32 @@ use crate::{
     asset_sync::{self, ManagedTreeSyncReport, SourceFileMapping, SyncBehavior},
 };
 use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use tempfile::TempDir;
 
 const SKILL_FILE_NAME: &str = "SKILL.md";
+const CANONICAL_SKILL_FILE_NAME: &str = "skill.yaml";
+const DEFAULT_CANONICAL_INSTRUCTIONS_FILE: &str = "instructions.md";
+const SKILL_RESOURCE_DIRS: &[&str] = &["scripts", "references", "assets"];
+const CLAUDE_ONLY_FRONTMATTER_KEYS: &[&str] = &[
+    "disable-model-invocation",
+    "user-invocable",
+    "allowed-tools",
+    "arguments",
+    "argument-hint",
+    "agent",
+    "context",
+];
+
+static YAML_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"(?s)\A---\r?\n(.*?)\r?\n---\r?\n?(.*)\z")
+        .expect("frontmatter regex should compile")
+});
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillSyncReport {
@@ -17,10 +38,113 @@ pub struct SkillSyncReport {
     pub pruned_files: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct SkillSourceSet {
     pub mappings: Vec<SourceFileMapping>,
     pub includes_legacy_commands: bool,
+    pub warnings: Vec<String>,
+    _render_workspace: Option<TempDir>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillValidationReport {
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum SkillSourceOrigin {
+    LegacyCommand,
+    Shared,
+    AgentOverride,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkillCandidateKind {
+    CanonicalDirectory,
+    LegacyDirectory,
+    LegacyFile,
+}
+
+#[derive(Debug, Clone)]
+struct SkillCandidate {
+    name: String,
+    path: PathBuf,
+    kind: SkillCandidateKind,
+    origin: SkillSourceOrigin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SkillTargetName {
+    Claude,
+    ClaudeCode,
+    Codex,
+    Gemini,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SkillInvocationMode {
+    Auto,
+    Manual,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct CanonicalSkillDefinition {
+    version: u8,
+    name: String,
+    description: String,
+    #[serde(default = "default_instructions_file")]
+    instructions_file: String,
+    #[serde(default)]
+    targets: BTreeMap<SkillTargetName, SkillTargetOverlay>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct SkillTargetOverlay {
+    #[serde(default)]
+    invocation: Option<SkillInvocationMode>,
+    #[serde(default)]
+    disable_model_invocation: Option<bool>,
+    #[serde(default)]
+    user_invocable: Option<bool>,
+    #[serde(default)]
+    allowed_tools: Option<Vec<String>>,
+    #[serde(default)]
+    arguments: Option<YamlValue>,
+    #[serde(default)]
+    argument_hint: Option<String>,
+    #[serde(default)]
+    context: Option<YamlValue>,
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    interface: Option<YamlValue>,
+    #[serde(default)]
+    dependencies: Option<YamlValue>,
+}
+
+#[derive(Debug, Clone)]
+struct LegacySkillDocument {
+    raw_content: String,
+    frontmatter: Option<YamlMapping>,
+    body: String,
+    parse_warning: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedTextFile {
+    relative_path: String,
+    content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RenderedSkillBundle {
+    name: String,
+    generated_files: Vec<RenderedTextFile>,
+    resource_mappings: Vec<SourceFileMapping>,
 }
 
 impl SkillSyncReport {
@@ -86,6 +210,735 @@ pub fn sync_skill_mappings_with_options(
         asset_sync::sync_managed_tree(target_dir, mappings, behavior)?;
 
     Ok(SkillSyncReport { target_dir: synced_target_dir, synced_skills, synced_files, pruned_files })
+}
+
+fn default_instructions_file() -> String {
+    DEFAULT_CANONICAL_INSTRUCTIONS_FILE.to_string()
+}
+
+/// Validate Claudius skills by loading and rendering them for the selected
+/// agent(s) without writing deployment targets.
+///
+/// # Errors
+///
+/// Returns an error if canonical skills are invalid, required files are
+/// missing, or rendering fails for the selected target agent.
+pub fn validate_claudius_skill_sources(
+    config_dir: &Path,
+    agent_filter: Option<Agent>,
+) -> Result<SkillValidationReport> {
+    let mut warnings = BTreeSet::new();
+
+    for agent in validation_agents(agent_filter) {
+        let source_set = collect_claudius_skill_source_set(config_dir, Some(agent))
+            .with_context(|| format!("Failed to validate skills for {}", agent_label(agent)))?;
+        warnings.extend(source_set.warnings);
+    }
+
+    Ok(SkillValidationReport { warnings: warnings.into_iter().collect() })
+}
+
+fn validation_agents(agent_filter: Option<Agent>) -> Vec<Agent> {
+    agent_filter.map_or_else(
+        || vec![Agent::Claude, Agent::ClaudeCode, Agent::Codex, Agent::Gemini],
+        |selected| vec![selected],
+    )
+}
+
+fn agent_label(agent: Agent) -> &'static str {
+    match agent {
+        Agent::Claude => "claude",
+        Agent::ClaudeCode => "claude-code",
+        Agent::Codex => "codex",
+        Agent::Gemini => "gemini",
+    }
+}
+
+fn effective_render_agent(agent: Option<Agent>) -> Agent {
+    agent.unwrap_or(Agent::Claude)
+}
+
+fn canonical_target_for_agent(agent: Agent) -> SkillTargetName {
+    match agent {
+        Agent::Claude => SkillTargetName::Claude,
+        Agent::ClaudeCode => SkillTargetName::ClaudeCode,
+        Agent::Codex => SkillTargetName::Codex,
+        Agent::Gemini => SkillTargetName::Gemini,
+    }
+}
+
+fn discover_skill_candidates(
+    skills_root: &Path,
+    commands_root: &Path,
+    agent: Option<Agent>,
+) -> Result<(Vec<SkillCandidate>, bool)> {
+    let mut merged = BTreeMap::<String, SkillCandidate>::new();
+    let legacy_commands = collect_legacy_command_candidates(commands_root)?;
+    let includes_legacy_commands = !legacy_commands.is_empty();
+
+    for candidate in legacy_commands {
+        merged.insert(candidate.name.clone(), candidate);
+    }
+
+    for candidate in
+        collect_skill_candidates_in_directory(skills_root, SkillSourceOrigin::Shared, true)?
+    {
+        merged.insert(candidate.name.clone(), candidate);
+    }
+
+    if let Some(selected_agent) = agent {
+        let agent_root = skills_root.join(agent_skill_subdir(selected_agent));
+        for candidate in collect_skill_candidates_in_directory(
+            &agent_root,
+            SkillSourceOrigin::AgentOverride,
+            false,
+        )? {
+            merged.insert(candidate.name.clone(), candidate);
+        }
+    }
+
+    Ok((merged.into_values().collect(), includes_legacy_commands))
+}
+
+fn collect_skill_candidates_in_directory(
+    root: &Path,
+    origin: SkillSourceOrigin,
+    skip_agent_dirs: bool,
+) -> Result<Vec<SkillCandidate>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = fs::read_dir(root)
+        .with_context(|| format!("Failed to read skills directory: {}", root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        let entry_name = entry
+            .file_name()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Invalid skill entry name"))?
+            .to_string();
+
+        if path.is_dir() {
+            if skip_agent_dirs && is_agent_skill_subdir(&entry_name) {
+                continue;
+            }
+
+            let canonical_path = path.join(CANONICAL_SKILL_FILE_NAME);
+            let legacy_skill_path = path.join(SKILL_FILE_NAME);
+
+            if canonical_path.exists() && legacy_skill_path.exists() {
+                anyhow::bail!(
+                    "Skill directory {} contains both {} and {}; choose exactly one source format",
+                    path.display(),
+                    CANONICAL_SKILL_FILE_NAME,
+                    SKILL_FILE_NAME,
+                );
+            }
+
+            let kind = if canonical_path.exists() {
+                SkillCandidateKind::CanonicalDirectory
+            } else if legacy_skill_path.exists() {
+                SkillCandidateKind::LegacyDirectory
+            } else {
+                anyhow::bail!(
+                    "Skill directory {} must contain either {} or {}",
+                    path.display(),
+                    CANONICAL_SKILL_FILE_NAME,
+                    SKILL_FILE_NAME,
+                );
+            };
+
+            candidates.push(SkillCandidate { name: entry_name, path, kind, origin });
+            continue;
+        }
+
+        if path.is_file() && path.extension().and_then(|value| value.to_str()) == Some("md") {
+            let skill_name = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?
+                .to_string();
+            candidates.push(SkillCandidate {
+                name: skill_name,
+                path,
+                kind: SkillCandidateKind::LegacyFile,
+                origin,
+            });
+        }
+    }
+
+    Ok(candidates)
+}
+
+fn collect_legacy_command_candidates(commands_root: &Path) -> Result<Vec<SkillCandidate>> {
+    if !commands_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = fs::read_dir(commands_root)
+        .with_context(|| format!("Failed to read commands directory: {}", commands_root.display()))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let path = entry.path();
+        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+
+        let skill_name = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Invalid skill file stem"))?
+            .to_string();
+        candidates.push(SkillCandidate {
+            name: skill_name,
+            path,
+            kind: SkillCandidateKind::LegacyFile,
+            origin: SkillSourceOrigin::LegacyCommand,
+        });
+    }
+
+    Ok(candidates)
+}
+
+fn render_candidate_to_mappings(
+    candidate: &SkillCandidate,
+    render_agent: Agent,
+    render_workspace: &Path,
+    warnings: &mut BTreeSet<String>,
+) -> Result<Vec<SourceFileMapping>> {
+    let bundle = match candidate.kind {
+        SkillCandidateKind::CanonicalDirectory => {
+            render_canonical_skill_bundle(candidate, render_agent, warnings)?
+        },
+        SkillCandidateKind::LegacyDirectory | SkillCandidateKind::LegacyFile => {
+            render_legacy_skill_bundle(candidate, render_agent, warnings)?
+        },
+    };
+
+    materialize_rendered_bundle(&bundle, render_workspace)
+}
+
+fn render_canonical_skill_bundle(
+    candidate: &SkillCandidate,
+    render_agent: Agent,
+    warnings: &mut BTreeSet<String>,
+) -> Result<RenderedSkillBundle> {
+    let definition = load_canonical_skill_definition(candidate)?;
+    let target_name = canonical_target_for_agent(render_agent);
+    let target_overlay = definition.targets.get(&target_name).cloned().unwrap_or_default();
+    let instructions = load_canonical_instructions(&candidate.path, &definition, target_name)?;
+
+    match target_name {
+        SkillTargetName::Codex => {
+            if target_overlay.disable_model_invocation.is_some()
+                || target_overlay.user_invocable.is_some()
+                || target_overlay.allowed_tools.is_some()
+                || target_overlay.arguments.is_some()
+                || target_overlay.argument_hint.is_some()
+                || target_overlay.context.is_some()
+                || target_overlay.agent.is_some()
+            {
+                warnings.insert(format!(
+                    "Codex target overlay for skill `{}` contains Claude-specific fields that will be ignored during rendering.",
+                    definition.name
+                ));
+            }
+        },
+        SkillTargetName::Claude | SkillTargetName::ClaudeCode | SkillTargetName::Gemini => {
+            if target_overlay.interface.is_some() || target_overlay.dependencies.is_some() {
+                warnings.insert(format!(
+                    "{} target overlay for skill `{}` contains Codex-only fields that will be ignored during rendering.",
+                    target_name_label(target_name),
+                    definition.name
+                ));
+            }
+        },
+    }
+
+    let generated_files = match target_name {
+        SkillTargetName::Codex => render_codex_generated_files(
+            &definition.name,
+            &definition.description,
+            &instructions,
+            &target_overlay,
+        )?,
+        SkillTargetName::Claude | SkillTargetName::ClaudeCode | SkillTargetName::Gemini => {
+            vec![RenderedTextFile {
+                relative_path: SKILL_FILE_NAME.to_string(),
+                content: render_claude_family_skill_markdown(
+                    &definition.name,
+                    &definition.description,
+                    &instructions,
+                    &target_overlay,
+                )?,
+            }]
+        },
+    };
+
+    Ok(RenderedSkillBundle {
+        name: definition.name.clone(),
+        generated_files,
+        resource_mappings: collect_canonical_resource_mappings(&candidate.path, &definition.name)?,
+    })
+}
+
+fn load_canonical_skill_definition(candidate: &SkillCandidate) -> Result<CanonicalSkillDefinition> {
+    let definition_path = candidate.path.join(CANONICAL_SKILL_FILE_NAME);
+    let content = fs::read_to_string(&definition_path)
+        .with_context(|| format!("Failed to read {}", definition_path.display()))?;
+    let definition: CanonicalSkillDefinition = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse {}", definition_path.display()))?;
+
+    if definition.version != 1 {
+        anyhow::bail!(
+            "Canonical skill {} uses unsupported version {}; only version 1 is supported",
+            definition_path.display(),
+            definition.version,
+        );
+    }
+
+    if definition.name.trim().is_empty() {
+        anyhow::bail!("Canonical skill {} must define a non-empty name", definition_path.display());
+    }
+
+    if definition.description.trim().is_empty() {
+        anyhow::bail!(
+            "Canonical skill {} must define a non-empty description",
+            definition_path.display()
+        );
+    }
+
+    if definition.name != candidate.name {
+        anyhow::bail!(
+            "Canonical skill directory name `{}` must match skill name `{}`",
+            candidate.name,
+            definition.name,
+        );
+    }
+
+    Ok(definition)
+}
+
+fn load_canonical_instructions(
+    skill_root: &Path,
+    definition: &CanonicalSkillDefinition,
+    target_name: SkillTargetName,
+) -> Result<String> {
+    let instructions_path = skill_root.join(&definition.instructions_file);
+    let mut body = fs::read_to_string(&instructions_path)
+        .with_context(|| format!("Failed to read {}", instructions_path.display()))?;
+
+    let prepend_path = skill_root
+        .join("targets")
+        .join(format!("{}.prepend.md", target_name_label(target_name)));
+    if prepend_path.exists() {
+        let prepend = fs::read_to_string(&prepend_path)
+            .with_context(|| format!("Failed to read {}", prepend_path.display()))?;
+        body = format!("{}\n\n{}", prepend.trim_end(), body.trim_start());
+    }
+
+    let append_path = skill_root
+        .join("targets")
+        .join(format!("{}.append.md", target_name_label(target_name)));
+    if append_path.exists() {
+        let append = fs::read_to_string(&append_path)
+            .with_context(|| format!("Failed to read {}", append_path.display()))?;
+        body = format!("{}\n\n{}", body.trim_end(), append.trim_start());
+    }
+
+    Ok(body)
+}
+
+fn render_codex_generated_files(
+    name: &str,
+    description: &str,
+    instructions: &str,
+    target_overlay: &SkillTargetOverlay,
+) -> Result<Vec<RenderedTextFile>> {
+    let mut files = vec![RenderedTextFile {
+        relative_path: SKILL_FILE_NAME.to_string(),
+        content: render_codex_skill_markdown(name, description, instructions)?,
+    }];
+
+    if let Some(openai_yaml) = render_codex_openai_yaml(target_overlay)? {
+        files.push(RenderedTextFile {
+            relative_path: "agents/openai.yaml".to_string(),
+            content: openai_yaml,
+        });
+    }
+
+    Ok(files)
+}
+
+fn render_legacy_skill_bundle(
+    candidate: &SkillCandidate,
+    render_agent: Agent,
+    warnings: &mut BTreeSet<String>,
+) -> Result<RenderedSkillBundle> {
+    let skill_path = legacy_skill_markdown_path(candidate);
+    let document = parse_legacy_skill_document(&skill_path)?;
+
+    if let Some(parse_warning) = &document.parse_warning {
+        warnings.insert(parse_warning.clone());
+    }
+
+    let mut generated_files = Vec::new();
+    let mut resource_mappings = if candidate.kind == SkillCandidateKind::LegacyDirectory {
+        collect_legacy_directory_resource_mappings(
+            &candidate.path,
+            &candidate.name,
+            &BTreeSet::from([SKILL_FILE_NAME.to_string()]),
+        )?
+    } else {
+        Vec::new()
+    };
+
+    if render_agent == Agent::Codex {
+        if let Some(frontmatter) = &document.frontmatter {
+            let Some((name, description)) = extract_name_and_description(frontmatter) else {
+                warnings.insert(format!(
+                    "Legacy skill `{}` contains YAML frontmatter without valid `name` and `description`; preserving the original SKILL.md for Codex.",
+                    candidate.name
+                ));
+                generated_files.push(RenderedTextFile {
+                    relative_path: SKILL_FILE_NAME.to_string(),
+                    content: document.raw_content.clone(),
+                });
+                return Ok(RenderedSkillBundle {
+                    name: candidate.name.clone(),
+                    generated_files,
+                    resource_mappings,
+                });
+            };
+
+            if frontmatter_contains_any(frontmatter, CLAUDE_ONLY_FRONTMATTER_KEYS)
+                && candidate.origin != SkillSourceOrigin::AgentOverride
+            {
+                warnings.insert(format!(
+                    "Legacy shared skill `{}` contains Claude-specific metadata that will be dropped when rendering for Codex.",
+                    candidate.name
+                ));
+            }
+
+            generated_files.push(RenderedTextFile {
+                relative_path: SKILL_FILE_NAME.to_string(),
+                content: render_codex_skill_markdown(&name, &description, &document.body)?,
+            });
+
+            if let Some(openai_yaml) = render_codex_openai_yaml_from_legacy(frontmatter)? {
+                if candidate.kind == SkillCandidateKind::LegacyDirectory {
+                    resource_mappings = collect_legacy_directory_resource_mappings(
+                        &candidate.path,
+                        &candidate.name,
+                        &BTreeSet::from([
+                            SKILL_FILE_NAME.to_string(),
+                            "agents/openai.yaml".to_string(),
+                        ]),
+                    )?;
+                }
+                generated_files.push(RenderedTextFile {
+                    relative_path: "agents/openai.yaml".to_string(),
+                    content: openai_yaml,
+                });
+            }
+        } else {
+            generated_files.push(RenderedTextFile {
+                relative_path: SKILL_FILE_NAME.to_string(),
+                content: document.raw_content.clone(),
+            });
+        }
+    } else {
+        generated_files.push(RenderedTextFile {
+            relative_path: SKILL_FILE_NAME.to_string(),
+            content: document.raw_content.clone(),
+        });
+    }
+
+    Ok(RenderedSkillBundle { name: candidate.name.clone(), generated_files, resource_mappings })
+}
+
+fn legacy_skill_markdown_path(candidate: &SkillCandidate) -> PathBuf {
+    match candidate.kind {
+        SkillCandidateKind::LegacyDirectory => candidate.path.join(SKILL_FILE_NAME),
+        SkillCandidateKind::CanonicalDirectory | SkillCandidateKind::LegacyFile => {
+            candidate.path.clone()
+        },
+    }
+}
+
+fn parse_legacy_skill_document(path: &Path) -> Result<LegacySkillDocument> {
+    let raw_content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    let Some(captures) = YAML_FRONTMATTER_RE.captures(&raw_content) else {
+        return Ok(LegacySkillDocument {
+            body: raw_content.clone(),
+            frontmatter: None,
+            parse_warning: None,
+            raw_content,
+        });
+    };
+
+    let frontmatter_text = captures.get(1).map(|capture| capture.as_str()).ok_or_else(|| {
+        anyhow::anyhow!("Failed to extract YAML frontmatter from {}", path.display())
+    })?;
+    let body = captures.get(2).map(|capture| capture.as_str().to_string()).ok_or_else(|| {
+        anyhow::anyhow!("Failed to extract Markdown body from {}", path.display())
+    })?;
+
+    let frontmatter = match serde_yaml::from_str::<YamlMapping>(frontmatter_text) {
+        Ok(parsed) => Some(parsed),
+        Err(error) => {
+            return Ok(LegacySkillDocument {
+                raw_content: raw_content.clone(),
+                frontmatter: None,
+                body: raw_content,
+                parse_warning: Some(format!(
+                    "Legacy skill {} has invalid YAML frontmatter and will be treated as raw Markdown: {}",
+                    path.display(),
+                    error
+                )),
+            });
+        },
+    };
+
+    Ok(LegacySkillDocument { raw_content, frontmatter, body, parse_warning: None })
+}
+
+fn extract_name_and_description(frontmatter: &YamlMapping) -> Option<(String, String)> {
+    let name = frontmatter
+        .get(YamlValue::String("name".to_string()))
+        .and_then(YamlValue::as_str)?;
+    let description = frontmatter
+        .get(YamlValue::String("description".to_string()))
+        .and_then(YamlValue::as_str)?;
+
+    Some((name.to_string(), description.to_string()))
+}
+
+fn frontmatter_contains_any(frontmatter: &YamlMapping, keys: &[&str]) -> bool {
+    keys.iter()
+        .any(|key| frontmatter.contains_key(YamlValue::String((*key).to_string())))
+}
+
+fn render_claude_family_skill_markdown(
+    name: &str,
+    description: &str,
+    instructions: &str,
+    target_overlay: &SkillTargetOverlay,
+) -> Result<String> {
+    let mut frontmatter = YamlMapping::new();
+    frontmatter.insert(yaml_key("name"), YamlValue::String(name.to_string()));
+    frontmatter.insert(yaml_key("description"), YamlValue::String(description.to_string()));
+
+    let disable_model_invocation = target_overlay.disable_model_invocation.or_else(|| {
+        target_overlay
+            .invocation
+            .map(|mode| matches!(mode, SkillInvocationMode::Manual))
+    });
+    insert_optional_yaml_value(
+        &mut frontmatter,
+        "disable-model-invocation",
+        disable_model_invocation.map(YamlValue::Bool),
+    );
+    insert_optional_yaml_value(
+        &mut frontmatter,
+        "user-invocable",
+        target_overlay.user_invocable.map(YamlValue::Bool),
+    );
+    insert_optional_yaml_value(
+        &mut frontmatter,
+        "allowed-tools",
+        target_overlay
+            .allowed_tools
+            .as_ref()
+            .map(|value| serde_yaml::to_value(value).expect("allowed tools should serialize")),
+    );
+    insert_optional_yaml_value(&mut frontmatter, "arguments", target_overlay.arguments.clone());
+    insert_optional_yaml_value(
+        &mut frontmatter,
+        "argument-hint",
+        target_overlay.argument_hint.clone().map(YamlValue::String),
+    );
+    insert_optional_yaml_value(&mut frontmatter, "context", target_overlay.context.clone());
+    insert_optional_yaml_value(
+        &mut frontmatter,
+        "agent",
+        target_overlay.agent.clone().map(YamlValue::String),
+    );
+
+    render_markdown_with_frontmatter(&frontmatter, instructions)
+}
+
+fn render_codex_skill_markdown(
+    name: &str,
+    description: &str,
+    instructions: &str,
+) -> Result<String> {
+    let mut frontmatter = YamlMapping::new();
+    frontmatter.insert(yaml_key("name"), YamlValue::String(name.to_string()));
+    frontmatter.insert(yaml_key("description"), YamlValue::String(description.to_string()));
+    render_markdown_with_frontmatter(&frontmatter, instructions)
+}
+
+fn render_codex_openai_yaml(target_overlay: &SkillTargetOverlay) -> Result<Option<String>> {
+    let mut document = YamlMapping::new();
+
+    if let Some(interface) = &target_overlay.interface {
+        document.insert(yaml_key("interface"), interface.clone());
+    }
+    if let Some(dependencies) = &target_overlay.dependencies {
+        document.insert(yaml_key("dependencies"), dependencies.clone());
+    }
+
+    if let Some(invocation) = target_overlay.invocation {
+        let mut policy = YamlMapping::new();
+        policy.insert(
+            yaml_key("allow_implicit_invocation"),
+            YamlValue::Bool(matches!(invocation, SkillInvocationMode::Auto)),
+        );
+        document.insert(yaml_key("policy"), YamlValue::Mapping(policy));
+    }
+
+    if document.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(serialize_yaml_document(&YamlValue::Mapping(document))?))
+}
+
+fn render_codex_openai_yaml_from_legacy(frontmatter: &YamlMapping) -> Result<Option<String>> {
+    let disable_model_invocation = frontmatter
+        .get(YamlValue::String("disable-model-invocation".to_string()))
+        .and_then(YamlValue::as_bool);
+
+    if disable_model_invocation != Some(true) {
+        return Ok(None);
+    }
+
+    let mut policy = YamlMapping::new();
+    policy.insert(yaml_key("allow_implicit_invocation"), YamlValue::Bool(false));
+
+    let mut document = YamlMapping::new();
+    document.insert(yaml_key("policy"), YamlValue::Mapping(policy));
+    Ok(Some(serialize_yaml_document(&YamlValue::Mapping(document))?))
+}
+
+fn render_markdown_with_frontmatter(frontmatter: &YamlMapping, body: &str) -> Result<String> {
+    let serialized = serialize_yaml_document(&YamlValue::Mapping(frontmatter.clone()))?;
+    let trimmed_body = body.trim_end();
+
+    if trimmed_body.is_empty() {
+        return Ok(format!("---\n{serialized}---\n"));
+    }
+
+    Ok(format!("---\n{serialized}---\n\n{trimmed_body}\n"))
+}
+
+fn serialize_yaml_document(value: &YamlValue) -> Result<String> {
+    let serialized = serde_yaml::to_string(value).context("Failed to serialize YAML")?;
+    Ok(serialized.strip_prefix("---\n").unwrap_or(&serialized).to_string())
+}
+
+fn yaml_key(name: &str) -> YamlValue {
+    YamlValue::String(name.to_string())
+}
+
+fn insert_optional_yaml_value(mapping: &mut YamlMapping, key: &str, value: Option<YamlValue>) {
+    if let Some(value) = value {
+        mapping.insert(yaml_key(key), value);
+    }
+}
+
+fn collect_canonical_resource_mappings(
+    skill_root: &Path,
+    skill_name: &str,
+) -> Result<Vec<SourceFileMapping>> {
+    let mut mappings = Vec::new();
+
+    for dir_name in SKILL_RESOURCE_DIRS {
+        let path = skill_root.join(dir_name);
+        if !path.exists() {
+            continue;
+        }
+
+        let nested = asset_sync::collect_directory_tree_mappings(&path)?;
+        mappings.extend(nested.into_iter().map(|mapping| SourceFileMapping {
+            source_path: mapping.source_path,
+            relative_path: normalize_skill_relative_path(
+                skill_name,
+                &format!("{dir_name}/{}", mapping.relative_path),
+            ),
+        }));
+    }
+
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+fn collect_legacy_directory_resource_mappings(
+    skill_root: &Path,
+    skill_name: &str,
+    excluded_relative_paths: &BTreeSet<String>,
+) -> Result<Vec<SourceFileMapping>> {
+    let mappings = asset_sync::collect_directory_tree_mappings(skill_root)?
+        .into_iter()
+        .filter(|mapping| !excluded_relative_paths.contains(&mapping.relative_path))
+        .map(|mapping| SourceFileMapping {
+            source_path: mapping.source_path,
+            relative_path: normalize_skill_relative_path(skill_name, &mapping.relative_path),
+        })
+        .collect::<Vec<_>>();
+
+    Ok(mappings)
+}
+
+fn materialize_rendered_bundle(
+    bundle: &RenderedSkillBundle,
+    render_workspace: &Path,
+) -> Result<Vec<SourceFileMapping>> {
+    let skill_workspace = render_workspace.join(&bundle.name);
+    fs::create_dir_all(&skill_workspace).with_context(|| {
+        format!("Failed to create render workspace {}", skill_workspace.display())
+    })?;
+
+    let mut mappings = bundle.resource_mappings.clone();
+    for generated_file in &bundle.generated_files {
+        let generated_path = skill_workspace.join(&generated_file.relative_path);
+        if let Some(parent) = generated_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        fs::write(&generated_path, &generated_file.content)
+            .with_context(|| format!("Failed to write {}", generated_path.display()))?;
+        mappings.push(SourceFileMapping {
+            source_path: generated_path,
+            relative_path: normalize_skill_relative_path(
+                &bundle.name,
+                &generated_file.relative_path,
+            ),
+        });
+    }
+
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(mappings)
+}
+
+fn target_name_label(target: SkillTargetName) -> &'static str {
+    match target {
+        SkillTargetName::Claude => "claude",
+        SkillTargetName::ClaudeCode => "claude-code",
+        SkillTargetName::Codex => "codex",
+        SkillTargetName::Gemini => "gemini",
+    }
 }
 
 /// List all skills in a directory.
@@ -213,25 +1066,38 @@ pub fn collect_claudius_skill_source_set(
 ) -> Result<SkillSourceSet> {
     let skills_root = config_dir.join("skills");
     let commands_root = config_dir.join("commands");
-    let legacy_mappings = collect_legacy_command_mappings(&commands_root)?;
-    let includes_legacy_commands = !legacy_mappings.is_empty();
-    let shared_mappings = collect_shared_skill_mappings(&skills_root)?;
-    let agent_mappings = agent.map_or_else(
-        || Ok(Vec::new()),
-        |selected| collect_agent_skill_mappings(&skills_root, selected),
-    )?;
+    let render_agent = effective_render_agent(agent);
+    let (candidates, includes_legacy_commands) =
+        discover_skill_candidates(&skills_root, &commands_root, agent)?;
+    let render_workspace = TempDir::new().context("Failed to create temporary skill render dir")?;
+    let mut warnings = BTreeSet::new();
 
-    let mut merged = BTreeMap::<String, Vec<SourceFileMapping>>::new();
-    extend_skill_groups(&mut merged, legacy_mappings);
-    extend_skill_groups(&mut merged, shared_mappings);
-    extend_skill_groups(&mut merged, agent_mappings);
+    let mut mappings = Vec::new();
+    for candidate in &candidates {
+        if candidate.origin == SkillSourceOrigin::AgentOverride {
+            warnings.insert(format!(
+                "Deprecated full agent override directory detected for skill `{}` under skills/{}/{}; prefer canonical target overlays in skill.yaml.",
+                candidate.name,
+                agent_skill_subdir(render_agent),
+                candidate.name,
+            ));
+        }
 
-    let mappings = merged
-        .into_values()
-        .flat_map(std::iter::IntoIterator::into_iter)
-        .collect::<Vec<_>>();
+        mappings.extend(render_candidate_to_mappings(
+            candidate,
+            render_agent,
+            render_workspace.path(),
+            &mut warnings,
+        )?);
+    }
 
-    Ok(SkillSourceSet { mappings, includes_legacy_commands })
+    mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(SkillSourceSet {
+        mappings,
+        includes_legacy_commands,
+        warnings: warnings.into_iter().collect(),
+        _render_workspace: Some(render_workspace),
+    })
 }
 
 /// Collect mappings for shared skills in `skills/`, excluding agent-specific
@@ -345,27 +1211,6 @@ fn skill_names_from_mappings(mappings: &[SourceFileMapping]) -> Vec<String> {
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
-}
-
-fn extend_skill_groups(
-    groups: &mut BTreeMap<String, Vec<SourceFileMapping>>,
-    mappings: Vec<SourceFileMapping>,
-) {
-    let mut grouped = BTreeMap::<String, Vec<SourceFileMapping>>::new();
-    for mapping in mappings {
-        let skill_name = mapping
-            .relative_path
-            .split('/')
-            .next()
-            .expect("skill mappings always contain a top-level directory")
-            .to_string();
-        grouped.entry(skill_name).or_default().push(mapping);
-    }
-
-    for (skill_name, mut group_mappings) in grouped {
-        group_mappings.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
-        groups.insert(skill_name, group_mappings);
-    }
 }
 
 fn agent_skill_subdir(agent: Agent) -> &'static str {
@@ -547,6 +1392,79 @@ mod tests {
             fs::read_to_string(&first_mapping.source_path).expect("source should read"),
             "# Agent"
         );
+    }
+
+    #[test]
+    fn test_collect_claudius_skill_source_set_renders_canonical_codex_bundle() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let config_dir = temp_dir.path().join("claudius");
+        let skill_dir = config_dir.join("skills").join("setup-commitlint");
+
+        fs::create_dir_all(skill_dir.join("scripts")).expect("Failed to create skill scripts dir");
+        fs::write(
+            skill_dir.join(CANONICAL_SKILL_FILE_NAME),
+            "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n",
+        )
+        .expect("Failed to write skill.yaml");
+        fs::write(
+            skill_dir.join(DEFAULT_CANONICAL_INSTRUCTIONS_FILE),
+            "Set up commitlint in the current repository.\n",
+        )
+        .expect("Failed to write instructions");
+        fs::write(skill_dir.join("scripts").join("setup.sh"), "#!/usr/bin/env bash\necho setup\n")
+            .expect("Failed to write script");
+
+        let source_set = collect_claudius_skill_source_set(&config_dir, Some(Agent::Codex))
+            .expect("canonical codex source set should render");
+        let relative_paths = source_set
+            .mappings
+            .iter()
+            .map(|mapping| mapping.relative_path.clone())
+            .collect::<Vec<_>>();
+
+        assert!(relative_paths.contains(&"setup-commitlint/SKILL.md".to_string()));
+        assert!(relative_paths.contains(&"setup-commitlint/agents/openai.yaml".to_string()));
+        assert!(relative_paths.contains(&"setup-commitlint/scripts/setup.sh".to_string()));
+
+        let skill_mapping = source_set
+            .mappings
+            .iter()
+            .find(|mapping| mapping.relative_path == "setup-commitlint/SKILL.md")
+            .expect("SKILL.md mapping should exist");
+        let skill_content =
+            fs::read_to_string(&skill_mapping.source_path).expect("Rendered SKILL.md should read");
+        assert!(skill_content.contains("name: setup-commitlint"));
+        assert!(skill_content.contains("description: Set up commitlint."));
+        assert!(!skill_content.contains("display_name"));
+
+        let openai_mapping = source_set
+            .mappings
+            .iter()
+            .find(|mapping| mapping.relative_path == "setup-commitlint/agents/openai.yaml")
+            .expect("openai.yaml mapping should exist");
+        let openai_content = fs::read_to_string(&openai_mapping.source_path)
+            .expect("Rendered openai.yaml should read");
+        assert!(openai_content.contains("display_name: Commitlint Setup"));
+        assert!(openai_content.contains("allow_implicit_invocation: false"));
+    }
+
+    #[test]
+    fn test_collect_claudius_skill_source_set_rejects_mixed_canonical_and_legacy_dir() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let config_dir = temp_dir.path().join("claudius");
+        let skill_dir = config_dir.join("skills").join("mixed-skill");
+
+        fs::create_dir_all(&skill_dir).expect("Failed to create skill dir");
+        fs::write(skill_dir.join(SKILL_FILE_NAME), "# Legacy").expect("Failed to write legacy");
+        fs::write(
+            skill_dir.join(CANONICAL_SKILL_FILE_NAME),
+            "version: 1\nname: mixed-skill\ndescription: Mixed\n",
+        )
+        .expect("Failed to write canonical");
+
+        let error = collect_claudius_skill_source_set(&config_dir, Some(Agent::ClaudeCode))
+            .expect_err("mixed skill dir should be rejected");
+        assert!(error.to_string().contains("contains both skill.yaml and SKILL.md"));
     }
 
     #[test]

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -1594,6 +1594,9 @@ fn collect_skill_source_set(config: &Config) -> Option<skills::SkillSourceSet> {
 
 fn log_skill_source_details(config: &Config, source_set: &skills::SkillSourceSet) {
     if !source_set.includes_legacy_commands {
+        for warning in &source_set.warnings {
+            warn!("{warning}");
+        }
         return;
     }
 
@@ -1605,6 +1608,10 @@ fn log_skill_source_details(config: &Config, source_set: &skills::SkillSourceSet
         Err(e) => {
             warn!("Legacy commands directory detected but config root is unavailable: {e}");
         },
+    }
+
+    for warning in &source_set.warnings {
+        warn!("{warning}");
     }
 }
 

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -85,6 +85,35 @@ impl TestFixture {
         Ok(self)
     }
 
+    /// Create a canonical skill with `skill.yaml` and `instructions.md`.
+    pub fn with_canonical_skill(
+        &self,
+        name: &str,
+        skill_yaml: &str,
+        instructions: &str,
+    ) -> std::io::Result<&Self> {
+        let skill_path = self.config.join("skills").join(name);
+        fs::create_dir_all(&skill_path)?;
+        fs::write(skill_path.join("skill.yaml"), skill_yaml)?;
+        fs::write(skill_path.join("instructions.md"), instructions)?;
+        Ok(self)
+    }
+
+    /// Write an arbitrary file under a skill directory.
+    pub fn with_skill_file(
+        &self,
+        name: &str,
+        relative_path: &str,
+        content: &str,
+    ) -> std::io::Result<&Self> {
+        let path = self.config.join("skills").join(name).join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(path, content)?;
+        Ok(self)
+    }
+
     /// Create an agent-specific skill directory with SKILL.md.
     pub fn with_agent_skill(
         &self,

--- a/tests/integration/agent_assets_test.rs
+++ b/tests/integration/agent_assets_test.rs
@@ -127,6 +127,32 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_sync_gemini_warns_on_deprecated_agent_skill_overrides() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_gemini_settings(r#"{"general":{"preferredEditor":"code"}}"#)
+            .unwrap();
+        fixture.with_agent_skill("gemini", "gemini-skill", "# Gemini Skill").unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["config", "sync", "--agent", "gemini"])
+            .assert()
+            .success()
+            .stderr(predicate::str::contains(
+                "Deprecated full agent override directory detected for skill `gemini-skill` under skills/gemini/gemini-skill; prefer canonical target overlays in skill.yaml.",
+            ));
+
+        assert!(fixture.project_file_exists(".gemini/skills/gemini-skill/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_sync_claude_code_syncs_subagents() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();

--- a/tests/integration/agent_assets_test.rs
+++ b/tests/integration/agent_assets_test.rs
@@ -145,7 +145,7 @@ mod tests {
             .assert()
             .success()
             .stderr(predicate::str::contains(
-                "Deprecated full agent override directory detected for skill `gemini-skill` under skills/gemini/gemini-skill; prefer canonical target overlays in skill.yaml.",
+                "Deprecated full agent override directory detected for skill `gemini-skill` under skills/gemini/gemini-skill; prefer canonical target overlays in skill.yaml and migrate it with `claudius skills migrate`.",
             ));
 
         assert!(fixture.project_file_exists(".gemini/skills/gemini-skill/SKILL.md"));

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -232,6 +232,6 @@ mod tests {
                 "Shared legacy skill contains Claude-specific metadata that Codex rendering will drop.",
             ))
             .stdout(predicate::str::contains("shared-review"))
-            .stdout(predicate::str::contains("Migrate these overrides into shared skill.yaml target overlays"));
+            .stdout(predicate::str::contains("Run `claudius skills migrate` for these overrides"));
     }
 }

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -196,4 +196,42 @@ mod tests {
             .stdout(predicate::str::contains("Codex-specific skills source is present."))
             .stdout(predicate::str::contains("EXPERIMENTAL").not());
     }
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_reports_skill_renderer_migration_warnings() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_skill(
+                "shared-review",
+                "---\nname: shared-review\ndescription: Review code changes.\ndisable-model-invocation: true\n---\n\nReview code changes.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "codex",
+                "codex-only",
+                "---\nname: codex-only\ndescription: Codex-specific override.\n---\n\nUse Codex-specific instructions.\n",
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Codex full override skill directories are still in use.",
+            ))
+            .stdout(predicate::str::contains(
+                "Shared legacy skill contains Claude-specific metadata that Codex rendering will drop.",
+            ))
+            .stdout(predicate::str::contains("shared-review"))
+            .stdout(predicate::str::contains("Migrate these overrides into shared skill.yaml target overlays"));
+    }
 }

--- a/tests/integration/init_test.rs
+++ b/tests/integration/init_test.rs
@@ -71,7 +71,8 @@ mod tests {
         assert!(config_dir.join("gemini.system_defaults.json").exists());
         assert!(config_dir.join("settings.json").exists());
         assert!(config_dir.join("skills").exists());
-        assert!(config_dir.join("skills/example/SKILL.md").exists());
+        assert!(config_dir.join("skills/example/skill.yaml").exists());
+        assert!(config_dir.join("skills/example/instructions.md").exists());
         assert!(config_dir.join("commands/gemini").exists());
         assert!(config_dir.join("agents/gemini").exists());
         assert!(config_dir.join("agents/claude-code").exists());

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -409,7 +409,7 @@ mod tests {
                 "Legacy shared skill `shared-review` contains Claude-specific metadata that will be dropped when rendering for Codex.",
             ))
             .stdout(predicate::str::contains(
-                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml.",
+                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml and migrate it with `claudius skills migrate`.",
             ));
     }
 
@@ -436,7 +436,7 @@ mod tests {
             .assert()
             .success()
             .stdout(predicate::str::contains(
-                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml.",
+                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml and migrate it with `claudius skills migrate`.",
             ));
 
         assert!(fixture.project_file_exists(".agents/skills/codex-only/SKILL.md"));
@@ -474,6 +474,181 @@ mod tests {
             .stdout(predicate::str::contains(
                 "Canonical skill `setup-review` contains unsupported targets entry `targets/codex.yaml`",
             ));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_renders_target_body_override() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\n",
+                "Shared review instructions.\n",
+            )
+            .unwrap();
+        fixture
+            .with_skill_file(
+                "setup-review",
+                "targets/claude-code.md",
+                "Claude Code specific review instructions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "claude-code"])
+            .assert()
+            .success();
+
+        let skill_content =
+            fixture.read_project_file(".claude/skills/setup-review/SKILL.md").unwrap();
+        assert!(skill_content.contains("Claude Code specific review instructions."));
+        assert!(!skill_content.contains("Shared review instructions."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_migrate_converts_deprecated_override_to_canonical_overlay() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\n",
+                "Shared review instructions.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "claude-code",
+                "setup-review",
+                "---\nname: setup-review\ndescription: Review the repository.\ndisable-model-invocation: true\nargument-hint: '[scope]'\n---\n\nClaude Code specific review instructions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut migrate = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        migrate
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "migrate", "--agent", "claude-code"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Migrated 1 deprecated full override skill director"))
+            .stdout(predicate::str::contains("skills/claude-code/setup-review"));
+
+        let skill_yaml = fs::read_to_string(
+            fixture.config.join("skills").join("setup-review").join("skill.yaml"),
+        )
+        .unwrap();
+        assert!(skill_yaml.contains("claude-code:"));
+        assert!(skill_yaml.contains("disable-model-invocation: true"));
+        assert!(skill_yaml.contains("argument-hint: '[scope]'"));
+
+        let target_body = fs::read_to_string(
+            fixture
+                .config
+                .join("skills")
+                .join("setup-review")
+                .join("targets")
+                .join("claude-code.md"),
+        )
+        .unwrap();
+        assert_eq!(target_body, "Claude Code specific review instructions.\n");
+        assert!(!fixture.config.join("skills").join("claude-code").join("setup-review").exists());
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "claude-code"])
+            .assert()
+            .success();
+
+        let rendered = fixture.read_project_file(".claude/skills/setup-review/SKILL.md").unwrap();
+        assert!(rendered.contains("disable-model-invocation: true"));
+        assert!(rendered.contains("argument-hint: '[scope]'"));
+        assert!(rendered.contains("Claude Code specific review instructions."));
+        assert!(!rendered.contains("Shared review instructions."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_migrate_dry_run_leaves_override_tree_untouched() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\n",
+                "Shared review instructions.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "claude-code",
+                "setup-review",
+                "---\nname: setup-review\ndescription: Review the repository.\ndisable-model-invocation: true\n---\n\nClaude Code specific review instructions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "migrate", "--agent", "claude-code", "--dry-run"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Dry-run: would migrate 1 deprecated full override"));
+
+        assert!(fixture.config.join("skills").join("claude-code").join("setup-review").exists());
+        assert!(!fixture
+            .config
+            .join("skills")
+            .join("setup-review")
+            .join("targets")
+            .join("claude-code.md")
+            .exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_migrate_rejects_legacy_shared_skill() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_skill(
+                "setup-review",
+                "---\nname: setup-review\ndescription: Review the repository.\n---\n\nShared review instructions.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "claude-code",
+                "setup-review",
+                "---\nname: setup-review\ndescription: Review the repository.\ndisable-model-invocation: true\n---\n\nClaude Code specific review instructions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "migrate", "--agent", "claude-code"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Shared skill `setup-review` is still legacy"));
     }
 
     #[test]

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -415,6 +415,35 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_skills_sync_warns_on_deprecated_agent_overrides() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_agent_skill(
+                "codex",
+                "codex-only",
+                "---\nname: codex-only\ndescription: Codex override.\n---\n\nCodex-specific override.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml.",
+            ));
+
+        assert!(fixture.project_file_exists(".agents/skills/codex-only/SKILL.md"));
+    }
+
+    #[test]
+    #[serial]
     fn test_skills_validate_warns_on_unsupported_canonical_entries() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -415,6 +415,40 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_skills_validate_warns_on_unsupported_canonical_entries() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\n",
+                "Review the repository and summarize the findings.\n",
+            )
+            .unwrap();
+        fixture.with_skill_file("setup-review", "notes.txt", "ignored").unwrap();
+        fixture
+            .with_skill_file("setup-review", "targets/codex.yaml", "invocation: manual\n")
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "validate"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Canonical skill `setup-review` contains unsupported top-level entry `notes.txt`",
+            ))
+            .stdout(predicate::str::contains(
+                "Canonical skill `setup-review` contains unsupported targets entry `targets/codex.yaml`",
+            ));
+    }
+
+    #[test]
+    #[serial]
     fn test_skills_only_mode_project_local() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -252,6 +252,169 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_skills_sync_codex_filters_claude_specific_legacy_frontmatter() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_skill(
+                "review",
+                "---\nname: review\ndescription: Review the current diff.\ndisable-model-invocation: true\nargument-hint: \"[scope]\"\nallowed-tools:\n  - Bash(git status)\n---\n\nReview the current diff and flag regressions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "contains Claude-specific metadata that will be dropped when rendering for Codex",
+            ));
+
+        let skill_content = fixture.read_project_file(".agents/skills/review/SKILL.md").unwrap();
+        assert!(skill_content.contains("name: review"));
+        assert!(skill_content.contains("description: Review the current diff."));
+        assert!(!skill_content.contains("disable-model-invocation"));
+        assert!(!skill_content.contains("argument-hint"));
+        assert!(!skill_content.contains("allowed-tools"));
+
+        let openai_yaml =
+            fixture.read_project_file(".agents/skills/review/agents/openai.yaml").unwrap();
+        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_render_canonical_codex_outputs_openai_yaml_and_resources() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-commitlint",
+                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint for the current repository.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n    dependencies:\n      tools:\n        - type: mcp\n          value: openaiDeveloperDocs\n",
+                "Set up commitlint and wire it into git hooks.\n",
+            )
+            .unwrap();
+        fixture
+            .with_skill_file(
+                "setup-commitlint",
+                "scripts/setup.sh",
+                "#!/usr/bin/env bash\necho setup\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let output_dir = fixture.temp.path().join("rendered-skills");
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args([
+                "skills",
+                "render",
+                "--agent",
+                "codex",
+                "--output",
+                output_dir.to_str().unwrap(),
+            ])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Rendered 1 skill(s) for codex"));
+
+        let skill_content =
+            fs::read_to_string(output_dir.join("setup-commitlint").join("SKILL.md")).unwrap();
+        assert!(skill_content.contains("name: setup-commitlint"));
+        assert!(
+            skill_content.contains("description: Set up commitlint for the current repository.")
+        );
+        assert!(!skill_content.contains("display_name"));
+
+        let openai_yaml = fs::read_to_string(
+            output_dir.join("setup-commitlint").join("agents").join("openai.yaml"),
+        )
+        .unwrap();
+        assert!(openai_yaml.contains("display_name: Commitlint Setup"));
+        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
+        assert!(openai_yaml.contains("openaiDeveloperDocs"));
+        assert!(output_dir.join("setup-commitlint").join("scripts").join("setup.sh").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_sync_canonical_claude_code_outputs_rich_frontmatter() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-git-hooks",
+                "version: 1\nname: setup-git-hooks\ndescription: Install repository git hooks.\ntargets:\n  claude-code:\n    invocation: manual\n    argument-hint: \"[hook-name]\"\n    allowed-tools:\n      - Bash(git config core.hooksPath .githooks)\n",
+                "Install and verify project-local git hooks.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "claude-code"])
+            .assert()
+            .success();
+
+        let skill_content =
+            fixture.read_project_file(".claude/skills/setup-git-hooks/SKILL.md").unwrap();
+        assert!(skill_content.contains("name: setup-git-hooks"));
+        assert!(skill_content.contains("description: Install repository git hooks."));
+        assert!(skill_content.contains("disable-model-invocation: true"));
+        assert!(skill_content.contains("argument-hint: '[hook-name]'"));
+        assert!(skill_content.contains("allowed-tools:"));
+        assert!(skill_content.contains("Install and verify project-local git hooks."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_validate_reports_legacy_leakage_and_deprecated_agent_overrides() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_skill(
+                "shared-review",
+                "---\nname: shared-review\ndescription: Review changes.\ndisable-model-invocation: true\n---\n\nReview changes.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "codex",
+                "codex-only",
+                "---\nname: codex-only\ndescription: Codex override.\n---\n\nCodex-specific override.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "validate"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Legacy shared skill `shared-review` contains Claude-specific metadata that will be dropped when rendering for Codex.",
+            ))
+            .stdout(predicate::str::contains(
+                "Deprecated full agent override directory detected for skill `codex-only` under skills/codex/codex-only; prefer canonical target overlays in skill.yaml.",
+            ));
+    }
+
+    #[test]
+    #[serial]
     fn test_skills_only_mode_project_local() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -56,6 +56,59 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_validate_includes_skill_renderer_warnings() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_skill(
+                "shared-review",
+                "---\nname: shared-review\ndescription: Review changes.\ndisable-model-invocation: true\n---\n\nReview changes.\n",
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Legacy shared skill `shared-review` contains Claude-specific metadata that will be dropped when rendering for Codex.",
+            ));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_strict_fails_on_skill_renderer_warnings() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_skill(
+                "shared-review",
+                "---\nname: shared-review\ndescription: Review changes.\ndisable-model-invocation: true\n---\n\nReview changes.\n",
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "codex", "--strict"])
+            .assert()
+            .failure()
+            .stdout(predicate::str::contains(
+                "Legacy shared skill `shared-review` contains Claude-specific metadata that will be dropped when rendering for Codex.",
+            ))
+            .stderr(predicate::str::contains("Validation failed due to warnings (--strict)"));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_validate_codex_managed_config_is_supported() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();


### PR DESCRIPTION
## Summary
- add the canonical skill renderer pipeline for Claude, Claude Code, Codex, and Gemini
- introduce canonical `skill.yaml` skills, renderer validation, and stronger doctor warnings for metadata leakage and deprecated full overrides
- add `claudius skills migrate` plus `targets/<agent>.md` support so deprecated full override trees can be migrated into canonical overlays
- update bootstrap templates, docs, and integration coverage for the full Phase 1-5 rollout

## Testing
- `nix develop -c cargo fmt --all`
- `nix develop -c cargo check`
- `nix develop -c cargo test -- --test-threads=1`