### PR TITLE
ci(deps): pin install-action to v2.85.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-llvm-cov
 
@@ -127,7 +127,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-audit
 
@@ -136,7 +136,7 @@ jobs:
         continue-on-error: true
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-deny
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Cargo audit for known vulnerabilities
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-audit
 
@@ -56,7 +56,7 @@ jobs:
 
       # Cargo deny for license and security checks
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: cargo-deny
 


### PR DESCRIPTION
## Summary
- replace floating `taiki-e/install-action@v2` references with the full commit SHA for v2.85.7
- update all five uses across CI and security workflows
- supersede #130, which proposed pinning the older v2.85.5 release

## Rationale
The full SHA makes workflow execution reproducible and reduces tag-movement supply-chain risk. The trailing version comments keep the selected release human-readable and allow Dependabot to track future updates.

## Validation
- verified `67729d5c413db75907f0ad1e39bb04b9c868ff60` is the official v2.85.7 tag commit
- `check-yaml` passed for both modified workflows
- pre-commit checks passed