### PR TITLE
feat(validation): replace field whitelists with deprecation checks

### DIFF
--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -17,10 +17,15 @@ const DEFAULT_MCP_SERVERS: &str = r#"{
 
 /// Default settings.json template
 const DEFAULT_SETTINGS: &str = r#"{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "apiKeyHelper": null,
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "cleanupPeriodDays": 30,
   "env": {},
-  "includeCoAuthoredBy": true,
   "permissions": {
     "allow": [],
     "deny": [],

--- a/src/claude_settings.rs
+++ b/src/claude_settings.rs
@@ -1,0 +1,62 @@
+use serde_json::Value;
+
+/// Validate Claude Code settings for known compatibility concerns.
+///
+/// Unknown fields are intentionally preserved without warnings because Claude Code evolves faster
+/// than Claudius and its published JSON schema can lag behind the CLI.
+#[must_use]
+pub fn validate_claude_settings(settings: &Value) -> Vec<String> {
+    let Value::Object(fields) = settings else {
+        return Vec::new();
+    };
+
+    fields
+        .contains_key("includeCoAuthoredBy")
+        .then(|| {
+            "includeCoAuthoredBy is deprecated; use attribution.commit, attribution.pr, and attribution.sessionUrl"
+                .to_string()
+        })
+        .into_iter()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn current_documented_settings_do_not_warn() {
+        let settings = json!({
+            "$schema": "https://json.schemastore.org/claude-code-settings.json",
+            "attribution": {"commit": "", "pr": "", "sessionUrl": false},
+            "effortLevel": "xhigh",
+            "hooks": {},
+            "model": "opus",
+            "outputStyle": "default",
+            "permissions": {
+                "allow": ["Read"],
+                "ask": ["Bash(git push *)"],
+                "deny": ["Read(./.env)"],
+                "additionalDirectories": ["../shared"],
+                "disableBypassPermissionsMode": "disable"
+            },
+            "preferredNotifChannel": "terminal_bell",
+            "statusLine": {"type": "command", "command": "statusline"}
+        });
+
+        assert!(validate_claude_settings(&settings).is_empty());
+    }
+
+    #[test]
+    fn deprecated_attribution_setting_warns() {
+        let warnings = validate_claude_settings(&json!({"includeCoAuthoredBy": false}));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings.first().is_some_and(|warning| warning.contains("attribution")));
+    }
+
+    #[test]
+    fn future_settings_are_preserved_without_speculative_warnings() {
+        assert!(validate_claude_settings(&json!({"futureSetting": true})).is_empty());
+    }
+}

--- a/src/codex_settings.rs
+++ b/src/codex_settings.rs
@@ -85,7 +85,7 @@ pub struct ModelProvider {
     pub extra: HashMap<String, TomlValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ShellEnvironmentPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inherit: Option<String>,
@@ -101,9 +101,18 @@ pub struct ShellEnvironmentPolicy {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_only: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<HashMap<String, String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub experimental_use_profile: Option<bool>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, TomlValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SandboxConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
@@ -113,9 +122,12 @@ pub struct SandboxConfig {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_access: Option<bool>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, TomlValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SandboxWorkspaceWrite {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub writable_roots: Vec<String>,
@@ -128,191 +140,42 @@ pub struct SandboxWorkspaceWrite {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude_slash_tmp: Option<bool>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, TomlValue>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct HistoryConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persistence: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_bytes: Option<usize>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, TomlValue>,
 }
-
-// Known field names for validation
-pub const KNOWN_CODEX_FIELDS: &[&str] = &[
-    "agents",
-    "allow_login_shell",
-    "analytics",
-    "model",
-    "model_auto_compact_token_limit",
-    "model_catalog_json",
-    "review_model",
-    "model_instructions_file",
-    "model_provider",
-    "model_reasoning_effort",
-    "model_reasoning_summary",
-    "model_supports_reasoning_summaries",
-    "model_context_window",
-    "model_verbosity",
-    "notice",
-    "approval_policy",
-    "approvals_reviewer",
-    "apps",
-    "auto_review",
-    "background_terminal_max_timeout",
-    "background_terminal_timeout",
-    "commit_attribution",
-    "compact_prompt",
-    "default_permissions",
-    "disable_paste_burst",
-    "notify",
-    "model_providers",
-    "shell_environment_policy",
-    "sandbox_mode",
-    "sandbox_workspace_write",
-    "sandbox",
-    "history",
-    "hooks",
-    "log_dir",
-    "mcp_servers",
-    "mcp_oauth_callback_port",
-    "mcp_oauth_callback_url",
-    "mcp_oauth_credentials_store",
-    "memories",
-    // Newer Codex CLI fields (non-exhaustive; used only for warning suppression)
-    "check_for_update_on_startup",
-    "instructions",
-    "developer_instructions",
-    "default_profile",
-    "experimental_compact_prompt_file",
-    "experimental_instructions_file",
-    "experimental_use_unified_exec_tool",
-    "feedback",
-    "features",
-    "profile",
-    "profiles",
-    "personality",
-    "plan_mode_reasoning_effort",
-    "projects",
-    "project_root_markers",
-    "project_doc_max_bytes",
-    "project_doc_fallback_filenames",
-    "service_tier",
-    "skills",
-    "sqlite_home",
-    "suppress_unstable_features_warning",
-    "tool_suggest",
-    "tool_output_token_limit",
-    "tui",
-    "hide_agent_reasoning",
-    "show_raw_agent_reasoning",
-    "file_opener",
-    "cli_auth_credentials_store",
-    "forced_chatgpt_workspace_id",
-    "forced_login_method",
-    "chatgpt_base_url",
-    "openai_base_url",
-    "otel",
-    "oss_provider",
-    "permissions",
-    "tools",
-    "web_search",
-    "windows",
-    "windows_wsl_setup_acknowledged",
-    // Legacy / compatibility fields
-    "disable_response_storage",
-];
-
-// We no longer validate model provider fields since they can have arbitrary extra fields
-// pub const KNOWN_MODEL_PROVIDER_FIELDS: &[&str] = &["name", "base_url", "env_key", "http_headers"];
-
-pub const KNOWN_SHELL_ENV_FIELDS: &[&str] = &[
-    "inherit",
-    "ignore_default_excludes",
-    "exclude",
-    "set",
-    "include_only",
-    "experimental_use_profile",
-];
-
-pub const KNOWN_SANDBOX_FIELDS: &[&str] = &["mode", "writable_roots", "network_access"];
-
-pub const KNOWN_SANDBOX_WORKSPACE_WRITE_FIELDS: &[&str] =
-    &["writable_roots", "network_access", "exclude_tmpdir_env_var", "exclude_slash_tmp"];
-
-pub const KNOWN_HISTORY_FIELDS: &[&str] = &["persistence", "max_bytes"];
-
-pub const KNOWN_CODEX_FEATURE_FIELDS: &[&str] = &[
-    "apps",
-    "browser_use",
-    "codex_hooks",
-    "computer_use",
-    "enable_request_compression",
-    "fast_mode",
-    "in_app_browser",
-    "memories",
-    "multi_agent",
-    "personality",
-    "prevent_idle_sleep",
-    "shell_snapshot",
-    "shell_tool",
-    "skill_mcp_dependency_install",
-    "undo",
-    "unified_exec",
-    "web_search",
-    "web_search_cached",
-    "web_search_request",
-];
 
 const CODEX_MCP_STDIO_UNSUPPORTED_FIELDS: &[&str] =
     &["url", "bearer_token_env_var", "http_headers", "env_http_headers"];
 
 const CODEX_MCP_STREAMABLE_HTTP_UNSUPPORTED_FIELDS: &[&str] = &["command", "args", "env", "cwd"];
 
-/// Validates Codex TOML settings and returns warnings for unknown fields
+/// Validates Codex TOML settings for known compatibility concerns.
+///
+/// Unknown fields are preserved without warnings so newer Codex settings remain forward-compatible.
 #[must_use]
 pub fn validate_codex_settings(toml_value: &TomlValue) -> Vec<String> {
     let mut warnings = Vec::new();
 
     if let TomlValue::Table(table) = toml_value {
         for (key, value) in table {
-            if !KNOWN_CODEX_FIELDS.contains(&key.as_str()) {
-                warnings.push(format!("Unknown setting '{key}' found in Codex configuration"));
-            }
-
-            validate_nested_codex_field(key.as_str(), value, &mut warnings);
             validate_deprecated_codex_field(key.as_str(), value, &mut warnings);
         }
     }
 
     warnings
-}
-
-/// Validate nested fields based on the parent field name
-fn validate_nested_codex_field(parent_key: &str, value: &TomlValue, warnings: &mut Vec<String>) {
-    let validation_config = match parent_key {
-        // Skip validation for model_providers since they can have arbitrary extra fields
-        "model_providers" => return,
-        "shell_environment_policy" => {
-            Some((KNOWN_SHELL_ENV_FIELDS, "shell_environment_policy", false))
-        },
-        "sandbox_workspace_write" => {
-            Some((KNOWN_SANDBOX_WORKSPACE_WRITE_FIELDS, "sandbox_workspace_write", false))
-        },
-        "sandbox" => Some((KNOWN_SANDBOX_FIELDS, "sandbox", false)),
-        "history" => Some((KNOWN_HISTORY_FIELDS, "history", false)),
-        "features" => Some((KNOWN_CODEX_FEATURE_FIELDS, "features", false)),
-        _ => None,
-    };
-
-    if let Some((known_fields, field_name, is_nested)) = validation_config {
-        if is_nested {
-            validate_nested_providers(value, known_fields, field_name, warnings);
-        } else {
-            validate_simple_table(value, known_fields, field_name, warnings);
-        }
-    }
 }
 
 fn validate_deprecated_codex_field(
@@ -350,8 +213,51 @@ fn validate_deprecated_codex_field(
                 .to_string(),
         ),
         "features" => validate_deprecated_codex_feature_flags(value, warnings),
+        "shell_environment_policy" => validate_shell_environment_policy(value, warnings),
         _ => {},
     }
+}
+
+fn validate_shell_environment_policy(value: &TomlValue, warnings: &mut Vec<String>) {
+    let TomlValue::Table(policy) = value else {
+        return;
+    };
+
+    for legacy_field in ["exclude", "include_only"] {
+        if policy.contains_key(legacy_field) {
+            warnings.push(format!(
+                "shell_environment_policy.{legacy_field} is legacy; prefer shell_environment_policy.filters"
+            ));
+        }
+    }
+
+    if policy.contains_key("filters")
+        && (policy.contains_key("exclude") || policy.contains_key("include_only"))
+    {
+        warnings.push(
+            "shell_environment_policy.filters cannot be combined with legacy exclude or include_only in the same configuration layer"
+                .to_string(),
+        );
+    }
+}
+
+/// Validates Codex `requirements.toml` for known compatibility concerns.
+#[must_use]
+pub fn validate_codex_requirements(toml_value: &TomlValue) -> Vec<String> {
+    let Some(policies) = toml_value.get("allowed_approval_policies").and_then(TomlValue::as_array)
+    else {
+        return Vec::new();
+    };
+
+    policies
+        .iter()
+        .any(|policy| policy.as_str() == Some("on-failure"))
+        .then(|| {
+            "allowed_approval_policies contains deprecated \"on-failure\"; remove it or use \"on-request\""
+                .to_string()
+        })
+        .into_iter()
+        .collect()
 }
 
 fn validate_deprecated_codex_feature_flags(value: &TomlValue, warnings: &mut Vec<String>) {
@@ -371,48 +277,6 @@ fn validate_deprecated_codex_feature_flags(value: &TomlValue, warnings: &mut Vec
             "features.{field} is deprecated; prefer the top-level {replacement} setting"
         ));
     });
-}
-
-/// Validate model providers which have an additional nesting level
-fn validate_nested_providers(
-    value: &TomlValue,
-    known_fields: &[&str],
-    field_name: &str,
-    warnings: &mut Vec<String>,
-) {
-    let TomlValue::Table(providers) = value else {
-        return;
-    };
-
-    for (provider_name, provider_value) in providers {
-        let TomlValue::Table(provider_table) = provider_value else {
-            continue;
-        };
-
-        for (field, _) in provider_table {
-            if !known_fields.contains(&field.as_str()) {
-                warnings.push(format!("Unknown field '{field}' in {field_name}.{provider_name}"));
-            }
-        }
-    }
-}
-
-/// Validate simple table fields
-fn validate_simple_table(
-    value: &TomlValue,
-    known_fields: &[&str],
-    field_name: &str,
-    warnings: &mut Vec<String>,
-) {
-    let TomlValue::Table(table) = value else {
-        return;
-    };
-
-    for (field, _) in table {
-        if !known_fields.contains(&field.as_str()) {
-            warnings.push(format!("Unknown field '{field}' in {field_name}"));
-        }
-    }
 }
 
 fn json_to_toml_value(value: &JsonValue) -> Option<TomlValue> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agent_paths;
 pub mod app_config;
 pub mod asset_sync;
 pub mod bootstrap;
+pub mod claude_settings;
 pub mod cli;
 pub mod codex_settings;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,7 +668,7 @@ fn validate_codex_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
 
     let codex_requirements_path = config_dir.join("codex.requirements.toml");
     if codex_requirements_path.exists() {
-        validate_toml_parse_file(&codex_requirements_path)?;
+        warnings.extend(validate_codex_requirements_file(&codex_requirements_path)?);
     }
 
     if let Some((managed_config_path, is_legacy)) = select_codex_managed_config_source(config_dir) {
@@ -685,12 +685,16 @@ fn validate_codex_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
     Ok(warnings)
 }
 
-fn validate_toml_parse_file(path: &std::path::Path) -> Result<()> {
+fn validate_codex_requirements_file(path: &std::path::Path) -> Result<Vec<String>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("Failed to read {}", path.display()))?;
-    let _: toml::Value =
+    let value: toml::Value =
         toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
-    Ok(())
+
+    Ok(claudius::codex_settings::validate_codex_requirements(&value)
+        .into_iter()
+        .map(|warning| format!("{}: {warning}", path.display()))
+        .collect())
 }
 
 fn validate_codex_settings_like_file(path: &std::path::Path) -> Result<Vec<String>> {

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -136,69 +136,10 @@ fn infer_json_config_kind(path: &Path) -> Option<JsonConfigKind> {
     }
 }
 
-const KNOWN_PERMISSION_FIELDS: &[&str] = &["allow", "deny", "defaultMode"];
-
-// Known Claude/Codex settings fields
-const KNOWN_CLAUDE_FIELDS: &[&str] = &[
-    "apiKeyHelper",
-    "cleanupPeriodDays",
-    "env",
-    "includeCoAuthoredBy",
-    "permissions",
-    "preferredNotifChannel",
-    "mcpServers",
-    "mcp_servers",
-    "extra",
-    // Codex-specific fields
-    "model",
-    "modelProvider",
-    "model_provider",
-    "approvalPolicy",
-    "approval_policy",
-    "disableResponseStorage",
-    "disable_response_storage",
-    "notify",
-    "modelProviders",
-    "model_providers",
-    "shellEnvironmentPolicy",
-    "shell_environment_policy",
-    "sandbox",
-    "history",
-];
-
-/// Validates Claude/Codex settings and returns warnings for unknown fields
+/// Validates Claude settings and returns compatibility warnings.
 #[must_use]
 pub fn validate_claude_settings(json: &Value) -> Vec<String> {
-    let mut warnings = Vec::new();
-
-    if let Value::Object(map) = json {
-        for (key, value) in map {
-            if !KNOWN_CLAUDE_FIELDS.contains(&key.as_str()) {
-                warnings
-                    .push(format!("Unknown setting '{key}' found in Claude/Codex configuration"));
-            }
-
-            // Validate nested permissions object
-            if key == "permissions" {
-                validate_permissions(value, &mut warnings);
-            }
-        }
-    }
-
-    warnings
-}
-
-/// Validate permissions object fields
-fn validate_permissions(value: &Value, warnings: &mut Vec<String>) {
-    let Value::Object(perm_map) = value else {
-        return;
-    };
-
-    for (perm_key, _) in perm_map {
-        if !KNOWN_PERMISSION_FIELDS.contains(&perm_key.as_str()) {
-            warnings.push(format!("Unknown field '{perm_key}' in permissions"));
-        }
-    }
+    crate::claude_settings::validate_claude_settings(json)
 }
 
 /// Pre-validate settings before sync to catch JSON errors early
@@ -484,7 +425,8 @@ mod tests {
             "apiKeyHelper": "/bin/helper",
             "cleanupPeriodDays": 30,
             "env": {"KEY": "value"},
-            "includeCoAuthoredBy": true,
+            "$schema": "https://json.schemastore.org/claude-code-settings.json",
+            "attribution": {"commit": "", "pr": "", "sessionUrl": false},
             "permissions": {
                 "allow": ["Read"],
                 "deny": ["Write"],
@@ -507,9 +449,7 @@ mod tests {
         });
 
         let warnings = validate_claude_settings(&json);
-        assert_eq!(warnings.len(), 2);
-        assert!(warnings.first().is_some_and(|w| w.contains("unknownField")));
-        assert!(warnings.get(1).is_some_and(|w| w.contains("anotherUnknown")));
+        assert!(warnings.is_empty());
     }
 
     #[test]
@@ -522,8 +462,7 @@ mod tests {
         });
 
         let warnings = validate_claude_settings(&json);
-        assert_eq!(warnings.len(), 1);
-        assert!(warnings.first().is_some_and(|w| w.contains("unknownPerm")));
+        assert!(warnings.is_empty());
     }
 
     #[test]
@@ -615,7 +554,7 @@ mod tests {
         fs::create_dir_all(&claude_home).expect("Failed to create test directory");
         let file_path = claude_home.join("unrelated.json");
 
-        fs::write(&file_path, json!({ "unrelated": true }).to_string())
+        fs::write(&file_path, json!({ "includeCoAuthoredBy": false }).to_string())
             .expect("Failed to write file");
 
         let (_, result) = validate_json_file(&file_path).expect("Failed to validate JSON file");
@@ -627,7 +566,7 @@ mod tests {
         assert!(claude_result
             .warnings
             .first()
-            .is_some_and(|warning| warning.contains("unrelated")));
+            .is_some_and(|warning| warning.contains("attribution")));
     }
 
     #[test]
@@ -658,7 +597,7 @@ mod tests {
         let file_path = temp_dir.path().join("claude.json");
 
         let content = json!({
-            "unknownField": "value"
+            "includeCoAuthoredBy": false
         });
 
         fs::write(&file_path, content.to_string()).expect("Failed to write file");
@@ -695,7 +634,8 @@ mod tests {
         assert_eq!(settings.api_key_helper, Some("/bin/helper".to_string()));
         assert_eq!(settings.cleanup_period_days, Some(30));
         assert_eq!(settings.include_co_authored_by, Some(true));
-        assert!(result.warnings.is_empty());
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings.first().is_some_and(|warning| warning.contains("attribution")));
     }
 
     #[test]

--- a/tests/integration/codex_toml_test.rs
+++ b/tests/integration/codex_toml_test.rs
@@ -287,18 +287,68 @@ unknown_sandbox_field = true
         let toml_value: TomlValue = toml::from_str(toml_str)?;
         let warnings = validate_codex_settings(&toml_value);
 
-        anyhow::ensure!(warnings.len() == 2, "Expected 2 warnings");
+        anyhow::ensure!(warnings.is_empty(), "Future fields should not produce warnings");
+
+        let settings: CodexSettings = toml::from_str(toml_str)?;
+        let rendered = toml::to_string_pretty(&settings)?;
+        let round_trip: TomlValue = toml::from_str(&rendered)?;
         anyhow::ensure!(
-            warnings.iter().any(|w| w.contains("unknown_top_level")),
-            "Expected unknown_top_level warning"
+            round_trip.get("unknown_top_level").is_some(),
+            "unknown top-level fields must survive a settings round trip"
         );
-        // Model provider fields are no longer validated since they can have arbitrary extra fields
-        // assert!(warnings.iter().any(|w| w.contains("unknown_provider_field")));
         anyhow::ensure!(
-            warnings.iter().any(|w| w.contains("unknown_sandbox_field")),
-            "Expected unknown_sandbox_field warning"
+            round_trip
+                .get("sandbox_workspace_write")
+                .and_then(|sandbox| sandbox.get("unknown_sandbox_field"))
+                .and_then(TomlValue::as_bool)
+                == Some(true),
+            "unknown nested fields must survive a settings round trip"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_codex_shell_environment_filters_round_trip() -> Result<()> {
+        let source = r#"
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.filters]
+"PATH" = "include"
+"*_TOKEN" = "exclude"
+"#;
+
+        let settings: CodexSettings = toml::from_str(source)?;
+        let rendered = toml::to_string_pretty(&settings)?;
+        let reparsed: TomlValue = toml::from_str(&rendered)?;
+
+        anyhow::ensure!(
+            reparsed
+                .get("shell_environment_policy")
+                .and_then(|policy| policy.get("filters"))
+                .and_then(|filters| filters.get("*_TOKEN"))
+                .and_then(TomlValue::as_str)
+                == Some("exclude"),
+            "canonical filters must survive a settings round trip"
+        );
+        anyhow::ensure!(validate_codex_settings(&reparsed).is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_codex_settings_warns_on_legacy_shell_filters() -> Result<()> {
+        let value: TomlValue = toml::from_str(
+            r#"
+[shell_environment_policy]
+exclude = ["*_TOKEN"]
+include_only = ["PATH"]
+"#,
+        )?;
+
+        let warnings = validate_codex_settings(&value);
+        anyhow::ensure!(warnings.len() == 2, "Expected one warning per legacy field");
+        anyhow::ensure!(warnings.iter().all(|warning| warning.contains("filters")));
         Ok(())
     }
 

--- a/tests/integration/init_test.rs
+++ b/tests/integration/init_test.rs
@@ -84,7 +84,19 @@ mod tests {
         let _: serde_json::Value = serde_json::from_str(&mcp_content).unwrap();
 
         let settings_content = fs::read_to_string(config_dir.join("settings.json")).unwrap();
-        let _: serde_json::Value = serde_json::from_str(&settings_content).unwrap();
+        let settings: serde_json::Value = serde_json::from_str(&settings_content).unwrap();
+        assert_eq!(
+            settings.get("$schema").and_then(serde_json::Value::as_str),
+            Some("https://json.schemastore.org/claude-code-settings.json"),
+        );
+        assert_eq!(
+            settings
+                .get("attribution")
+                .and_then(|attribution| attribution.get("sessionUrl"))
+                .and_then(serde_json::Value::as_bool),
+            Some(false),
+        );
+        assert!(settings.get("includeCoAuthoredBy").is_none());
     }
 
     #[test]

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -376,6 +376,31 @@ web_search = true
 
     #[test]
     #[serial]
+    fn test_config_validate_warns_on_deprecated_codex_requirement() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(
+            fixture.config.join("codex.requirements.toml"),
+            r#"allowed_approval_policies = ["untrusted", "on-failure", "on-request"]"#,
+        )
+        .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "allowed_approval_policies contains deprecated \"on-failure\"",
+            ));
+    }
+
+    #[test]
+    #[serial]
     fn test_config_validate_warns_when_onepassword_subtable_is_ignored() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();

--- a/tests/unit/settings_sync_test.rs
+++ b/tests/unit/settings_sync_test.rs
@@ -21,7 +21,8 @@ mod tests {
             "env": {
                 "CUSTOM_VAR": "value"
             },
-            "includeCoAuthoredBy": true,
+            "$schema": "https://json.schemastore.org/claude-code-settings.json",
+            "attribution": {"commit": "", "pr": "", "sessionUrl": false},
             "permissions": {
                 "allow": ["Read", "Write"],
                 "deny": ["Delete"],
@@ -61,10 +62,8 @@ mod tests {
         let (json_value, validation_result) =
             validate_json_file_as(&settings_file, JsonConfigKind::Claude).unwrap();
 
-        // Should have warnings about unknown fields
-        assert_eq!(validation_result.warnings.len(), 2);
-        assert!(validation_result.warnings.iter().any(|w| w.contains("unknownField")));
-        assert!(validation_result.warnings.iter().any(|w| w.contains("unknownPermission")));
+        // Future fields must be preserved without speculative warnings.
+        assert!(validation_result.warnings.is_empty());
 
         // But the JSON should still be parsed
         assert!(json_value.get("unknownField").is_some());


### PR DESCRIPTION
## Summary

- replace stale Claude/Codex unknown-field whitelists with focused deprecation diagnostics
- preserve current and future Codex nested settings during round trips, including canonical `shell_environment_policy.filters`
- validate deprecated approval policies in `codex.requirements.toml`
- bootstrap Claude settings with the official schema and `attribution` format

## Details

Claude validation now lives in an agent-specific module and warns about the documented `includeCoAuthoredBy` deprecation without rejecting future settings. Codex validation likewise focuses on actionable migrations: legacy shell environment arrays, incompatible filter combinations, and deprecated requirements policies.

The typed Codex nested tables now use `serde(flatten)` so accepting an unknown field also guarantees that sync preserves it. The canonical `filters` table is modeled explicitly and covered by a round-trip regression test.

## Verification

- `nix develop --impure --command cargo test --all-targets --all-features`
- `nix develop --impure --command cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `config init` followed by strict Claude Code and Codex validation smoke tests
- pre-commit hooks
