### PR TITLE
chore(deps): update Rust toolchain and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        rust: [stable, "1.95.0"]  # Test both stable and MSRV
+        rust: [stable, "1.97.1"]  # Test both stable and MSRV
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Raised the minimum supported Rust version and reproducible Nix toolchain to Rust 1.97.1
+- Updated all Cargo dependencies, including `serial_test` 4.0
+- CPU profiling now writes pprof-compatible protobuf reports instead of SVG flamegraphs, removing a vulnerable transitive XML parser while preserving portable profile analysis
+
 ## [0.2.4] - 2026-05-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ claudius --list-commands
 ```
 
 ### Prerequisites
-- Rust 1.95.0 or higher
+- Rust 1.97.1 or higher
 - Nix 2.19.0 or higher (optional, for development)
 
 ### Basic Usage
@@ -705,13 +705,13 @@ When `CLAUDIUS_PROFILE=1` is set, Claudius provides detailed timing information:
 
 ### Advanced Profiling
 
-For CPU profiling with flamegraphs (requires `profiling` feature):
+For CPU profiling with pprof-compatible protobuf reports (requires the `profiling` feature):
 
 ```bash
 # Build with profiling feature
 cargo build --profile=profiling --features=profiling
 
-# Flamegraphs will be saved as flamegraph-*.svg
+# Profiles will be saved as profile-*.pb and can be inspected with pprof tools
 ```
 
 ## Development Guide
@@ -1293,7 +1293,7 @@ Coverage builds are slower than normal builds. For day-to-day development, run t
 
 ### Rust Version Compatibility
 
-This project targets **Rust 1.95.0+** (see `clippy.toml` `msrv`). The Nix devShell uses the latest
+This project targets **Rust 1.97.1+** (see `clippy.toml` `msrv`). The Nix devShell uses the latest
 stable Rust pinned by `flake.lock`.
 
 ### How to Update Dependencies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +80,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -104,7 +91,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -112,12 +99,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert_cmd"
@@ -192,9 +173,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bstr"
@@ -212,12 +193,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "cc"
@@ -310,7 +285,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.19",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -401,7 +376,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -443,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -486,12 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,9 +468,9 @@ checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -569,15 +538,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -611,25 +578,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -638,10 +596,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
+name = "home"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -668,12 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ignore"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,38 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "inferno"
-version = "0.11.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
-dependencies = [
- "ahash",
- "indexmap",
- "is-terminal",
- "itoa",
- "log",
- "num-format",
- "once_cell",
- "quick-xml",
- "rgb",
- "str_stack",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
+ "hashbrown",
 ]
 
 [[package]]
@@ -744,13 +668,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -759,12 +682,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -780,6 +697,12 @@ checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -858,17 +781,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -946,16 +859,17 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "findshlibs",
- "inferno",
  "libc",
  "log",
  "nix",
  "once_cell",
+ "protobuf",
+ "protobuf-codegen",
  "smallvec",
  "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1008,16 +922,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,7 +947,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1055,19 +959,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "protobuf",
+ "protobuf-parse",
+ "regex",
+ "tempfile",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-parse"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "log",
+ "protobuf",
+ "protobuf-support",
+ "tempfile",
+ "thiserror 1.0.69",
+ "which",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quote"
@@ -1154,7 +1100,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1165,7 +1111,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1202,15 +1148,6 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "rstest"
@@ -1258,15 +1195,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1382,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
 dependencies = [
  "futures-executor",
  "futures-util",
@@ -1396,13 +1346,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1446,12 +1396,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "str_stack"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -1511,10 +1455,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1525,11 +1469,31 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1554,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1590,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -1677,12 +1641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,12 +1667,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -1747,23 +1699,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1774,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1784,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1797,45 +1740,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
+name = "which"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -1860,7 +1781,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1930,12 +1851,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1948,97 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.119",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "claudius"
 version = "0.2.4"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.97.1"
 authors = ["claudius contributors"]
 description = "Comprehensive configuration management tool for Claude Desktop/CLI"
 license = "MIT"
@@ -29,7 +29,7 @@ toml = "1.0"
 rayon = "1.11"
 
 # Optional dependencies for profiling
-pprof = { version = "0.15", features = ["flamegraph"], optional = true }
+pprof = { version = "0.15", features = ["protobuf-codec"], optional = true }
 
 [features]
 default = []
@@ -42,7 +42,7 @@ predicates = "3.1"
 pretty_assertions = "1.4"
 proptest = "1.11"
 rstest = "0.26"
-serial_test = "3.4"
+serial_test = "4.0"
 
 [profile.dev]
 opt-level = 0

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ cargo install --path .
 
 ## Prerequisites
 
-- **Rust**: 1.95.0 or higher
+- **Rust**: 1.97.1 or higher
 - **Nix**: 2.19.0 or higher (optional, for development)
 - **1Password CLI**: For secret management features (optional)
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,7 +3,7 @@
 
 # Deny dangerous and problematic patterns
 avoid-breaking-exported-api = false
-msrv = "1.95.0"
+msrv = "1.97.1"
 
 # Threshold configurations
 cognitive-complexity-threshold = 20

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
 
         # Use a specific Rust version for reproducibility.
         # Keep this in sync with the MSRV in Cargo.toml.
-        rustToolchain = pkgs.rust-bin.stable."1.95.0".default;
+        rustToolchain = pkgs.rust-bin.stable."1.97.1".default;
         rustPlatform = pkgs.makeRustPlatform {
           cargo = rustToolchain;
           rustc = rustToolchain;

--- a/src/asset_sync.rs
+++ b/src/asset_sync.rs
@@ -441,9 +441,14 @@ mod tests {
         fs::write(&source_file, "first").expect("write initial source");
         set_read_only(&source_file, true);
 
-        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
-        sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: false })
-            .expect("initial sync should succeed");
+        let initial_mappings =
+            collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        sync_managed_tree(
+            &target_dir,
+            &initial_mappings,
+            SyncBehavior { dry_run: false, prune: false },
+        )
+        .expect("initial sync should succeed");
 
         let target_file = target_dir.join("skill.txt");
         assert_eq!(fs::read_to_string(&target_file).expect("read target"), "first");
@@ -454,9 +459,14 @@ mod tests {
         set_read_only(&source_file, true);
         set_read_only(&target_file, true);
 
-        let mappings = collect_directory_tree_mappings(&source_dir).expect("collect mappings");
-        sync_managed_tree(&target_dir, &mappings, SyncBehavior { dry_run: false, prune: false })
-            .expect("second sync should succeed");
+        let updated_mappings =
+            collect_directory_tree_mappings(&source_dir).expect("collect mappings");
+        sync_managed_tree(
+            &target_dir,
+            &updated_mappings,
+            SyncBehavior { dry_run: false, prune: false },
+        )
+        .expect("second sync should succeed");
 
         assert_eq!(fs::read_to_string(&target_file).expect("read updated target"), "second");
         assert!(!fs::metadata(&target_file).expect("target metadata").permissions().readonly());

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -31,7 +31,7 @@ const DEFAULT_SETTINGS: &str = r#"{
 "#;
 
 /// Example canonical skill definition template
-const EXAMPLE_SKILL_DEFINITION: &str = r#"version: 1
+const EXAMPLE_SKILL_DEFINITION: &str = r"version: 1
 name: example
 description: Example skill scaffold created by `claudius config init`.
 targets:
@@ -41,10 +41,10 @@ targets:
 # interface / dependencies, or an explicit hidden helper skill:
 #   codex:
 #     allow-implicit-invocation: false
-"#;
+";
 
 /// Example canonical skill instructions template
-const EXAMPLE_SKILL_INSTRUCTIONS: &str = r#"# Example Skill
+const EXAMPLE_SKILL_INSTRUCTIONS: &str = r"# Example Skill
 
 This is an example canonical skill.
 
@@ -55,7 +55,7 @@ Describe how and when to use this skill.
 ## Implementation
 
 Replace this content with your actual skill instructions.
-"#;
+";
 
 /// Example rule template
 const EXAMPLE_RULE: &str = r"# Example Rule

--- a/src/config/writer.rs
+++ b/src/config/writer.rs
@@ -259,7 +259,7 @@ mod tests {
         let parts: Vec<&str> = backup_path.split('.').collect();
         let timestamp = parts.last().expect("Parts should have last element");
         assert_eq!(timestamp.len(), 15); // YYYYMMDD_HHMMSS
-        assert!(timestamp.chars().nth(8).expect("Timestamp should have 9th character") == '_');
+        assert_eq!(timestamp.chars().nth(8).expect("Timestamp should have 9th character"), '_');
     }
 
     #[test]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -357,7 +357,7 @@ fn inspect_gemini_sources(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn inspect_skill_sources(
     config_dir: &Path,
     agent_filter: Option<Agent>,
@@ -511,6 +511,7 @@ fn push_deprecated_override_finding(
     });
 }
 
+#[allow(clippy::too_many_lines)]
 fn inspect_shared_legacy_skill_metadata_leakage(
     config_dir: &Path,
     agent_filter: Option<Agent>,
@@ -531,8 +532,8 @@ fn inspect_shared_legacy_skill_metadata_leakage(
 
     for entry in entries.flatten() {
         let path = entry.path();
-        let entry_name = entry.file_name();
-        let Some(entry_name) = entry_name.to_str() else {
+        let entry_file_name = entry.file_name();
+        let Some(entry_name) = entry_file_name.to_str() else {
             continue;
         };
 
@@ -550,8 +551,7 @@ fn inspect_shared_legacy_skill_metadata_leakage(
                             .to_string(),
                     path: Some(skill_file),
                     detail: Some(format!(
-                        "Skill `{}` still uses Claude-specific frontmatter keys in a shared SKILL.md.",
-                        entry_name
+                        "Skill `{entry_name}` still uses Claude-specific frontmatter keys in a shared SKILL.md."
                     )),
                     recommendation:
                         "Migrate this skill to canonical skill.yaml or move Claude-only metadata into a Claude-specific target overlay."

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 #[cfg(feature = "profiling")]
-use claudius::profiling::profile_flamegraph;
+use claudius::profiling::profile_report;
 use claudius::{
     agent_paths,
     app_config::AppConfig,
@@ -127,7 +127,7 @@ fn dispatch_command(command: cli::Commands, app_config: Option<&AppConfig>) -> R
             cli::SkillsCommands::Sync(args) => run_sync_skills(args, app_config),
             cli::SkillsCommands::Validate(args) => run_validate_skills(args),
             cli::SkillsCommands::Migrate(args) => run_migrate_skills(args),
-            cli::SkillsCommands::Render(args) => run_render_skills(args, app_config),
+            cli::SkillsCommands::Render(args) => run_render_skills(&args, app_config),
         },
         cli::Commands::Context(subcommand) => match subcommand {
             cli::ContextCommands::Append(args) => run_append_context(
@@ -322,7 +322,7 @@ fn run_migrate_skills(args: cli::SkillsMigrateArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_render_skills(args: cli::SkillsRenderArgs, app_config: Option<&AppConfig>) -> Result<()> {
+fn run_render_skills(args: &cli::SkillsRenderArgs, app_config: Option<&AppConfig>) -> Result<()> {
     let effective_agent = determine_agent(args.agent, app_config);
     let config_dir = Config::get_config_dir().context("Failed to determine Claudius config dir")?;
     let source_set = skills::collect_claudius_skill_source_set(&config_dir, effective_agent)?;
@@ -1467,7 +1467,7 @@ fn run_command(command: &[String], app_config: Option<&AppConfig>) -> Result<()>
 
     #[cfg(feature = "profiling")]
     let status = if profiling_enabled {
-        profile_flamegraph("run-command", || run_command_inner(command))??
+        profile_report("run-command", || run_command_inner(command))??
     } else {
         run_command_inner(command)?
     };

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -199,13 +199,13 @@ fn sync_transport_specific_fields(
         Some(McpTransport::Remote) => {
             existing.url.clone_from(&overlay.url);
             existing.server_type.clone_from(&overlay.server_type);
-            existing.headers = overlay.headers.clone();
+            existing.headers.clone_from(&overlay.headers);
             sync_keys(&mut existing.extra, &overlay.extra, MCP_JSON_REMOTE_ONLY_EXTRA_FIELDS);
         },
         Some(McpTransport::Stdio) => {
             existing.command.clone_from(&overlay.command);
-            existing.args = overlay.args.clone();
-            existing.env = overlay.env.clone();
+            existing.args.clone_from(&overlay.args);
+            existing.env.clone_from(&overlay.env);
             sync_keys(&mut existing.extra, &overlay.extra, MCP_JSON_STDIO_ONLY_EXTRA_FIELDS);
         },
         None => {},
@@ -238,20 +238,22 @@ fn contains_any_key(map: &HashMap<String, Value>, keys: &[&str]) -> bool {
 }
 
 fn remove_keys(map: &mut HashMap<String, Value>, keys: &[&str]) {
-    keys.iter().for_each(|key| {
+    for key in keys {
         map.remove(*key);
-    });
+    }
 }
 
 fn sync_keys(target: &mut HashMap<String, Value>, overlay: &HashMap<String, Value>, keys: &[&str]) {
-    keys.iter().for_each(|key| match overlay.get(*key) {
-        Some(value) => {
-            target.insert((*key).to_string(), value.clone());
-        },
-        None => {
-            target.remove(*key);
-        },
-    });
+    for key in keys {
+        match overlay.get(*key) {
+            Some(value) => {
+                target.insert((*key).to_string(), value.clone());
+            },
+            None => {
+                target.remove(*key);
+            },
+        }
+    }
 }
 
 /// Detect conflicts in settings
@@ -619,7 +621,7 @@ mod tests {
         );
 
         assert_eq!(conflicts.len(), 1);
-        assert_eq!(conflicts[0].0, "notion");
+        assert_eq!(conflicts.first().expect("one conflict").0, "notion");
     }
 
     #[test]

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -33,23 +33,23 @@ macro_rules! time_block {
     }};
 }
 
-/// Profile a function with flamegraph support
+/// Profile a function and write a pprof-compatible protobuf report.
 ///
 /// # Errors
 ///
 /// Returns an error if:
 /// - Failed to build the profiler
-/// - Failed to create the output file
-/// - Failed to generate the flamegraph report
+/// - Failed to build or encode the profiling report
+/// - Failed to write the output file
 #[cfg(feature = "profiling")]
-pub fn profile_flamegraph<F, R>(label: &str, f: F) -> Result<R, anyhow::Error>
+pub fn profile_report<F, R>(label: &str, f: F) -> Result<R, anyhow::Error>
 where
     F: FnOnce() -> R,
 {
+    use pprof::protos::Message;
     use pprof::ProfilerGuardBuilder;
-    use std::fs::File;
 
-    info!("Starting flamegraph profiling for: {}", label);
+    info!("Starting CPU profiling for: {}", label);
 
     let guard = ProfilerGuardBuilder::default()
         .frequency(1000)
@@ -60,18 +60,20 @@ where
     let result = f();
 
     if let Ok(report) = guard.report().build() {
-        let file_name = format!("flamegraph-{}-{}.svg", label, chrono::Utc::now().timestamp());
-        let file = File::create(&file_name)?;
-        report.flamegraph(file)?;
-        info!("Flamegraph saved to: {}", file_name);
+        let file_name = format!("profile-{}-{}.pb", label, chrono::Utc::now().timestamp());
+        let profile = report.pprof()?;
+        let mut content = Vec::new();
+        profile.write_to_vec(&mut content)?;
+        std::fs::write(&file_name, content)?;
+        info!("CPU profile saved to: {}", file_name);
     }
 
     Ok(result)
 }
 
-/// Profile a function without flamegraph (no-op when profiling feature is disabled)
+/// Profile a function (no-op when the profiling feature is disabled).
 #[cfg(not(feature = "profiling"))]
-pub fn profile_flamegraph<F, R>(_label: &str, f: F) -> R
+pub fn profile_report<F, R>(_label: &str, f: F) -> R
 where
     F: FnOnce() -> R,
 {

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -456,13 +456,12 @@ fn canonical_shared_skill_candidate(
             "Shared canonical skill `{skill_name}` does not exist under skills/{skill_name}; create it before migrating deprecated full overrides."
         ),
         (true, true) => anyhow::bail!(
-            "Shared skill `{skill_name}` contains both {} and {}; resolve that mixed format before migration.",
-            CANONICAL_SKILL_FILE_NAME,
-            SKILL_FILE_NAME,
+            "Shared skill `{skill_name}` contains both {CANONICAL_SKILL_FILE_NAME} and {SKILL_FILE_NAME}; resolve that mixed format before migration."
         ),
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn plan_single_override_body_migration(
     shared_root: &Path,
     definition: &CanonicalSkillDefinition,
@@ -623,6 +622,7 @@ fn validate_legacy_override_core_metadata(
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 fn extract_target_overlay_from_legacy(
     frontmatter: &YamlMapping,
     agent: Agent,
@@ -804,6 +804,7 @@ fn optional_yaml_frontmatter_value(frontmatter: &YamlMapping, key: &str) -> Opti
     frontmatter.get(yaml_key(key)).cloned()
 }
 
+#[allow(clippy::too_many_lines)]
 fn merge_target_overlay(
     existing: &mut SkillTargetOverlay,
     incoming: SkillTargetOverlay,
@@ -1040,6 +1041,7 @@ fn discover_skill_candidates(
     Ok((merged.into_values().collect(), includes_legacy_commands))
 }
 
+#[allow(clippy::too_many_lines)]
 fn collect_skill_candidates_in_directory(
     root: &Path,
     origin: SkillSourceOrigin,
@@ -1166,6 +1168,7 @@ fn render_candidate_to_mappings(
     materialize_rendered_bundle(&bundle, render_workspace)
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_canonical_skill_bundle(
     candidate: &SkillCandidate,
     render_agent: Agent,
@@ -1535,6 +1538,7 @@ fn render_codex_generated_files(
     Ok(files)
 }
 
+#[allow(clippy::too_many_lines)]
 fn render_legacy_skill_bundle(
     candidate: &SkillCandidate,
     render_agent: Agent,
@@ -1590,7 +1594,7 @@ fn render_legacy_skill_bundle(
                 content: render_codex_skill_markdown(&name, &description, &document.body)?,
             });
 
-            if let Some(openai_yaml) = render_codex_openai_yaml_from_legacy(frontmatter)? {
+            if let Some(openai_yaml) = render_codex_openai_yaml_from_legacy(frontmatter) {
                 if candidate.kind == SkillCandidateKind::LegacyDirectory {
                     resource_mappings = collect_legacy_directory_resource_mappings(
                         &candidate.path,
@@ -1609,13 +1613,13 @@ fn render_legacy_skill_bundle(
         } else {
             generated_files.push(RenderedTextFile {
                 relative_path: SKILL_FILE_NAME.to_string(),
-                content: document.raw_content.clone(),
+                content: document.raw_content,
             });
         }
     } else {
         generated_files.push(RenderedTextFile {
             relative_path: SKILL_FILE_NAME.to_string(),
-            content: document.raw_content.clone(),
+            content: document.raw_content,
         });
     }
 
@@ -1772,8 +1776,8 @@ fn render_codex_openai_yaml(target_overlay: &SkillTargetOverlay) -> Result<Optio
     Ok(Some(serialize_yaml_document(&YamlValue::Mapping(document))?))
 }
 
-fn render_codex_openai_yaml_from_legacy(_frontmatter: &YamlMapping) -> Result<Option<String>> {
-    Ok(None)
+fn render_codex_openai_yaml_from_legacy(_frontmatter: &YamlMapping) -> Option<String> {
+    None
 }
 
 fn render_markdown_with_frontmatter(frontmatter: &YamlMapping, body: &str) -> Result<String> {
@@ -1797,8 +1801,8 @@ fn yaml_key(name: &str) -> YamlValue {
 }
 
 fn insert_optional_yaml_value(mapping: &mut YamlMapping, key: &str, value: Option<YamlValue>) {
-    if let Some(value) = value {
-        mapping.insert(yaml_key(key), value);
+    if let Some(yaml_value) = value {
+        mapping.insert(yaml_key(key), yaml_value);
     }
 }
 

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -1488,13 +1488,13 @@ fn strip_mcp_transport_keys(
     overlay_table: &toml::map::Map<String, TomlValue>,
 ) {
     if overlay_table.contains_key("url") {
-        MCP_TOML_STDIO_ONLY_FIELDS.iter().for_each(|key| {
+        for key in MCP_TOML_STDIO_ONLY_FIELDS {
             target_table.remove(*key);
-        });
+        }
     } else if overlay_table.contains_key("command") {
-        MCP_TOML_REMOTE_ONLY_FIELDS.iter().for_each(|key| {
+        for key in MCP_TOML_REMOTE_ONLY_FIELDS {
             target_table.remove(*key);
-        });
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- raise the MSRV, Nix toolchain, and CI matrix to Rust 1.97.1
- update all compatible Cargo dependencies and move `serial_test` to 4.0
- address Rust 1.97.1 Clippy diagnostics without changing runtime behavior
- replace the vulnerable optional flamegraph dependency path with pprof protobuf output
- update prerequisites, profiling documentation, and the changelog

## Validation
- `cargo outdated --root-deps-only`
- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (278 passed, 1 ignored)
- `cargo audit`
- `cargo deny check`
- `nix flake check --impure`
- `cargo build --profile profiling --features profiling`
- profiling smoke test producing a non-empty pprof protobuf report

## Security
The former `pprof` flamegraph feature pulled in `inferno 0.11` and vulnerable `quick-xml 0.26` (RUSTSEC-2026-0194 and RUSTSEC-2026-0195). The profiling feature now emits pprof-compatible protobuf files and the vulnerable dependency path is absent.