### PR TITLE
feat(config): add migrate command for deprecated settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,32 @@ claudius config sync --global --agent gemini --gemini-system-defaults
 claudius skills sync --agent codex
 ```
 
+### `claudius config migrate`
+Migrate deprecated agent settings in Claudius source files to their documented
+successors. Only transformations with vendor-documented semantics are applied,
+unknown fields are never touched, and re-running on migrated files reports
+nothing to do. A timestamped backup is created before every rewrite; TOML
+comments are preserved.
+
+Current rules: `includeCoAuthoredBy` → `attribution` and `$schema` addition for
+Claude settings; `background_terminal_timeout` → `background_terminal_max_timeout`
+and `experimental_instructions_file` → `model_instructions_file` for Codex
+settings; removal of deprecated `"on-failure"` from `allowed_approval_policies`
+in Codex requirements. Deprecated settings without a documented mechanical
+translation (e.g. `shell_environment_policy.exclude` / `include_only` →
+`filters`) are only reported by `claudius config validate`.
+
+```bash
+# Preview all pending migrations as unified diffs
+claudius config migrate --dry-run
+
+# Migrate all available source files
+claudius config migrate
+
+# Migrate only the Codex source files
+claudius config migrate --agent codex
+```
+
 ### `claudius skills sync`
 Synchronize skills into the selected agent's skills directory.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,11 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "similar",
  "tempfile",
  "thiserror 2.0.19",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1371,6 +1373,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "similar"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,6 +1560,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rayon = "1.11"
 
 # Optional dependencies for profiling
 pprof = { version = "0.15", features = ["protobuf-codec"], optional = true }
+toml_edit = "0.25.13"
+similar = "3.1.1"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -338,6 +338,42 @@ claudius config doctor --agent gemini
 claudius config doctor --global
 ```
 
+### `claudius config migrate`
+
+Migrate deprecated agent settings in Claudius source files to their documented
+successors. The command is intentionally conservative: it only applies
+transformations whose semantics are documented by the agent vendors, never
+touches unknown fields, and re-running it on migrated files reports nothing to
+do.
+
+Current rules:
+
+- Claude / Claude Code (`claude.settings.json` or legacy `settings.json`):
+  - `includeCoAuthoredBy` → `attribution` block
+  - add the official `$schema` reference when missing
+- Codex (`codex.settings.toml`, comments preserved):
+  - `background_terminal_timeout` → `background_terminal_max_timeout`
+  - `experimental_instructions_file` → `model_instructions_file`
+- Codex (`codex.requirements.toml`, comments preserved):
+  - remove deprecated `"on-failure"` from `allowed_approval_policies`
+
+Deprecated settings without a documented mechanical translation (for example
+`shell_environment_policy.exclude` / `include_only` → `filters`) are reported
+by `claudius config validate` but never rewritten automatically.
+
+A timestamped backup is created next to every file before it is rewritten.
+
+```bash
+# Preview all pending migrations as unified diffs
+claudius config migrate --dry-run
+
+# Migrate all available source files
+claudius config migrate
+
+# Migrate only the Codex source files
+claudius config migrate --agent codex
+```
+
 ### `claudius skills sync`
 
 Synchronize skills into the selected agent's skills directory.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -216,6 +216,40 @@ Use --global to inspect global deployment targets under $HOME.
 Use --agent to focus on a single agent surface."
     )]
     Doctor(ConfigDoctorArgs),
+
+    /// Migrate deprecated agent settings to their documented successors
+    #[command(long_about = "Migrate deprecated agent settings in Claudius source files to their
+documented successors.
+
+This command only applies transformations whose semantics are documented
+by the agent vendors, and it never touches unknown fields:
+  • Claude / Claude Code (claude.settings.json or legacy settings.json):
+      - includeCoAuthoredBy → attribution block
+      - add the official $schema reference when missing
+  • Codex (codex.settings.toml, comments preserved):
+      - background_terminal_timeout → background_terminal_max_timeout
+      - experimental_instructions_file → model_instructions_file
+  • Codex (codex.requirements.toml, comments preserved):
+      - remove deprecated \"on-failure\" from allowed_approval_policies
+
+Deprecated settings without a documented mechanical translation (for
+example shell_environment_policy.exclude / include_only → filters) are
+reported by `claudius config validate` but never rewritten.
+
+A timestamped backup is created next to every file before it is
+rewritten. Re-running the command on migrated files reports nothing to
+do.
+
+Examples:
+  # Preview all pending migrations as unified diffs
+  claudius config migrate --dry-run
+
+  # Migrate only the Codex source files
+  claudius config migrate --agent codex
+
+  # Migrate Claude Code settings
+  claudius config migrate --agent claude-code")]
+    Migrate(ConfigMigrateArgs),
 }
 
 #[derive(Subcommand, Debug)]
@@ -490,6 +524,17 @@ pub struct ConfigValidateArgs {
     /// Treat warnings as errors (exit non-zero)
     #[arg(long)]
     pub strict: bool,
+}
+
+#[derive(Args, Debug, Clone, Copy)]
+pub struct ConfigMigrateArgs {
+    /// Migrate a specific agent's settings (defaults to all available source files)
+    #[arg(short, long, value_enum)]
+    pub agent: Option<crate::app_config::Agent>,
+
+    /// Show pending migrations as diffs without writing anything
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Args, Debug, Clone, Copy)]

--- a/src/config_migrate.rs
+++ b/src/config_migrate.rs
@@ -1,0 +1,568 @@
+//! Migration engine for deprecated agent settings.
+//!
+//! Rewrites Claudius source configuration files to replace deprecated
+//! settings with their documented successors. The engine is intentionally
+//! conservative: it only applies transformations whose semantics are
+//! documented by the agent vendors, it never touches unknown fields, and
+//! re-running a migration on already-migrated files produces no changes.
+
+use anyhow::{Context, Result};
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml_edit::{DocumentMut, Item, Key};
+
+use crate::app_config::Agent;
+use crate::config::writer::backup_file;
+
+/// Official JSON schema for Claude Code `settings.json`.
+pub const CLAUDE_SETTINGS_SCHEMA_URL: &str =
+    "https://json.schemastore.org/claude-code-settings.json";
+
+/// Result of migrating one file's content: `(migrated, changes, notes)`.
+pub type MigrationOutcome = (String, Vec<String>, Vec<String>);
+
+/// Top-level Codex `config.toml` keys that were renamed upstream.
+const CODEX_RENAMED_KEYS: &[(&str, &str)] = &[
+    ("background_terminal_timeout", "background_terminal_max_timeout"),
+    ("experimental_instructions_file", "model_instructions_file"),
+];
+
+/// A planned rewrite of a single configuration file.
+#[derive(Debug, Clone)]
+pub struct FileMigration {
+    /// File the migration applies to.
+    pub path: PathBuf,
+    /// Content currently on disk.
+    pub original: String,
+    /// Content after applying all migration rules.
+    pub migrated: String,
+    /// Human-readable descriptions of the applied rules.
+    pub changes: Vec<String>,
+}
+
+impl FileMigration {
+    /// Whether applying this migration would modify the file.
+    #[must_use]
+    pub fn is_changed(&self) -> bool {
+        self.original != self.migrated
+    }
+}
+
+/// The full set of planned migrations plus advisory notes.
+#[derive(Debug, Clone, Default)]
+pub struct MigrationPlan {
+    /// Per-file migrations (only files with pending changes are included).
+    pub files: Vec<FileMigration>,
+    /// Findings that require manual action and are never auto-applied.
+    pub notes: Vec<String>,
+}
+
+/// Plan migrations for the requested agent (or all agents when `None`).
+///
+/// # Errors
+///
+/// Returns an error if a source file cannot be read or parsed.
+pub fn plan_migration(config_dir: &Path, agent: Option<Agent>) -> Result<MigrationPlan> {
+    let mut plan = MigrationPlan::default();
+
+    match agent {
+        Some(Agent::Claude | Agent::ClaudeCode) => plan_claude(config_dir, &mut plan)?,
+        Some(Agent::Codex) => plan_codex(config_dir, &mut plan)?,
+        Some(Agent::Gemini) => plan
+            .notes
+            .push("No migration rules are defined for Gemini settings yet".to_string()),
+        None => {
+            plan_claude(config_dir, &mut plan)?;
+            plan_codex(config_dir, &mut plan)?;
+        },
+    }
+
+    Ok(plan)
+}
+
+/// Apply a previously computed plan, creating a timestamped backup of every
+/// file before it is rewritten. Returns the created backup paths.
+///
+/// # Errors
+///
+/// Returns an error if a backup cannot be created or a file cannot be
+/// written.
+pub fn apply_migration(plan: &MigrationPlan) -> Result<Vec<String>> {
+    let changed_files = plan.files.iter().filter(|file| file.is_changed()).collect::<Vec<_>>();
+
+    for file in &changed_files {
+        let current = fs::read_to_string(&file.path)
+            .with_context(|| format!("Failed to re-read {}", file.path.display()))?;
+        if current != file.original {
+            anyhow::bail!(
+                "Refusing to overwrite {} because it changed after the migration was planned",
+                file.path.display()
+            );
+        }
+    }
+
+    changed_files
+        .iter()
+        .map(|file| {
+            let backup = backup_file(&file.path)
+                .with_context(|| format!("Failed to back up {}", file.path.display()))?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Refusing to migrate missing file: {}", file.path.display())
+                })?;
+            fs::write(&file.path, &file.migrated)
+                .with_context(|| format!("Failed to write {}", file.path.display()))?;
+            Ok(backup)
+        })
+        .collect()
+}
+
+fn plan_claude(config_dir: &Path, plan: &mut MigrationPlan) -> Result<()> {
+    let preferred = config_dir.join("claude.settings.json");
+    let legacy = config_dir.join("settings.json");
+    let source = if preferred.exists() {
+        if legacy.exists() {
+            plan.notes.push(format!(
+                "Legacy {} also exists; only {} is migrated because sync prefers it",
+                legacy.display(),
+                preferred.display()
+            ));
+        }
+        preferred
+    } else if legacy.exists() {
+        legacy
+    } else {
+        return Ok(());
+    };
+
+    let content = fs::read_to_string(&source)
+        .with_context(|| format!("Failed to read {}", source.display()))?;
+    let (migrated, changes, notes) = migrate_claude_settings_content(&content)
+        .with_context(|| format!("Failed to migrate {}", source.display()))?;
+
+    plan.notes.extend(notes);
+    if migrated != content {
+        plan.files
+            .push(FileMigration { path: source, original: content, migrated, changes });
+    }
+    Ok(())
+}
+
+fn plan_codex(config_dir: &Path, plan: &mut MigrationPlan) -> Result<()> {
+    plan_toml_file(config_dir.join("codex.settings.toml"), migrate_codex_settings_content, plan)?;
+    plan_toml_file(
+        config_dir.join("codex.requirements.toml"),
+        migrate_codex_requirements_content,
+        plan,
+    )
+}
+
+fn plan_toml_file(
+    path: PathBuf,
+    migrate: fn(&str) -> Result<MigrationOutcome>,
+    plan: &mut MigrationPlan,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let content =
+        fs::read_to_string(&path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let (migrated, changes, notes) =
+        migrate(&content).with_context(|| format!("Failed to migrate {}", path.display()))?;
+
+    plan.notes.extend(notes);
+    if migrated != content {
+        plan.files.push(FileMigration { path, original: content, migrated, changes });
+    }
+    Ok(())
+}
+
+/// Migrate Claude settings JSON content.
+///
+/// Rules:
+/// - Replace deprecated `includeCoAuthoredBy` with the `attribution` block.
+/// - Add the official `$schema` reference when missing.
+///
+/// Returns `(migrated, changes, notes)`. When no rule applies, the original
+/// content is returned byte-for-byte so re-runs stay idempotent.
+///
+/// # Errors
+///
+/// Returns an error if the content is not a JSON object.
+pub fn migrate_claude_settings_content(content: &str) -> Result<MigrationOutcome> {
+    let value: Value = serde_json::from_str(content).context("Settings file is not valid JSON")?;
+    let Value::Object(fields) = value else {
+        anyhow::bail!("Settings file must contain a JSON object");
+    };
+
+    let mut changes = Vec::new();
+    let mut notes = Vec::new();
+    let without_flag = migrate_include_co_authored_by(fields, &mut changes, &mut notes);
+    let with_schema = ensure_schema_field(without_flag, &mut changes);
+
+    if changes.is_empty() {
+        return Ok((content.to_string(), changes, notes));
+    }
+
+    let mut rendered = serde_json::to_string_pretty(&Value::Object(with_schema))
+        .context("Failed to render migrated settings")?;
+    rendered.push('\n');
+    Ok((rendered, changes, notes))
+}
+
+fn migrate_include_co_authored_by(
+    fields: Map<String, Value>,
+    changes: &mut Vec<String>,
+    notes: &mut Vec<String>,
+) -> Map<String, Value> {
+    let Some(flag_value) = fields.get("includeCoAuthoredBy") else {
+        return fields;
+    };
+    let Some(flag) = flag_value.as_bool() else {
+        notes.push(
+            "includeCoAuthoredBy has a non-boolean value; migrate it to attribution manually"
+                .to_string(),
+        );
+        return fields;
+    };
+
+    let has_attribution = fields.contains_key("attribution");
+    changes.push(match (has_attribution, flag) {
+        (true, _) => {
+            "removed deprecated includeCoAuthoredBy (attribution is already configured)"
+        },
+        (false, false) => {
+            "replaced includeCoAuthoredBy = false with attribution { \"commit\": \"\", \"pr\": \"\", \"sessionUrl\": false }"
+        },
+        (false, true) => {
+            "removed includeCoAuthoredBy = true (matches the default attribution behavior)"
+        },
+    }.to_string());
+
+    fields
+        .into_iter()
+        .flat_map(|(key, value)| {
+            if key == "includeCoAuthoredBy" {
+                (!has_attribution && !flag)
+                    .then(|| {
+                        (
+                            "attribution".to_string(),
+                            serde_json::json!({ "commit": "", "pr": "", "sessionUrl": false }),
+                        )
+                    })
+                    .into_iter()
+                    .collect::<Vec<_>>()
+            } else {
+                vec![(key, value)]
+            }
+        })
+        .collect()
+}
+
+fn ensure_schema_field(
+    fields: Map<String, Value>,
+    changes: &mut Vec<String>,
+) -> Map<String, Value> {
+    if fields.contains_key("$schema") {
+        return fields;
+    }
+
+    changes.push(format!("added \"$schema\": \"{CLAUDE_SETTINGS_SCHEMA_URL}\""));
+    std::iter::once(("$schema".to_string(), Value::String(CLAUDE_SETTINGS_SCHEMA_URL.to_string())))
+        .chain(fields)
+        .collect()
+}
+
+/// Migrate Codex `config.toml` content, preserving comments and layout.
+///
+/// Rules (documented upstream renames only):
+/// - `background_terminal_timeout` → `background_terminal_max_timeout`
+/// - `experimental_instructions_file` → `model_instructions_file`
+///
+/// `shell_environment_policy.exclude` / `include_only` are intentionally NOT
+/// auto-converted to `filters`: the exact translation semantics are not
+/// documented upstream, so `claudius config validate` only reports them.
+///
+/// # Errors
+///
+/// Returns an error if the content is not valid TOML.
+pub fn migrate_codex_settings_content(content: &str) -> Result<MigrationOutcome> {
+    let mut doc: DocumentMut = content.parse().context("Codex settings file is not valid TOML")?;
+    let mut changes = Vec::new();
+    let mut notes = Vec::new();
+
+    for (old, new) in CODEX_RENAMED_KEYS {
+        rename_top_level_key(&mut doc, old, new, &mut changes, &mut notes);
+    }
+
+    if changes.is_empty() {
+        return Ok((content.to_string(), changes, notes));
+    }
+    Ok((doc.to_string(), changes, notes))
+}
+
+fn rename_top_level_key(
+    doc: &mut DocumentMut,
+    old: &str,
+    new: &str,
+    changes: &mut Vec<String>,
+    notes: &mut Vec<String>,
+) {
+    let table = doc.as_table_mut();
+    if !table.contains_key(old) {
+        return;
+    }
+    if table.contains_key(new) {
+        notes.push(format!("{old} and {new} are both set; remove the deprecated {old} manually"));
+        return;
+    }
+
+    if let Some((key, item)) = table.remove_entry(old) {
+        let mut renamed = Key::new(new);
+        *renamed.leaf_decor_mut() = key.leaf_decor().clone();
+        table.insert_formatted(&renamed, item);
+        changes.push(format!("renamed {old} to {new}"));
+    }
+}
+
+/// Migrate Codex `requirements.toml` content, preserving comments.
+///
+/// Removes the deprecated `"on-failure"` entry from
+/// `allowed_approval_policies`.
+///
+/// # Errors
+///
+/// Returns an error if the content is not valid TOML.
+pub fn migrate_codex_requirements_content(content: &str) -> Result<MigrationOutcome> {
+    let mut doc: DocumentMut =
+        content.parse().context("Codex requirements file is not valid TOML")?;
+    let mut changes = Vec::new();
+    let mut notes = Vec::new();
+
+    if let Some(array) = doc.get_mut("allowed_approval_policies").and_then(Item::as_array_mut) {
+        let before = array.len();
+        let retained = array.iter().filter(|value| value.as_str() != Some("on-failure")).count();
+        if retained == 0 && before > 0 {
+            notes.push(
+                "allowed_approval_policies only contains deprecated \"on-failure\"; choose a replacement policy manually"
+                    .to_string(),
+            );
+        } else {
+            array.retain(|value| value.as_str() != Some("on-failure"));
+        }
+        if array.len() < before {
+            changes.push(
+                "removed deprecated \"on-failure\" from allowed_approval_policies".to_string(),
+            );
+        }
+    }
+
+    if changes.is_empty() {
+        return Ok((content.to_string(), changes, notes));
+    }
+    Ok((doc.to_string(), changes, notes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn migrate_claude(content: &str) -> (String, Vec<String>, Vec<String>) {
+        migrate_claude_settings_content(content).expect("migration should succeed")
+    }
+
+    #[test]
+    fn include_co_authored_by_false_becomes_hiding_attribution() {
+        let content = r#"{
+  "cleanupPeriodDays": 30,
+  "includeCoAuthoredBy": false
+}
+"#;
+        let (migrated, changes, notes) = migrate_claude(content);
+        let value: Value = serde_json::from_str(&migrated).expect("migrated JSON should parse");
+
+        assert_eq!(value.get("includeCoAuthoredBy"), None);
+        assert_eq!(
+            value.get("attribution"),
+            Some(&json!({ "commit": "", "pr": "", "sessionUrl": false }))
+        );
+        assert_eq!(value.get("cleanupPeriodDays"), Some(&json!(30)));
+        assert!(value.get("$schema").is_some());
+        assert_eq!(changes.len(), 2);
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn include_co_authored_by_true_is_dropped_without_attribution() {
+        let (migrated, changes, _) = migrate_claude(r#"{ "includeCoAuthoredBy": true }"#);
+        let value: Value = serde_json::from_str(&migrated).expect("migrated JSON should parse");
+
+        assert_eq!(value.get("includeCoAuthoredBy"), None);
+        assert_eq!(value.get("attribution"), None);
+        assert!(changes.iter().any(|change| change.contains("default attribution")));
+    }
+
+    #[test]
+    fn existing_attribution_wins_over_deprecated_flag() {
+        let content = r#"{
+  "attribution": { "commit": "custom", "pr": "" },
+  "includeCoAuthoredBy": false
+}
+"#;
+        let (migrated, changes, _) = migrate_claude(content);
+        let value: Value = serde_json::from_str(&migrated).expect("migrated JSON should parse");
+
+        assert_eq!(value.get("includeCoAuthoredBy"), None);
+        assert_eq!(value.get("attribution"), Some(&json!({ "commit": "custom", "pr": "" })));
+        assert!(changes.iter().any(|change| change.contains("already configured")));
+    }
+
+    #[test]
+    fn non_boolean_flag_is_left_alone_with_a_note() {
+        let content = r#"{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "includeCoAuthoredBy": "yes"
+}
+"#;
+        let (migrated, changes, notes) = migrate_claude(content);
+
+        assert_eq!(migrated, content);
+        assert!(changes.is_empty());
+        assert_eq!(notes.len(), 1);
+    }
+
+    #[test]
+    fn unknown_fields_and_order_are_preserved() {
+        let content = r#"{
+  "futureSetting": { "nested": [1, 2, 3] },
+  "includeCoAuthoredBy": false,
+  "zebra": true
+}
+"#;
+        let (migrated, _, _) = migrate_claude(content);
+        let value: Value = serde_json::from_str(&migrated).expect("migrated JSON should parse");
+        let keys: Vec<&String> = value.as_object().expect("object").keys().collect();
+
+        assert_eq!(keys, ["$schema", "futureSetting", "attribution", "zebra"]);
+        assert_eq!(value.get("futureSetting"), Some(&json!({ "nested": [1, 2, 3] })));
+    }
+
+    #[test]
+    fn claude_migration_is_idempotent() {
+        let (first, _, _) = migrate_claude(r#"{ "includeCoAuthoredBy": false }"#);
+        let (second, changes, notes) = migrate_claude(&first);
+
+        assert_eq!(first, second);
+        assert!(changes.is_empty());
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn codex_rename_preserves_comments() {
+        let content = "# How long background terminals may run\n\
+                       background_terminal_timeout = 300\n\
+                       \n\
+                       # Unrelated setting\n\
+                       model = \"gpt-5.5\"\n";
+        let (migrated, changes, notes) =
+            migrate_codex_settings_content(content).expect("migration should succeed");
+
+        assert!(migrated.contains("background_terminal_max_timeout = 300"));
+        assert!(!migrated.contains("background_terminal_timeout ="));
+        assert!(migrated.contains("# How long background terminals may run"));
+        assert!(migrated.contains("# Unrelated setting"));
+        assert!(migrated.contains("model = \"gpt-5.5\""));
+        assert_eq!(changes.len(), 1);
+        assert!(notes.is_empty());
+    }
+
+    #[test]
+    fn codex_rename_conflict_is_reported_not_applied() {
+        let content = "background_terminal_timeout = 300\n\
+                       background_terminal_max_timeout = 600\n";
+        let (migrated, changes, notes) =
+            migrate_codex_settings_content(content).expect("migration should succeed");
+
+        assert_eq!(migrated, content);
+        assert!(changes.is_empty());
+        assert_eq!(notes.len(), 1);
+        assert!(
+            notes.first().is_some_and(
+                |note| note.contains("remove the deprecated background_terminal_timeout")
+            )
+        );
+    }
+
+    #[test]
+    fn codex_migration_is_idempotent() {
+        let content = "experimental_instructions_file = \"instructions.md\"\n";
+        let (first, _, _) =
+            migrate_codex_settings_content(content).expect("migration should succeed");
+        let (second, changes, _) =
+            migrate_codex_settings_content(&first).expect("migration should succeed");
+
+        assert_eq!(first, second);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn requirements_on_failure_is_removed_and_comments_survive() {
+        let content = "# Admin approved policies\n\
+                       allowed_approval_policies = [\"untrusted\", \"on-failure\", \"never\"]\n";
+        let (migrated, changes, _) =
+            migrate_codex_requirements_content(content).expect("migration should succeed");
+
+        assert!(migrated.contains("# Admin approved policies"));
+        assert!(!migrated.contains("on-failure"));
+        assert!(migrated.contains("\"untrusted\""));
+        assert!(migrated.contains("\"never\""));
+        assert_eq!(changes.len(), 1);
+    }
+
+    #[test]
+    fn requirements_without_on_failure_are_untouched() {
+        let content = "allowed_approval_policies = [\"untrusted\", \"never\"]\n";
+        let (migrated, changes, _) =
+            migrate_codex_requirements_content(content).expect("migration should succeed");
+
+        assert_eq!(migrated, content);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn requirements_with_only_on_failure_requires_manual_replacement() {
+        let content = "allowed_approval_policies = [\"on-failure\"]\n";
+        let (migrated, changes, notes) =
+            migrate_codex_requirements_content(content).expect("migration should succeed");
+
+        assert_eq!(migrated, content);
+        assert!(changes.is_empty());
+        assert_eq!(notes.len(), 1);
+    }
+
+    #[test]
+    fn apply_refuses_to_overwrite_a_file_changed_after_planning() {
+        let temp_dir = tempfile::TempDir::new().expect("temp directory should be created");
+        let path = temp_dir.path().join("settings.json");
+        fs::write(&path, "original").expect("original file should be written");
+        let plan = MigrationPlan {
+            files: vec![FileMigration {
+                path: path.clone(),
+                original: "original".to_string(),
+                migrated: "migrated".to_string(),
+                changes: vec!["test migration".to_string()],
+            }],
+            notes: Vec::new(),
+        };
+        fs::write(&path, "changed externally").expect("file should be changed");
+
+        let error = apply_migration(&plan).expect_err("stale plan should be rejected");
+        assert!(error.to_string().contains("changed after the migration was planned"));
+        assert_eq!(
+            fs::read_to_string(path).expect("file should remain readable"),
+            "changed externally"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod claude_settings;
 pub mod cli;
 pub mod codex_settings;
 pub mod config;
+pub mod config_migrate;
 pub mod doctor;
 pub mod gemini_settings;
 pub(crate) mod json_merge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,7 @@ fn dispatch_command(command: cli::Commands, app_config: Option<&AppConfig>) -> R
             cli::ConfigCommands::Sync(args) => run_config_sync(args, app_config),
             cli::ConfigCommands::Validate(args) => run_config_validate(args, app_config),
             cli::ConfigCommands::Doctor(args) => run_config_doctor(args),
+            cli::ConfigCommands::Migrate(args) => run_config_migrate(args, app_config),
         },
         cli::Commands::Skills(subcommand) => match subcommand {
             cli::SkillsCommands::Sync(args) => run_sync_skills(args, app_config),
@@ -547,6 +548,50 @@ fn run_config_validate(
     }
 
     Ok(())
+}
+
+fn run_config_migrate(args: cli::ConfigMigrateArgs, _app_config: Option<&AppConfig>) -> Result<()> {
+    let cli::ConfigMigrateArgs { agent, dry_run } = args;
+
+    let config_dir =
+        Config::get_config_dir().context("Failed to determine Claudius config directory")?;
+    let plan = claudius::config_migrate::plan_migration(&config_dir, agent)?;
+
+    for note in &plan.notes {
+        println!("Note: {note}");
+    }
+
+    if plan.files.is_empty() {
+        println!("No deprecated settings found; nothing to migrate");
+        return Ok(());
+    }
+
+    for file in &plan.files {
+        print_file_migration(file, dry_run);
+    }
+
+    if dry_run {
+        println!("Dry run: no files were modified");
+        return Ok(());
+    }
+
+    let backups = claudius::config_migrate::apply_migration(&plan)?;
+    for backup in &backups {
+        println!("Backup created: {backup}");
+    }
+    println!("Migration complete: {} file(s) updated", plan.files.len());
+    Ok(())
+}
+
+fn print_file_migration(file: &claudius::config_migrate::FileMigration, dry_run: bool) {
+    println!("{}:", file.path.display());
+    for change in &file.changes {
+        println!("  - {change}");
+    }
+    if dry_run {
+        let diff = similar::TextDiff::from_lines(&file.original, &file.migrated);
+        print!("{}", diff.unified_diff().context_radius(2).header("current", "migrated"));
+    }
 }
 
 fn collect_config_validation_warnings(

--- a/tests/integration/config_migrate_test.rs
+++ b/tests/integration/config_migrate_test.rs
@@ -1,0 +1,159 @@
+use crate::fixtures::TestFixture;
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serial_test::serial;
+use std::fs;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn migrate_cmd(fixture: &TestFixture, extra_args: &[&str]) -> Command {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "migrate"])
+            .args(extra_args);
+        cmd
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_reports_nothing_for_clean_sources() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_claude_settings(
+                r#"{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": { "commit": "", "pr": "" }
+}
+"#,
+            )
+            .unwrap();
+
+        migrate_cmd(&fixture, &[])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("nothing to migrate"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_dry_run_shows_diff_without_writing() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        let original = r#"{ "includeCoAuthoredBy": false }"#;
+        fixture.with_claude_settings(original).unwrap();
+
+        migrate_cmd(&fixture, &["--dry-run"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("attribution"))
+            .stdout(predicate::str::contains("-{ \"includeCoAuthoredBy\": false }"))
+            .stdout(predicate::str::contains("Dry run: no files were modified"));
+
+        let untouched = fs::read_to_string(fixture.config.join("claude.settings.json")).unwrap();
+        assert_eq!(untouched, original);
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_rewrites_claude_settings_with_backup() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_claude_settings(r#"{ "cleanupPeriodDays": 30, "includeCoAuthoredBy": false }"#)
+            .unwrap();
+
+        migrate_cmd(&fixture, &["--agent", "claude-code"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Backup created:"))
+            .stdout(predicate::str::contains("Migration complete: 1 file(s) updated"));
+
+        let migrated = fs::read_to_string(fixture.config.join("claude.settings.json")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&migrated).unwrap();
+        assert_eq!(value.get("includeCoAuthoredBy"), None);
+        assert_eq!(
+            value.get("attribution"),
+            Some(&serde_json::json!({ "commit": "", "pr": "", "sessionUrl": false }))
+        );
+        assert_eq!(value.get("cleanupPeriodDays"), Some(&serde_json::json!(30)));
+
+        let backups: Vec<_> = fs::read_dir(&fixture.config)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry.file_name().to_string_lossy().starts_with("claude.settings.json.backup.")
+            })
+            .collect();
+        assert_eq!(backups.len(), 1);
+
+        // Second run is idempotent.
+        migrate_cmd(&fixture, &["--agent", "claude-code"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("nothing to migrate"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_codex_preserves_comments() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fixture
+            .with_codex_settings(
+                "# Keep this comment\nbackground_terminal_timeout = 300\nmodel = \"gpt-5.5\"\n",
+            )
+            .unwrap();
+        fs::write(
+            fixture.config.join("codex.requirements.toml"),
+            "# Admin policies\nallowed_approval_policies = [\"untrusted\", \"on-failure\"]\n",
+        )
+        .unwrap();
+
+        migrate_cmd(&fixture, &["--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Migration complete: 2 file(s) updated"));
+
+        let settings = fs::read_to_string(fixture.config.join("codex.settings.toml")).unwrap();
+        assert!(settings.contains("# Keep this comment"));
+        assert!(settings.contains("background_terminal_max_timeout = 300"));
+        assert!(!settings.contains("background_terminal_timeout ="));
+        assert!(settings.contains("model = \"gpt-5.5\""));
+
+        let requirements =
+            fs::read_to_string(fixture.config.join("codex.requirements.toml")).unwrap();
+        assert!(requirements.contains("# Admin policies"));
+        assert!(!requirements.contains("on-failure"));
+        assert!(requirements.contains("\"untrusted\""));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_without_agent_migrates_all_sources() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fs::write(fixture.config.join("config.toml"), "[default]\nagent = \"codex\"\n").unwrap();
+        fixture.with_claude_settings(r#"{ "includeCoAuthoredBy": false }"#).unwrap();
+        fixture.with_codex_settings("background_terminal_timeout = 300\n").unwrap();
+
+        migrate_cmd(&fixture, &[])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Migration complete: 2 file(s) updated"));
+
+        let claude = fs::read_to_string(fixture.config.join("claude.settings.json")).unwrap();
+        assert!(claude.contains("attribution"));
+        let codex = fs::read_to_string(fixture.config.join("codex.settings.toml")).unwrap();
+        assert!(codex.contains("background_terminal_max_timeout"));
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod cli_test;
 mod codex_model_providers_test;
 mod codex_sync_test;
 mod codex_toml_test;
+mod config_migrate_test;
 mod context_test;
 mod doctor_test;
 mod gemini_system_settings_test;


### PR DESCRIPTION
## Summary

- add conservative `claudius config migrate [--agent ...] [--dry-run]`
- migrate documented Claude and Codex deprecations while preserving unknown fields and TOML comments
- create backups before writes, reject stale plans, and provide unified dry-run diffs
- document migration behavior and intentionally leave ambiguous shell filter conversion manual

## Migration rules

- Claude: `includeCoAuthoredBy` to `attribution`, including `sessionUrl = false` when disabling all attribution; add `$schema`
- Codex settings: rename `background_terminal_timeout` and `experimental_instructions_file`
- Codex requirements: remove `on-failure` when another allowed policy remains; require manual selection rather than create an empty allowlist

## Safety

- conflicts are reported rather than overwritten
- files changed after planning are refused
- every changed file is backed up before rewrite
- dry-run is non-destructive and migrations are idempotent
- omitting `--agent` migrates all sources regardless of configured default agent

## Verification

- 465 tests passed, 1 ignored
- Clippy with `-D warnings`
- rustfmt
- smoke-tested dry-run, apply, backups, comments, and idempotent re-run
- pre-commit hooks
