### PR TITLE
feat(config): migrate Codex managed defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `claudius config migrate` now applies documented Codex key renames to managed defaults while leaving ambiguous approval-policy changes for explicit administrator review
+
 ### Changed
 - Raised the minimum supported Rust version and reproducible Nix toolchain to Rust 1.97.1
 - Updated all Cargo dependencies, including `serial_test` 4.0

--- a/README.md
+++ b/README.md
@@ -356,6 +356,14 @@ Current rules:
   - `experimental_instructions_file` → `model_instructions_file`
 - Codex (`codex.requirements.toml`, comments preserved):
   - remove deprecated `"on-failure"` from `allowed_approval_policies`
+- Codex managed defaults (`codex.managed_config.toml` or legacy
+  `managed_config.toml`, comments preserved):
+  - apply the same documented key renames as `codex.settings.toml`
+  - report `approval_policy = "on-failure"` for manual resolution
+
+Legacy `managed_config.toml` content is migrated in place, but the file itself
+is not renamed automatically. Rename it to `codex.managed_config.toml` after
+reviewing the migration.
 
 Deprecated settings without a documented mechanical translation (for example
 `shell_environment_policy.exclude` / `include_only` → `filters`) are reported

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,9 @@ by the agent vendors, and it never touches unknown fields:
       - experimental_instructions_file → model_instructions_file
   • Codex (codex.requirements.toml, comments preserved):
       - remove deprecated \"on-failure\" from allowed_approval_policies
+  • Codex managed defaults (codex.managed_config.toml or legacy managed_config.toml):
+      - apply the same documented key renames as codex.settings.toml
+      - report approval_policy = \"on-failure\" for manual resolution
 
 Deprecated settings without a documented mechanical translation (for
 example shell_environment_policy.exclude / include_only → filters) are

--- a/src/config_migrate.rs
+++ b/src/config_migrate.rs
@@ -154,7 +154,33 @@ fn plan_codex(config_dir: &Path, plan: &mut MigrationPlan) -> Result<()> {
         config_dir.join("codex.requirements.toml"),
         migrate_codex_requirements_content,
         plan,
-    )
+    )?;
+    plan_codex_managed_config(config_dir, plan)
+}
+
+fn plan_codex_managed_config(config_dir: &Path, plan: &mut MigrationPlan) -> Result<()> {
+    let preferred = config_dir.join("codex.managed_config.toml");
+    let legacy = config_dir.join("managed_config.toml");
+    let source = if preferred.exists() {
+        if legacy.exists() {
+            plan.notes.push(format!(
+                "Legacy {} also exists; only {} is migrated because sync prefers it",
+                legacy.display(),
+                preferred.display()
+            ));
+        }
+        preferred
+    } else if legacy.exists() {
+        plan.notes.push(format!(
+            "Using legacy {}; rename it to codex.managed_config.toml manually",
+            legacy.display()
+        ));
+        legacy
+    } else {
+        return Ok(());
+    };
+
+    plan_toml_file(source, migrate_codex_managed_config_content, plan)
 }
 
 fn plan_toml_file(
@@ -288,12 +314,41 @@ fn ensure_schema_field(
 ///
 /// Returns an error if the content is not valid TOML.
 pub fn migrate_codex_settings_content(content: &str) -> Result<MigrationOutcome> {
+    migrate_codex_settings_like_content(content, false)
+}
+
+/// Migrate Codex managed defaults, preserving comments and layout.
+///
+/// Documented key renames are applied mechanically. A deprecated
+/// `approval_policy = "on-failure"` value is only reported because choosing
+/// between `on-request` and `never` requires an administrator decision.
+///
+/// # Errors
+///
+/// Returns an error if the content is not valid TOML.
+pub fn migrate_codex_managed_config_content(content: &str) -> Result<MigrationOutcome> {
+    migrate_codex_settings_like_content(content, true)
+}
+
+fn migrate_codex_settings_like_content(
+    content: &str,
+    report_approval_policy: bool,
+) -> Result<MigrationOutcome> {
     let mut doc: DocumentMut = content.parse().context("Codex settings file is not valid TOML")?;
     let mut changes = Vec::new();
     let mut notes = Vec::new();
 
     for (old, new) in CODEX_RENAMED_KEYS {
         rename_top_level_key(&mut doc, old, new, &mut changes, &mut notes);
+    }
+
+    if report_approval_policy
+        && doc.get("approval_policy").and_then(Item::as_str) == Some("on-failure")
+    {
+        notes.push(
+            "approval_policy = \"on-failure\" requires a manual choice: use \"on-request\" for interactive approvals or \"never\" for non-interactive operation"
+                .to_string(),
+        );
     }
 
     if changes.is_empty() {
@@ -505,6 +560,33 @@ mod tests {
 
         assert_eq!(first, second);
         assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn managed_config_applies_safe_renames_and_reports_approval_policy() {
+        let content = "# Managed defaults\n\
+                       approval_policy = \"on-failure\"\n\
+                       experimental_instructions_file = \"instructions.md\"\n";
+        let (migrated, changes, notes) =
+            migrate_codex_managed_config_content(content).expect("migration should succeed");
+
+        assert!(migrated.contains("# Managed defaults"));
+        assert!(migrated.contains("approval_policy = \"on-failure\""));
+        assert!(migrated.contains("model_instructions_file = \"instructions.md\""));
+        assert!(!migrated.contains("experimental_instructions_file ="));
+        assert_eq!(changes.len(), 1);
+        assert!(notes.iter().any(|note| note.contains("manual choice")));
+    }
+
+    #[test]
+    fn managed_config_does_not_rewrite_approval_policy() {
+        let content = "approval_policy = \"on-failure\"\n";
+        let (migrated, changes, notes) =
+            migrate_codex_managed_config_content(content).expect("migration should succeed");
+
+        assert_eq!(migrated, content);
+        assert!(changes.is_empty());
+        assert_eq!(notes.len(), 1);
     }
 
     #[test]

--- a/tests/integration/config_migrate_test.rs
+++ b/tests/integration/config_migrate_test.rs
@@ -138,6 +138,71 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_config_migrate_codex_managed_config_renames_safe_keys_only() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        fs::write(
+            fixture.config.join("codex.managed_config.toml"),
+            "# Managed defaults\napproval_policy = \"on-failure\"\nbackground_terminal_timeout = 300\n",
+        )
+        .unwrap();
+
+        migrate_cmd(&fixture, &["--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("requires a manual choice"))
+            .stdout(predicate::str::contains("Migration complete: 1 file(s) updated"));
+
+        let managed = fs::read_to_string(fixture.config.join("codex.managed_config.toml")).unwrap();
+        assert!(managed.contains("# Managed defaults"));
+        assert!(managed.contains("approval_policy = \"on-failure\""));
+        assert!(managed.contains("background_terminal_max_timeout = 300"));
+        assert!(!managed.contains("background_terminal_timeout ="));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_codex_legacy_managed_config_is_not_renamed() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+        let legacy = fixture.config.join("managed_config.toml");
+        fs::write(&legacy, "experimental_instructions_file = \"instructions.md\"\n").unwrap();
+
+        migrate_cmd(&fixture, &["--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("rename it to codex.managed_config.toml manually"));
+
+        assert!(legacy.exists());
+        assert!(!fixture.config.join("codex.managed_config.toml").exists());
+        let managed = fs::read_to_string(legacy).unwrap();
+        assert!(managed.contains("model_instructions_file = \"instructions.md\""));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_migrate_prefers_codex_managed_config_over_legacy_source() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+        let preferred = fixture.config.join("codex.managed_config.toml");
+        let legacy = fixture.config.join("managed_config.toml");
+        fs::write(&preferred, "background_terminal_timeout = 300\n").unwrap();
+        fs::write(&legacy, "background_terminal_timeout = 600\n").unwrap();
+
+        migrate_cmd(&fixture, &["--agent", "codex"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("only"))
+            .stdout(predicate::str::contains("is migrated because sync prefers it"));
+
+        let preferred_content = fs::read_to_string(preferred).unwrap();
+        assert!(preferred_content.contains("background_terminal_max_timeout = 300"));
+        assert_eq!(fs::read_to_string(legacy).unwrap(), "background_terminal_timeout = 600\n");
+    }
+
+    #[test]
+    #[serial]
     fn test_config_migrate_without_agent_migrates_all_sources() {
         let fixture = TestFixture::new().unwrap();
         fixture.setup_env();


### PR DESCRIPTION
## Summary

- include `codex.managed_config.toml` in `claudius config migrate`
- apply only documented, semantics-preserving Codex key renames
- preserve `approval_policy = "on-failure"` and report the required administrator choice
- migrate legacy `managed_config.toml` content in place without renaming the file
- prefer `codex.managed_config.toml` when both source names exist

## Safety

The migration remains conservative: ambiguous approval-policy replacement and source-file renaming are advisory only. TOML comments and layout are preserved, and the existing backup/stale-plan protections still apply.

## Verification

- `nix develop --impure --command cargo test` (181 unit + 289 integration passed; 1 ignored)
- `nix develop --impure --command cargo clippy --all-targets --all-features -- -D warnings -A clippy::struct_excessive_bools`
- `nix develop --impure --command cargo fmt -- --check`
- `git diff --check`

`just check` reaches the existing Rust 1.97 `clippy::struct_excessive_bools` findings in three pre-existing structs; this PR does not modify those structures.
