### PR TITLE
fix(ci): harden security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 * * 1'  # Weekly on Monday at midnight UTC
   workflow_dispatch:
   push:
+    branches:
+      - main
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
@@ -129,6 +131,7 @@ jobs:
         with:
           format: spdx-json
           output-file: sbom.spdx.json
+          upload-release-assets: false
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v7
@@ -178,6 +181,9 @@ jobs:
     if: failure()
     needs: [audit, supply-chain, codeql]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Create issue for security failures
         uses: actions/github-script@v9


### PR DESCRIPTION
## Summary
- restrict the repository security audit push trigger to `main` Cargo metadata changes so release tag pushes do not invoke it
- disable automatic SBOM release asset uploads in the supply-chain job
- grant the notify job explicit `issues: write` permission so failure notifications can open an issue

## Root cause
The `v0.2.3` tag push triggered `Repository Security Audit` and the workflow then failed in two places:
- `anchore/sbom-action` tried to attach the generated SBOM to the release with insufficient token permissions
- the notify job tried to create an issue without `issues: write` permission

## Verification
- gh run view 25354602663 --log-failed
- nix develop --impure --command bash -lc 'pre-commit run check-yaml --files .github/workflows/security.yml'\n