### PR TITLE
fix(context): align managed rule references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Context install documentation, CLI help, and status messages now consistently describe managed rule reference sections instead of legacy include-style directives
+
 ## [0.2.1] - 2026-05-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,24 @@ Deprecated full override directories under `skills/<agent>/<skill>/` still deplo
 compatibility, but Claudius warns on every sync and recommends canonical target overlays
 in `skill.yaml`. Use `claudius skills migrate` to convert supported overrides automatically.
 
+### `claudius skills validate`
+Validate canonical and legacy skills without deploying them.
+
+This command loads shared, legacy, and agent-specific skill sources, validates
+canonical `skill.yaml` definitions, renders the selected agent view, and warns
+about deprecated override directories or metadata that will be dropped.
+
+```bash
+# Validate every supported render target
+claudius skills validate
+
+# Validate only the Codex view
+claudius skills validate --agent codex
+
+# Treat warnings as errors
+claudius skills validate --strict
+```
+
 ### `claudius skills migrate`
 Convert deprecated full override directories under `skills/<agent>/<skill>/` into canonical
 shared skill targets.
@@ -282,27 +300,48 @@ claudius skills migrate --agent claude-code
 claudius skills migrate --dry-run
 ```
 
+### `claudius skills render`
+Render skills for an agent into an output directory without touching native
+agent locations.
+
+```bash
+# Inspect rendered Claude Code skills
+claudius skills render --agent claude-code --output /tmp/claude-skills
+
+# Render Codex skills and prune stale generated files in the output directory
+claudius skills render --agent codex --output /tmp/codex-skills --prune
+```
+
 ### `claudius context append`
-Append rules or templates to CLAUDE.md.
+Append instructions or rules to the agent's context file (CLAUDE.md for
+Claude/Claude Code, GEMINI.md for Gemini, AGENTS.md for Codex).
 
 ```bash
 # Use predefined rule
 claudius context append security
 
 # Specify target directory
-claudius context append testing /path/to/project
+claudius context append testing --path /path/to/project
 
 # Use custom template
-claudius context append dummy . --template-path ./my-template.md
+claudius context append --template-path ./my-template.md
+
+# Append to the global context file in $HOME
+claudius context append security --global
+
+# Use specific agent
+claudius context append security --agent codex
+claudius context append testing --agent gemini
 ```
 
 ### `claudius context install`
-Install context rules to project-local .agents/rules directory with automatic reference directive.
+Install context rules to project-local `.agents/rules` with an automatic managed
+reference section in the agent context file.
 
 This command:
 - Copies specified rules from your rules directory to ./.agents/rules/ (default)
-- Adds a reference directive to CLAUDE.md/AGENTS.md to include all rules
-- The directive is idempotent - it won't be added if already present
+- Adds or updates a managed reference section in the context file
+- The managed section is idempotent - it won't be added twice
 - Supports subdirectories and preserves directory structure
 
 ```bash
@@ -322,11 +361,27 @@ claudius context install security --install-dir ./.claude/rules
 claudius context install security --agent gemini
 ```
 
-The reference directive added to CLAUDE.md/AGENTS.md looks like:
+The managed section added to the context file looks like:
 ```markdown
 # External Rule References
-The following rules are included from the .agents/rules directory:
-{include:.agents/rules/**/*.md}
+
+The following rules from `.agents/rules` are installed:
+
+- `.agents/rules/security.md`: security
+- `.agents/rules/testing.md`: testing
+
+Read these files to understand the project conventions and guidelines.
+```
+
+### `claudius context list`
+List available rules and templates in the rules directory.
+
+```bash
+# Simple list
+claudius context list
+
+# Show nested directories as a tree
+claudius context list --tree
 ```
 
 ### `claudius secrets run`
@@ -681,7 +736,7 @@ cargo build --profile=profiling --features=profiling
 3. **Build and Run**
    ```bash
    cargo build
-   cargo run -- sync --dry-run
+   cargo run -- config sync --dry-run
    ```
 
 4. **Code Quality**
@@ -745,35 +800,12 @@ claudius/
 4. **Versionable**: All configs in version-control-friendly formats
 5. **Linux and macOS**: Designed for Unix-like operating systems
 
-## Current Status & Roadmap
+## Release Tracking
 
-### Current Features (v0.1.0)
-- **Configuration Management**: MCP servers, settings, skills
-- **Multi-Project Support**: Project-local and global configurations
-- **Template System**: CLAUDE.md rules and custom templates
-- **Backup & Safety**: Dry-run mode, optional backups
-- **CLI Interface**: Intuitive subcommand structure with rich help
-- **Secret Management**: Integration with 1Password with inline op:// reference support
-- **Secure Execution**: Run commands with automatic secret resolution
-- **Variable Expansion**: DAG-based nested environment variable resolution
-- **Inline Secret References**: Support for {{op://...}} syntax within URLs and strings
-
-### Roadmap
-
-#### Near-term (v0.2.0)
-- Configuration validation
-- HashiCorp Vault integration
-- More comprehensive error recovery
-
-#### Mid-term (v0.3.0)
-- Configuration profiles
-- Rollback functionality
-- Import/export features
-
-#### Long-term
-- Web UI for configuration management
-- Plugin system for extensibility
-- Cloud synchronization support
+Release history and user-facing feature deltas live in [CHANGELOG.md](./CHANGELOG.md)
+and GitHub Releases. Keep this file focused on architecture, contributor
+workflow, and implementation detail rather than duplicating version-specific
+release notes here.
 
 ## Important Considerations
 
@@ -824,12 +856,6 @@ When contributing to Claudius:
 - Backups are optional but recommended
 - Project-local configurations take precedence over global ones
 - All configuration files are human-readable and editable
-
-## Version History
-
-| Version | Release Date | Description |
-|---------|-------------|-------------|
-| v0.1.0 | 2025-06-29 | Initial development release with comprehensive Claude configuration management |
 
 ## Code Style and Linting
 
@@ -1094,7 +1120,7 @@ just --list
 
 ```bash
 # Run with arguments
-just run sync --dry-run
+just run config sync --dry-run
 
 # Coverage with options
 just coverage-detailed --format html --min-coverage 90
@@ -1333,7 +1359,3 @@ nix flake update
   - [Unverified] or [Inference], plus a disclaimer that behavior is not guaranteed
 • If you break this rule, say:
   > Correction: I made an unverified claim. That was incorrect.
-
-# External Rule References
-The following rules are included from the .agents/rules directory:
-{include:.agents/rules/**/*.md}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,12 +336,12 @@ claudius context append testing --agent gemini
 
 ### `claudius context install`
 Install context rules to project-local `.agents/rules` with an automatic managed
-reference section in the agent context file.
+rule reference section in the agent context file.
 
 This command:
 - Copies specified rules from your rules directory to ./.agents/rules/ (default)
-- Adds or updates a managed reference section in the context file
-- The managed section is idempotent - it won't be added twice
+- Adds or updates a managed rule reference section in the context file
+- The managed rule reference section is idempotent - it won't be added twice
 - Supports subdirectories and preserves directory structure
 
 ```bash
@@ -361,8 +361,9 @@ claudius context install security --install-dir ./.claude/rules
 claudius context install security --agent gemini
 ```
 
-The managed section added to the context file looks like:
+The managed rule reference section added to the context file looks like:
 ```markdown
+<!-- CLAUDIUS_RULES_START -->
 # External Rule References
 
 The following rules from `.agents/rules` are installed:
@@ -371,6 +372,7 @@ The following rules from `.agents/rules` are installed:
 - `.agents/rules/testing.md`: testing
 
 Read these files to understand the project conventions and guidelines.
+<!-- CLAUDIUS_RULES_END -->
 ```
 
 ### `claudius context list`

--- a/README.md
+++ b/README.md
@@ -374,6 +374,25 @@ claudius skills sync --prune
 claudius skills sync --agent codex
 ```
 
+### `claudius skills validate`
+
+Validate canonical and legacy skills without deploying them.
+
+This command loads shared, legacy, and agent-specific skill sources, validates
+canonical `skill.yaml` definitions, renders the selected agent view, and warns
+about deprecated override directories or metadata that will be dropped.
+
+```bash
+# Validate every supported render target
+claudius skills validate
+
+# Validate only the Codex view
+claudius skills validate --agent codex
+
+# Treat warnings as errors
+claudius skills validate --strict
+```
+
 ### `claudius skills migrate`
 
 Convert deprecated full override directories under `skills/<agent>/<skill>/` into canonical
@@ -396,6 +415,19 @@ claudius skills migrate --agent claude-code
 claudius skills migrate --dry-run
 ```
 
+### `claudius skills render`
+
+Render skills for an agent into an output directory without touching native
+agent locations.
+
+```bash
+# Inspect rendered Claude Code skills
+claudius skills render --agent claude-code --output /tmp/claude-skills
+
+# Render Codex skills and prune stale generated files in the output directory
+claudius skills render --agent codex --output /tmp/codex-skills --prune
+```
+
 
 ### `claudius context append`
 
@@ -411,6 +443,9 @@ claudius context append testing --path /path/to/project
 # Use custom template file
 claudius context append --template-path ./my-template.md
 
+# Append to the global context file in $HOME
+claudius context append security --global
+
 # Use specific agent
 claudius context append security --agent codex
 claudius context append testing --agent gemini
@@ -420,7 +455,10 @@ claudius context append testing --agent gemini
 
 Install context rules to project-local .agents/rules directory.
 
-This command copies rules from your global rules directory to a project-local directory and adds a reference directive to the current agent's context file (CLAUDE.md, GEMINI.md, or AGENTS.md). The directive lists each installed rule explicitly with its file path.
+This command copies rules from your global rules directory to a project-local
+directory and adds a managed reference section to the current agent's context
+file (CLAUDE.md, GEMINI.md, or AGENTS.md). The section lists each installed
+rule explicitly with its file path.
 
 **Key features:**
 - Keeps context files compact while including many rules
@@ -443,6 +481,31 @@ claudius context install security --install-dir ./.claude/rules
 
 # Use specific agent
 claudius context install security --agent gemini
+```
+
+The managed section looks like:
+
+```markdown
+# External Rule References
+
+The following rules from `.agents/rules` are installed:
+
+- `.agents/rules/security.md`: security
+- `.agents/rules/testing.md`: testing
+
+Read these files to understand the project conventions and guidelines.
+```
+
+### `claudius context list`
+
+List available rules and templates in the rules directory.
+
+```bash
+# Simple list
+claudius context list
+
+# Show nested directories as a tree
+claudius context list --tree
 ```
 
 ### `claudius secrets run`
@@ -679,7 +742,7 @@ cat <<'EOF' > ~/.config/claudius/skills/my-skill/instructions.md
 Skill instructions go here.
 EOF
 
-# Skills are synced automatically
+# Sync project-local managed surfaces
 claudius config sync
 ```
 
@@ -722,6 +785,12 @@ When present, `claudius config sync` also deploys:
 - `~/.config/claudius/commands/gemini/*.toml` → `.gemini/commands/` or `~/.gemini/commands/`
 - `~/.config/claudius/agents/gemini/*.md` → `.gemini/agents/` or `~/.gemini/agents/`
 - `~/.config/claudius/agents/claude-code/*.md` → `.claude/agents/` or `~/.claude/agents/`
+
+Skill deployment during `claudius config sync` is intentionally narrower:
+- Claude / Claude Code / Gemini sync skills when the selected scope supports
+  agent-native skill directories
+- Codex skills remain explicit via `claudius skills sync --agent codex`
+- Claude Code managed and local scopes skip automatic skill sync
 
 Gemini extensions are not managed by Claudius. Install and update them through the Gemini CLI
 extension workflow, then keep extension-specific settings in `gemini.settings.json` if needed.
@@ -767,7 +836,7 @@ Claudius offers two ways to manage project context:
    - Best for: Small number of rules, simple projects
    - Result: All content in one file
 
-2. **context install**: Copies rules to `.agents/rules/` with reference directive
+2. **context install**: Copies rules to `.agents/rules/` with a managed reference section
    - Best for: Many rules, complex projects, team collaboration
    - Result: Compact context file + organized rule structure
 
@@ -992,20 +1061,14 @@ For development documentation including:
 
 Please see [CLAUDE.md](./CLAUDE.md).
 
-## Version History
+## Release Tracking
 
-See:
+For release history and user-facing change summaries, use:
 - [GitHub Releases](https://github.com/cariandrum22/claudius/releases)
 - [CHANGELOG.md](./CHANGELOG.md)
 
-Key features introduced in v0.1.0:
-- Multi-agent support (Claude, Codex, Gemini)
-- Secret management with 1Password integration
-- DAG-based variable expansion for nested environment variables
-- Project-local and global configuration modes
-- Context file templates (CLAUDE.md, GEMINI.md, and AGENTS.md)
-- Secure command execution with automatic secret resolution
-- Comprehensive test coverage and Nix flake support
+Avoid treating this README as a second version ledger. The changelog is the
+source of truth for version-by-version release notes.
 
 ## Project Background
 

--- a/README.md
+++ b/README.md
@@ -456,13 +456,14 @@ claudius context append testing --agent gemini
 Install context rules to project-local .agents/rules directory.
 
 This command copies rules from your global rules directory to a project-local
-directory and adds a managed reference section to the current agent's context
-file (CLAUDE.md, GEMINI.md, or AGENTS.md). The section lists each installed
-rule explicitly with its file path.
+directory and adds a managed rule reference section to the current agent's
+context file (CLAUDE.md, GEMINI.md, or AGENTS.md). The section lists each
+installed rule explicitly with its file path.
 
 **Key features:**
 - Keeps context files compact while including many rules
-- Reference directive is idempotent (updates existing section without duplication)
+- Managed rule reference section is idempotent (updates existing section without
+  duplication)
 - Lists specific file paths for each rule
 - Supports subdirectories and preserves directory structure
 
@@ -483,9 +484,10 @@ claudius context install security --install-dir ./.claude/rules
 claudius context install security --agent gemini
 ```
 
-The managed section looks like:
+The managed rule reference section looks like:
 
 ```markdown
+<!-- CLAUDIUS_RULES_START -->
 # External Rule References
 
 The following rules from `.agents/rules` are installed:
@@ -494,6 +496,7 @@ The following rules from `.agents/rules` are installed:
 - `.agents/rules/testing.md`: testing
 
 Read these files to understand the project conventions and guidelines.
+<!-- CLAUDIUS_RULES_END -->
 ```
 
 ### `claudius context list`
@@ -836,7 +839,7 @@ Claudius offers two ways to manage project context:
    - Best for: Small number of rules, simple projects
    - Result: All content in one file
 
-2. **context install**: Copies rules to `.agents/rules/` with a managed reference section
+2. **context install**: Copies rules to `.agents/rules/` with a managed rule reference section
    - Best for: Many rules, complex projects, team collaboration
    - Result: Compact context file + organized rule structure
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,15 +323,15 @@ Examples:
     )]
     Append(AppendContextArgs),
 
-    /// Install rules into project-local directories with include directives
+    /// Install rules into project-local directories with managed reference sections
     #[command(
         name = "install",
         long_about = "Install context rules to project-local .agents/rules directory.
 
 	This command:
 	  • Copies specified rules from your rules directory to ./.agents/rules/ (default)
-	  • Adds a reference directive to the current agent context file to include all rules
-	  • The directive is idempotent - it won't be added if already present
+	  • Adds or updates a managed reference section in the current agent context file
+	  • The managed section is idempotent - it won't be added twice
 
 This approach keeps context files compact while allowing you to include many rules.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,15 +323,15 @@ Examples:
     )]
     Append(AppendContextArgs),
 
-    /// Install rules into project-local directories with managed reference sections
+    /// Install rules into project-local directories with managed rule reference sections
     #[command(
         name = "install",
         long_about = "Install context rules to project-local .agents/rules directory.
 
 	This command:
 	  • Copies specified rules from your rules directory to ./.agents/rules/ (default)
-	  • Adds or updates a managed reference section in the current agent context file
-	  • The managed section is idempotent - it won't be added twice
+	  • Adds or updates a managed rule reference section in the current agent context file
+	  • The managed rule reference section is idempotent - it won't be added twice
 
 This approach keeps context files compact while allowing you to include many rules.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1595,7 +1595,7 @@ fn add_reference_directive(
 
         fs::write(&context_file_path, new_content)
             .with_context(|| format!("Failed to update {}", context_file_path.display()))?;
-        println!("Updated reference directive in {context_filename}");
+        println!("Updated managed rule reference section in {context_filename}");
         return Ok(());
     }
 
@@ -1606,7 +1606,7 @@ fn add_reference_directive(
         .with_context(|| format!("Failed to open {}", context_file_path.display()))?;
 
     file.write_all(reference_directive.as_bytes())?;
-    println!("Added reference directive to {context_filename}");
+    println!("Added managed rule reference section to {context_filename}");
     Ok(())
 }
 
@@ -1746,7 +1746,7 @@ fn run_install_context(
     // Copy specified rules
     let copied_rules = copy_rules(&rules_to_copy, &source_rules_dir, &rules_dir)?;
 
-    // Add reference directive to context file with the list of copied rules
+    // Add the managed rule reference section to the context file.
     add_reference_directive(&target_dir, &rules_dir, &context_filename, &copied_rules)?;
 
     println!("Successfully installed {} rule(s) to {}", copied_rules.len(), rules_dir.display());

--- a/tests/integration/install_context_test.rs
+++ b/tests/integration/install_context_test.rs
@@ -36,7 +36,7 @@ mod tests {
         installed_rule.assert(predicate::path::exists());
         installed_rule.assert(predicate::str::contains("# Test Rule"));
 
-        // Verify reference directive was added to CLAUDE.md
+        // Verify the managed rule reference section was added to CLAUDE.md
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md.assert(predicate::path::exists());
         claude_md.assert(predicate::str::contains("<!-- CLAUDIUS_RULES_START -->"));
@@ -58,7 +58,7 @@ mod tests {
         let test_rule = rules_dir.child("test-rule.md");
         test_rule.write_str("# Test Rule\nThis is a test rule.").unwrap();
 
-        // Pre-create CLAUDE.md with the directive
+        // Pre-create CLAUDE.md with the managed section
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md
             .write_str(
@@ -83,7 +83,7 @@ mod tests {
             .arg("test-rule")
             .assert()
             .success()
-            .stdout(predicate::str::contains("Updated reference directive"));
+            .stdout(predicate::str::contains("Updated managed rule reference section"));
 
         // Verify directive appears only once
         let content = fs::read_to_string(claude_md.path()).unwrap();
@@ -246,7 +246,7 @@ mod tests {
         let installed_rule = temp_dir.child(".custom/rules/test-rule.md");
         installed_rule.assert(predicate::path::exists());
 
-        // Verify reference directive uses custom path
+        // Verify the managed rule reference section uses the custom path
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md.assert(predicate::path::exists());
         claude_md.assert(predicate::str::contains("<!-- CLAUDIUS_RULES_START -->"));
@@ -306,7 +306,7 @@ mod tests {
             .child("advanced/testing-advanced.md")
             .assert(predicate::path::exists());
 
-        // Verify reference directive was added to CLAUDE.md
+        // Verify the managed rule reference section was added to CLAUDE.md
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md.assert(predicate::path::exists());
         claude_md.assert(predicate::str::contains("<!-- CLAUDIUS_RULES_START -->"));
@@ -371,7 +371,7 @@ mod tests {
         custom_rules.child("rule1.md").assert(predicate::path::exists());
         custom_rules.child("rule2.md").assert(predicate::path::exists());
 
-        // Verify reference directive uses custom path
+        // Verify the managed rule reference section uses the custom path
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md.assert(predicate::path::exists());
         claude_md.assert(predicate::str::contains("<!-- CLAUDIUS_RULES_START -->"));

--- a/tests/integration/install_context_test.rs
+++ b/tests/integration/install_context_test.rs
@@ -58,7 +58,7 @@ mod tests {
         let test_rule = rules_dir.child("test-rule.md");
         test_rule.write_str("# Test Rule\nThis is a test rule.").unwrap();
 
-        // Pre-create CLAUDE.md with the managed section
+        // Pre-create CLAUDE.md with the managed rule reference section
         let claude_md = temp_dir.child("CLAUDE.md");
         claude_md
             .write_str(


### PR DESCRIPTION
## Summary
- align README and contributor docs with the current `context` and `skills` command surface
- describe `context install` as a managed rule reference section instead of the retired include-style directive wording
- align CLI help text, runtime status messages, and integration tests with the same terminology

## Validation
- `nix develop -c cargo run -- --list-commands`
- `nix develop -c cargo run -- context append --help`
- `nix develop -c cargo run -- context install --help`
- `nix develop -c cargo run -- context list --help`
- `nix develop -c cargo run -- skills validate --help`
- `nix develop -c cargo run -- skills render --help`
- `nix develop -c cargo run -- config doctor --help`
- `nix develop -c cargo test install_context`
- `nix develop -c pre-commit run --files CHANGELOG.md README.md CLAUDE.md src/cli.rs src/main.rs tests/integration/install_context_test.rs`