### PR TITLE
fix(skills): preserve Codex skill discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Codex skill rendering no longer infers `allow_implicit_invocation: false` from legacy Claude metadata or canonical `invocation`, so rendered skills stay discoverable unless `allow-implicit-invocation: false` is set explicitly
+- Deprecated Codex override migration now preserves explicit hidden-skill intent by translating legacy `disable-model-invocation: true` into canonical `allow-implicit-invocation: false`
+
 ## [0.2.3] - 2026-05-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -736,8 +736,6 @@ description: Describe when to use this skill.
 targets:
   claude-code:
     invocation: manual
-  codex:
-    invocation: manual
 EOF
 cat <<'EOF' > ~/.config/claudius/skills/my-skill/instructions.md
 # My Skill
@@ -754,6 +752,19 @@ Preferred canonical skills use `skill.yaml` for portable metadata and
 `references/`, and `assets/` directories are copied as-is. If you need
 agent-specific body differences, add `targets/<agent>.md` for a full override or
 `targets/<agent>.prepend.md` / `targets/<agent>.append.md` for smaller fragments.
+
+Codex `agents/openai.yaml` output is optional. Add a `codex` target only when
+you need documented Codex-specific metadata such as `interface`,
+`dependencies`, or an explicit hidden helper skill:
+
+```yaml
+targets:
+  codex:
+    allow-implicit-invocation: false
+```
+
+If `allow-implicit-invocation` is omitted, Claudius leaves Codex implicit skill
+discovery at its default behavior.
 
 Legacy passthrough skills with top-level `SKILL.md` remain supported. Full
 agent override directories under `skills/<agent>/<skill>/SKILL.md` also remain

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -37,8 +37,10 @@ description: Example skill scaffold created by `claudius config init`.
 targets:
   claude-code:
     invocation: manual
-  codex:
-    invocation: manual
+# Add a codex target only when you need Codex-specific metadata such as
+# interface / dependencies, or an explicit hidden helper skill:
+#   codex:
+#     allow-implicit-invocation: false
 "#;
 
 /// Example canonical skill instructions template

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -130,6 +130,8 @@ struct SkillTargetOverlay {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     invocation: Option<SkillInvocationMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    allow_implicit_invocation: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     disable_model_invocation: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     user_invocable: Option<bool>,
@@ -637,6 +639,7 @@ fn extract_target_overlay_from_legacy(
 
             Ok(SkillTargetOverlay {
                 invocation: None,
+                allow_implicit_invocation: None,
                 disable_model_invocation: optional_bool_frontmatter_value(
                     frontmatter,
                     "disable-model-invocation",
@@ -695,7 +698,7 @@ fn extract_target_overlay_from_legacy(
                 CODEX_MIGRATION_FRONTMATTER_KEYS,
             )?;
 
-            let invocation =
+            let allow_implicit_invocation =
                 match optional_bool_frontmatter_value(frontmatter, "disable-model-invocation")
                     .with_context(|| {
                         format!(
@@ -704,12 +707,13 @@ fn extract_target_overlay_from_legacy(
                             SKILL_FILE_NAME,
                         )
                     })? {
-                    Some(true) => Some(SkillInvocationMode::Manual),
+                    Some(true) => Some(false),
                     _ => None,
                 };
 
             Ok(SkillTargetOverlay {
-                invocation,
+                invocation: None,
+                allow_implicit_invocation,
                 disable_model_invocation: None,
                 user_invocable: None,
                 allowed_tools: None,
@@ -812,6 +816,12 @@ fn merge_target_overlay(
         context,
     )?;
     merge_optional_overlay_field(
+        &mut existing.allow_implicit_invocation,
+        incoming.allow_implicit_invocation,
+        "allow-implicit-invocation",
+        context,
+    )?;
+    merge_optional_overlay_field(
         &mut existing.disable_model_invocation,
         incoming.disable_model_invocation,
         "disable-model-invocation",
@@ -885,6 +895,7 @@ where
 
 fn skill_target_overlay_is_empty(overlay: &SkillTargetOverlay) -> bool {
     overlay.invocation.is_none()
+        && overlay.allow_implicit_invocation.is_none()
         && overlay.disable_model_invocation.is_none()
         && overlay.user_invocable.is_none()
         && overlay.allowed_tools.is_none()
@@ -1168,6 +1179,12 @@ fn render_canonical_skill_bundle(
 
     match target_name {
         SkillTargetName::Codex => {
+            if target_overlay.invocation.is_some() {
+                warnings.insert(format!(
+                    "Codex target overlay for skill `{}` uses `invocation`, but Codex keeps implicit skill discovery enabled unless `allow-implicit-invocation` is set explicitly; `invocation` is ignored for Codex.",
+                    definition.name
+                ));
+            }
             if target_overlay.disable_model_invocation.is_some()
                 || target_overlay.user_invocable.is_some()
                 || target_overlay.allowed_tools.is_some()
@@ -1183,7 +1200,10 @@ fn render_canonical_skill_bundle(
             }
         },
         SkillTargetName::Claude | SkillTargetName::ClaudeCode | SkillTargetName::Gemini => {
-            if target_overlay.interface.is_some() || target_overlay.dependencies.is_some() {
+            if target_overlay.allow_implicit_invocation.is_some()
+                || target_overlay.interface.is_some()
+                || target_overlay.dependencies.is_some()
+            {
                 warnings.insert(format!(
                     "{} target overlay for skill `{}` contains Codex-only fields that will be ignored during rendering.",
                     target_name_label(target_name),
@@ -1736,11 +1756,11 @@ fn render_codex_openai_yaml(target_overlay: &SkillTargetOverlay) -> Result<Optio
         document.insert(yaml_key("dependencies"), dependencies.clone());
     }
 
-    if let Some(invocation) = target_overlay.invocation {
+    if let Some(allow_implicit_invocation) = target_overlay.allow_implicit_invocation {
         let mut policy = YamlMapping::new();
         policy.insert(
             yaml_key("allow_implicit_invocation"),
-            YamlValue::Bool(matches!(invocation, SkillInvocationMode::Auto)),
+            YamlValue::Bool(allow_implicit_invocation),
         );
         document.insert(yaml_key("policy"), YamlValue::Mapping(policy));
     }
@@ -1752,21 +1772,8 @@ fn render_codex_openai_yaml(target_overlay: &SkillTargetOverlay) -> Result<Optio
     Ok(Some(serialize_yaml_document(&YamlValue::Mapping(document))?))
 }
 
-fn render_codex_openai_yaml_from_legacy(frontmatter: &YamlMapping) -> Result<Option<String>> {
-    let disable_model_invocation = frontmatter
-        .get(YamlValue::String("disable-model-invocation".to_string()))
-        .and_then(YamlValue::as_bool);
-
-    if disable_model_invocation != Some(true) {
-        return Ok(None);
-    }
-
-    let mut policy = YamlMapping::new();
-    policy.insert(yaml_key("allow_implicit_invocation"), YamlValue::Bool(false));
-
-    let mut document = YamlMapping::new();
-    document.insert(yaml_key("policy"), YamlValue::Mapping(policy));
-    Ok(Some(serialize_yaml_document(&YamlValue::Mapping(document))?))
+fn render_codex_openai_yaml_from_legacy(_frontmatter: &YamlMapping) -> Result<Option<String>> {
+    Ok(None)
 }
 
 fn render_markdown_with_frontmatter(frontmatter: &YamlMapping, body: &str) -> Result<String> {
@@ -2340,7 +2347,7 @@ mod tests {
         fs::create_dir_all(skill_dir.join("scripts")).expect("Failed to create skill scripts dir");
         fs::write(
             skill_dir.join(CANONICAL_SKILL_FILE_NAME),
-            "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n",
+            "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    interface:\n      display_name: Commitlint Setup\n",
         )
         .expect("Failed to write skill.yaml");
         fs::write(
@@ -2382,6 +2389,34 @@ mod tests {
         let openai_content = fs::read_to_string(&openai_mapping.source_path)
             .expect("Rendered openai.yaml should read");
         assert!(openai_content.contains("display_name: Commitlint Setup"));
+        assert!(!openai_content.contains("allow_implicit_invocation"));
+    }
+
+    #[test]
+    fn test_collect_claudius_skill_source_set_renders_explicit_codex_policy() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let config_dir = temp_dir.path().join("claudius");
+        let skill_dir = config_dir.join("skills").join("hidden-review");
+
+        fs::create_dir_all(&skill_dir).expect("Failed to create skill dir");
+        fs::write(
+            skill_dir.join(CANONICAL_SKILL_FILE_NAME),
+            "version: 1\nname: hidden-review\ndescription: Review code privately.\ntargets:\n  codex:\n    allow-implicit-invocation: false\n",
+        )
+        .expect("Failed to write skill.yaml");
+        fs::write(skill_dir.join(DEFAULT_CANONICAL_INSTRUCTIONS_FILE), "Review code privately.\n")
+            .expect("Failed to write instructions");
+
+        let source_set = collect_claudius_skill_source_set(&config_dir, Some(Agent::Codex))
+            .expect("canonical codex source set should render");
+        let openai_mapping = source_set
+            .mappings
+            .iter()
+            .find(|mapping| mapping.relative_path == "hidden-review/agents/openai.yaml")
+            .expect("openai.yaml mapping should exist");
+        let openai_content = fs::read_to_string(&openai_mapping.source_path)
+            .expect("Rendered openai.yaml should read");
+
         assert!(openai_content.contains("allow_implicit_invocation: false"));
     }
 

--- a/tests/integration/doctor_test.rs
+++ b/tests/integration/doctor_test.rs
@@ -207,7 +207,7 @@ mod tests {
         fixture
             .with_canonical_skill(
                 "setup-commitlint",
-                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n",
+                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint.\ntargets:\n  codex:\n    interface:\n      display_name: Commitlint Setup\n",
                 "Set up commitlint in the current repository.\n",
             )
             .unwrap();

--- a/tests/integration/skills_test.rs
+++ b/tests/integration/skills_test.rs
@@ -281,10 +281,7 @@ mod tests {
         assert!(!skill_content.contains("disable-model-invocation"));
         assert!(!skill_content.contains("argument-hint"));
         assert!(!skill_content.contains("allowed-tools"));
-
-        let openai_yaml =
-            fixture.read_project_file(".agents/skills/review/agents/openai.yaml").unwrap();
-        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
+        assert!(!fixture.project_file_exists(".agents/skills/review/agents/openai.yaml"));
     }
 
     #[test]
@@ -297,7 +294,7 @@ mod tests {
         fixture
             .with_canonical_skill(
                 "setup-commitlint",
-                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint for the current repository.\ntargets:\n  codex:\n    invocation: manual\n    interface:\n      display_name: Commitlint Setup\n    dependencies:\n      tools:\n        - type: mcp\n          value: openaiDeveloperDocs\n",
+                "version: 1\nname: setup-commitlint\ndescription: Set up commitlint for the current repository.\ntargets:\n  codex:\n    interface:\n      display_name: Commitlint Setup\n    dependencies:\n      tools:\n        - type: mcp\n          value: openaiDeveloperDocs\n",
                 "Set up commitlint and wire it into git hooks.\n",
             )
             .unwrap();
@@ -339,9 +336,46 @@ mod tests {
         )
         .unwrap();
         assert!(openai_yaml.contains("display_name: Commitlint Setup"));
-        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
+        assert!(!openai_yaml.contains("allow_implicit_invocation"));
         assert!(openai_yaml.contains("openaiDeveloperDocs"));
         assert!(output_dir.join("setup-commitlint").join("scripts").join("setup.sh").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_render_canonical_codex_explicitly_disables_implicit_invocation() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "hidden-review",
+                "version: 1\nname: hidden-review\ndescription: Review code only when explicitly invoked.\ntargets:\n  codex:\n    allow-implicit-invocation: false\n",
+                "Review code only when explicitly invoked.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let output_dir = fixture.temp.path().join("rendered-hidden-skills");
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args([
+                "skills",
+                "render",
+                "--agent",
+                "codex",
+                "--output",
+                output_dir.to_str().unwrap(),
+            ])
+            .assert()
+            .success();
+
+        let openai_yaml =
+            fs::read_to_string(output_dir.join("hidden-review").join("agents").join("openai.yaml"))
+                .unwrap();
+        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
     }
 
     #[test]
@@ -478,6 +512,33 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_skills_validate_warns_when_codex_overlay_uses_legacy_invocation_field() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\ntargets:\n  codex:\n    invocation: manual\n",
+                "Review the repository and summarize the findings.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "validate", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "uses `invocation`, but Codex keeps implicit skill discovery enabled unless `allow-implicit-invocation` is set explicitly",
+            ));
+    }
+
+    #[test]
+    #[serial]
     fn test_skills_sync_renders_target_body_override() {
         let _env_guard = EnvGuard::new();
         let fixture = TestFixture::new().unwrap();
@@ -577,6 +638,75 @@ mod tests {
         assert!(rendered.contains("argument-hint: '[scope]'"));
         assert!(rendered.contains("Claude Code specific review instructions."));
         assert!(!rendered.contains("Shared review instructions."));
+    }
+
+    #[test]
+    #[serial]
+    fn test_skills_migrate_codex_override_preserves_explicit_hidden_policy() {
+        let _env_guard = EnvGuard::new();
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_canonical_skill(
+                "setup-review",
+                "version: 1\nname: setup-review\ndescription: Review the repository.\n",
+                "Shared review instructions.\n",
+            )
+            .unwrap();
+        fixture
+            .with_agent_skill(
+                "codex",
+                "setup-review",
+                "---\nname: setup-review\ndescription: Review the repository.\ndisable-model-invocation: true\n---\n\nCodex specific review instructions.\n",
+            )
+            .unwrap();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+
+        let mut migrate = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        migrate
+            .current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "migrate", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Migrated 1 deprecated full override skill director"))
+            .stdout(predicate::str::contains("skills/codex/setup-review"));
+
+        let skill_yaml = fs::read_to_string(
+            fixture.config.join("skills").join("setup-review").join("skill.yaml"),
+        )
+        .unwrap();
+        assert!(skill_yaml.contains("codex:"));
+        assert!(skill_yaml.contains("allow-implicit-invocation: false"));
+
+        let target_body = fs::read_to_string(
+            fixture
+                .config
+                .join("skills")
+                .join("setup-review")
+                .join("targets")
+                .join("codex.md"),
+        )
+        .unwrap();
+        assert_eq!(target_body, "Codex specific review instructions.\n");
+        assert!(!fixture.config.join("skills").join("codex").join("setup-review").exists());
+
+        let mut sync = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        sync.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .args(["skills", "sync", "--agent", "codex"])
+            .assert()
+            .success();
+
+        let rendered = fixture.read_project_file(".agents/skills/setup-review/SKILL.md").unwrap();
+        assert!(rendered.contains("Codex specific review instructions."));
+        assert!(!rendered.contains("Shared review instructions."));
+
+        let openai_yaml = fixture
+            .read_project_file(".agents/skills/setup-review/agents/openai.yaml")
+            .unwrap();
+        assert!(openai_yaml.contains("allow_implicit_invocation: false"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop inferring Codex `policy.allow_implicit_invocation: false` from legacy Claude metadata or canonical `invocation`
- add an explicit canonical `allow-implicit-invocation` field for Codex and preserve it when migrating deprecated Codex overrides
- update docs, bootstrap examples, and integration coverage to match the new renderer behavior

## Why
Codex currently hides many synced skills from the available skills list when `agents/openai.yaml` contains `policy.allow_implicit_invocation: false`.
Claudius was generating that policy too aggressively, which made ordinary synced skills undiscoverable.

## Testing
- `nix develop --impure --command bash -lc 'cargo test codex -- --test-threads=1 && cargo test skills -- --test-threads=1 && cargo test doctor -- --test-threads=1'`
