### PR TITLE
fix: keep skill sync and doctor state consistent

### DIFF
--- a/src/asset_sync.rs
+++ b/src/asset_sync.rs
@@ -188,6 +188,8 @@ fn copy_mapping(target_dir: &Path, mapping: &SourceFileMapping) -> Result<()> {
             .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
     }
 
+    make_owner_writable_if_needed(&destination)?;
+
     fs::copy(&mapping.source_path, &destination).with_context(|| {
         format!(
             "Failed to copy file from {} to {}",
@@ -196,6 +198,45 @@ fn copy_mapping(target_dir: &Path, mapping: &SourceFileMapping) -> Result<()> {
         )
     })?;
 
+    make_owner_writable_if_needed(&destination)?;
+
+    Ok(())
+}
+
+fn make_owner_writable_if_needed(path: &Path) -> Result<()> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("Failed to inspect {}", path.display()));
+        },
+    };
+
+    let mut permissions = metadata.permissions();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = permissions.mode();
+        if mode & 0o200 != 0 {
+            return Ok(());
+        }
+
+        permissions.set_mode(mode | 0o200);
+    }
+
+    #[cfg(not(unix))]
+    {
+        if !permissions.readonly() {
+            return Ok(());
+        }
+
+        permissions.set_readonly(false);
+    }
+
+    fs::set_permissions(path, permissions)
+        .with_context(|| format!("Failed to update permissions for {}", path.display()))?;
     Ok(())
 }
 
@@ -286,6 +327,12 @@ fn normalize_relative_path(path: &Path) -> String {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn set_read_only(path: &Path, read_only: bool) {
+        let mut permissions = fs::metadata(path).expect("metadata should load").permissions();
+        permissions.set_readonly(read_only);
+        fs::set_permissions(path, permissions).expect("permissions should update");
+    }
 
     #[test]
     fn sync_managed_tree_records_manifest_without_pruning() {
@@ -381,5 +428,37 @@ mod tests {
 
         assert_eq!(inspection.managed_files, vec!["keep.txt".to_string(), "old.txt".to_string()]);
         assert_eq!(inspection.stale_files, vec!["old.txt".to_string()]);
+    }
+
+    #[test]
+    fn sync_managed_tree_can_overwrite_read_only_targets() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let source_dir = temp_dir.path().join("source");
+        let target_dir = temp_dir.path().join("target");
+        let source_file = source_dir.join("skill.txt");
+
+        fs::create_dir_all(&source_dir).expect("create source");
+        fs::write(&source_file, "first").expect("write initial source");
+        set_read_only(&source_file, true);
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: false })
+            .expect("initial sync should succeed");
+
+        let target_file = target_dir.join("skill.txt");
+        assert_eq!(fs::read_to_string(&target_file).expect("read target"), "first");
+        assert!(!fs::metadata(&target_file).expect("target metadata").permissions().readonly());
+
+        set_read_only(&source_file, false);
+        fs::write(&source_file, "second").expect("update source");
+        set_read_only(&source_file, true);
+        set_read_only(&target_file, true);
+
+        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: false })
+            .expect("second sync should succeed");
+
+        assert_eq!(fs::read_to_string(&target_file).expect("read updated target"), "second");
+        assert!(!fs::metadata(&target_file).expect("target metadata").permissions().readonly());
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -222,7 +222,7 @@ fn collect_findings(
         &source_state.claude_code_agents,
         &mut findings,
     );
-    inspect_target_surfaces(options, deployment_base_dir, source_state, &mut findings)?;
+    inspect_target_surfaces(options, config_dir, deployment_base_dir, source_state, &mut findings)?;
 
     Ok(findings)
 }
@@ -671,16 +671,17 @@ fn inspect_auxiliary_sources(
 
 fn inspect_target_surfaces(
     options: DoctorOptions,
+    config_dir: &Path,
     deployment_base_dir: &Path,
     source_state: &SourceSurfaceState,
     findings: &mut Vec<DoctorFinding>,
 ) -> Result<()> {
     inspect_best_effort_targets(options, findings)?;
     inspect_unmanaged_targets(options.agent_filter, deployment_base_dir, findings);
-    inspect_claude_skill_targets(options, source_state, findings)?;
-    inspect_gemini_targets(options, deployment_base_dir, source_state, findings)?;
+    inspect_claude_skill_targets(options, config_dir, findings)?;
+    inspect_gemini_targets(options, config_dir, deployment_base_dir, source_state, findings)?;
     inspect_claude_code_targets(options, deployment_base_dir, source_state, findings)?;
-    inspect_codex_targets(options, source_state, findings)?;
+    inspect_codex_targets(options, config_dir, findings)?;
 
     Ok(())
 }
@@ -756,7 +757,7 @@ fn inspect_unmanaged_targets(
 
 fn inspect_claude_skill_targets(
     options: DoctorOptions,
-    source_state: &SourceSurfaceState,
+    config_dir: &Path,
     findings: &mut Vec<DoctorFinding>,
 ) -> Result<()> {
     if !(matches_filter(options.agent_filter, Agent::Claude)
@@ -765,12 +766,16 @@ fn inspect_claude_skill_targets(
         return Ok(());
     }
 
-    let source_mappings = combine_mappings(&[
-        &source_state.shared_skills,
-        &source_state.claude_skills,
-        &source_state.claude_code_skills,
-        &source_state.legacy_commands,
-    ]);
+    let source_mappings = match options.agent_filter {
+        Some(Agent::Claude) => collect_rendered_skill_mappings(config_dir, Agent::Claude)?,
+        Some(Agent::ClaudeCode) => collect_rendered_skill_mappings(config_dir, Agent::ClaudeCode)?,
+        _ => {
+            let claude_mappings = collect_rendered_skill_mappings(config_dir, Agent::Claude)?;
+            let claude_code_mappings =
+                collect_rendered_skill_mappings(config_dir, Agent::ClaudeCode)?;
+            combine_mappings(&[&claude_mappings, &claude_code_mappings])
+        },
+    };
     let target_dir =
         Config::new_with_agent(options.global, Some(Agent::ClaudeCode))?.skills_target_dir;
     push_stale_finding(
@@ -785,6 +790,7 @@ fn inspect_claude_skill_targets(
 
 fn inspect_gemini_targets(
     options: DoctorOptions,
+    config_dir: &Path,
     deployment_base_dir: &Path,
     source_state: &SourceSurfaceState,
     findings: &mut Vec<DoctorFinding>,
@@ -793,11 +799,7 @@ fn inspect_gemini_targets(
         return Ok(());
     }
 
-    let gemini_skill_source_mappings = combine_mappings(&[
-        &source_state.shared_skills,
-        &source_state.gemini_skills,
-        &source_state.legacy_commands,
-    ]);
+    let gemini_skill_source_mappings = collect_rendered_skill_mappings(config_dir, Agent::Gemini)?;
     let gemini_config = Config::new_with_agent(options.global, Some(Agent::Gemini))?;
     push_stale_finding(
         findings,
@@ -854,18 +856,14 @@ fn inspect_claude_code_targets(
 
 fn inspect_codex_targets(
     options: DoctorOptions,
-    source_state: &SourceSurfaceState,
+    config_dir: &Path,
     findings: &mut Vec<DoctorFinding>,
 ) -> Result<()> {
     if !matches_filter(options.agent_filter, Agent::Codex) {
         return Ok(());
     }
 
-    let codex_skill_source_mappings = combine_mappings(&[
-        &source_state.shared_skills,
-        &source_state.codex_skills,
-        &source_state.legacy_commands,
-    ]);
+    let codex_skill_source_mappings = collect_rendered_skill_mappings(config_dir, Agent::Codex)?;
     let codex_config = Config::new_with_agent(options.global, Some(Agent::Codex))?;
     push_stale_finding(
         findings,
@@ -884,7 +882,7 @@ fn inspect_codex_targets(
             skill_prune_command(options.global, Some(Agent::Codex)),
         );
 
-        if had_managed_files || !source_state.codex_skills.is_empty() {
+        if had_managed_files || !codex_skill_source_mappings.is_empty() {
             findings.push(DoctorFinding {
                 status: DoctorStatus::BestEffort,
                 summary: "Codex legacy compatibility skills target is enabled.".to_string(),
@@ -921,6 +919,13 @@ fn push_agent_skill_finding(
                 .to_string(),
         });
     }
+}
+
+fn collect_rendered_skill_mappings(
+    config_dir: &Path,
+    agent: Agent,
+) -> Result<Vec<SourceFileMapping>> {
+    Ok(skills::collect_claudius_skill_source_set(config_dir, Some(agent))?.mappings)
 }
 
 fn push_stale_finding(

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -199,6 +199,72 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_doctor_does_not_report_stale_for_synced_canonical_codex_skills() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_canonical_skill(
+                "setup-commitlint",
+                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n",
+                "Set up commitlint in the current repository.\n",
+            )
+            .unwrap();
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["skills", "sync", "--global", "--agent", "codex"])
+            .assert()
+            .success();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--global", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("STALE").not());
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_doctor_does_not_report_stale_for_synced_canonical_claude_code_skills() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_canonical_skill(
+                "setup-git-hooks",
+                "version: 1\nname: setup-git-hooks\ndescription: Install repository git hooks.\ntargets:\n  claude-code:\n    invocation: manual\n    argument-hint: \"[hook-name]\"\n    allowed-tools:\n      - Bash(git config core.hooksPath .githooks)\n",
+                "Install and verify project-local git hooks.\n",
+            )
+            .unwrap();
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["skills", "sync", "--global", "--agent", "claude-code"])
+            .assert()
+            .success();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "doctor", "--global", "--agent", "claude-code"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("STALE").not());
+    }
+
+    #[test]
+    #[serial]
     fn test_config_doctor_reports_skill_renderer_migration_warnings() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();


### PR DESCRIPTION
## Summary
- keep synced skill files owner-writable so repeated `claudius skills sync` runs can overwrite managed targets
- make `claudius config doctor` inspect rendered skill outputs instead of raw source files when checking stale skill targets
- add regression coverage for both behaviors

## Verification
- `nix develop --impure --command cargo test sync_managed_tree_can_overwrite_read_only_targets`
- `nix develop --impure --command cargo test test_config_doctor_`