### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudius"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claudius"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.95"
 authors = ["claudius contributors"]

--- a/flake.nix
+++ b/flake.nix
@@ -338,7 +338,7 @@
         packages = {
           default = rustPlatform.buildRustPackage {
             pname = "claudius";
-            version = "0.2.1";
+            version = "0.2.2";
             src = ./.;
 
             cargoLock = {


### PR DESCRIPTION
## Summary
- bump the Claudius crate version to `0.2.2`
- update the flake package version to `0.2.2`
- align the root `Cargo.lock` package entry with the `0.2.2` release

## Included release notes
- Context install documentation, CLI help, and status messages now consistently describe managed rule reference sections instead of legacy include-style directives
- Gemini sync now normalizes shared MCP server definitions before writing `settings.json`, translating `autoApprove` into `trust` when possible and dropping Gemini-incompatible keys such as `disabled`
- `claudius config validate --agent gemini` now inspects shared `mcpServers.json` for Gemini-incompatible MCP server fields before sync

## Testing
- `nix develop --command cargo check`