### PR TITLE
docs(examples): refresh stale settings examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,16 +507,22 @@ export CLAUDIUS_SECRET_PATH='/${CLAUDIUS_SECRET_BASE}api'  # Results in: /prodap
 ### settings.json
 ```json
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "apiKeyHelper": "/path/to/key-generator.sh",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "cleanupPeriodDays": 20,
   "env": {"CUSTOM_VAR": "value"},
-  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": ["Bash(npm run lint)"],
+    "ask": ["Bash(git push:*)"],
     "deny": ["Write(/etc/*)"],
-    "defaultMode": "allow"
+    "defaultMode": "acceptEdits"
   },
-  "preferredNotifChannel": "chat"
+  "preferredNotifChannel": "terminal_bell"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -608,16 +608,22 @@ Configure Claude/Claude Code settings:
 
 ```json
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "apiKeyHelper": "/path/to/key-generator.sh",
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
   "cleanupPeriodDays": 20,
   "env": {"CUSTOM_VAR": "value"},
-  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": ["Bash(npm run lint)"],
+    "ask": ["Bash(git push:*)"],
     "deny": ["Write(/etc/*)"],
-    "defaultMode": "allow"
+    "defaultMode": "acceptEdits"
   },
-  "preferredNotifChannel": "chat"
+  "preferredNotifChannel": "terminal_bell"
 }
 ```
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -170,8 +170,8 @@ const DEFAULT_CODEX_SETTINGS: &str = r#"# Codex Settings
 # - "untrusted" | "on-request" | "never"
 # approval_policy = "on-request"
 
-# List of notification channels
-# notify = ["desktop", "sound"]
+# Program invoked for notifications; it receives a JSON payload from Codex
+# notify = ["notify-send", "Codex"]
 
 # Model provider configurations
 # [model_providers.openai]


### PR DESCRIPTION
## Summary

- fix the Codex `notify` example to show an executable command rather than notification channel names
- modernize Claude settings examples with `$schema` and `attribution`
- replace invalid permission and notification enum values with current documented values
- demonstrate `permissions.ask`

## Verification

- 447 tests passed, 1 ignored
- Clippy with `-D warnings`
- rustfmt check
- pre-commit hooks
