### PR TITLE
feat(validation): add scoped diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `claudius config migrate` now applies documented Codex key renames to managed defaults while leaving ambiguous approval-policy changes for explicit administrator review
+- Configuration validation diagnostics now carry info, warning, or error severity, with documented Claude Code scope checks available through `config validate --scope`
 
 ### Changed
 - Raised the minimum supported Rust version and reproducible Nix toolchain to Rust 1.97.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,18 @@ claudius config sync --global --agent gemini --gemini-system-defaults
 claudius skills sync --agent codex
 ```
 
+### `claudius config validate`
+Validate configuration sources without writing files. Diagnostics use
+`info`, `warning`, and `error` severity; `--strict` fails only on warnings and
+errors. Claude Code scope checks cover only restrictions explicitly documented
+by the vendor.
+
+```bash
+claudius config validate
+claudius config validate --agent claude-code --scope project
+claudius config validate --strict
+```
+
 ### `claudius config migrate`
 Migrate deprecated agent settings in Claudius source files to their documented
 successors. Only transformations with vendor-documented semantics are applied,

--- a/README.md
+++ b/README.md
@@ -299,8 +299,9 @@ claudius config sync --global --agent gemini --gemini-system-defaults
 Validate configuration source files without writing anything.
 
 This command validates MCP servers, agent settings, Gemini custom commands,
-Gemini custom agents, and Claude Code subagent definitions. When Codex skills are
-present, it also surfaces their current compatibility-mode warning.
+Gemini custom agents, and Claude Code subagent definitions. Diagnostics carry
+`info`, `warning`, or `error` severity. `--strict` fails on warnings and errors,
+but informational migration guidance remains non-blocking.
 
 ```bash
 # Validate all available source files
@@ -311,7 +312,10 @@ claudius config validate --agent claude-code
 claudius config validate --agent codex
 claudius config validate --agent gemini
 
-# Fail on warnings
+# Check only vendor-documented Claude Code scope restrictions
+claudius config validate --agent claude-code --scope project
+
+# Fail on warnings and errors (not info)
 claudius config validate --strict
 ```
 

--- a/src/claude_settings.rs
+++ b/src/claude_settings.rs
@@ -1,5 +1,8 @@
 use serde_json::Value;
 
+use crate::app_config::ClaudeCodeScope;
+use crate::validation::Diagnostic;
+
 /// Validate Claude Code settings for known compatibility concerns.
 ///
 /// Unknown fields are intentionally preserved without warnings because Claude Code evolves faster
@@ -18,6 +21,59 @@ pub fn validate_claude_settings(settings: &Value) -> Vec<String> {
         })
         .into_iter()
         .collect()
+}
+
+/// Report settings that Claude Code explicitly documents as ignored outside
+/// particular configuration scopes.
+///
+/// This is intentionally not a complete field catalog. Only documented scope
+/// restrictions are encoded so new upstream settings remain forward-compatible.
+#[must_use]
+pub fn validate_claude_settings_scope(settings: &Value, scope: ClaudeCodeScope) -> Vec<Diagnostic> {
+    let Value::Object(fields) = settings else {
+        return Vec::new();
+    };
+
+    let mut diagnostics = Vec::new();
+    if matches!(scope, ClaudeCodeScope::Project | ClaudeCodeScope::Local) {
+        for field in ["askUserQuestionTimeout", "autoMode"] {
+            if fields.contains_key(field) {
+                diagnostics.push(Diagnostic::warning(format!(
+                    "{field} is ignored by Claude Code in {} scope; move it to user or managed settings",
+                    claude_scope_name(scope),
+                )));
+            }
+        }
+    }
+
+    if scope != ClaudeCodeScope::Managed {
+        for field in [
+            "allowAllClaudeAiMcps",
+            "allowedChannelPlugins",
+            "allowManagedHooksOnly",
+            "allowManagedMcpServersOnly",
+            "allowManagedPermissionRulesOnly",
+            "claudeMd",
+        ] {
+            if fields.contains_key(field) {
+                diagnostics.push(Diagnostic::warning(format!(
+                    "{field} is a managed-only Claude Code setting and is ignored in {} scope",
+                    claude_scope_name(scope),
+                )));
+            }
+        }
+    }
+
+    diagnostics
+}
+
+const fn claude_scope_name(scope: ClaudeCodeScope) -> &'static str {
+    match scope {
+        ClaudeCodeScope::Managed => "managed",
+        ClaudeCodeScope::User => "user",
+        ClaudeCodeScope::Project => "project",
+        ClaudeCodeScope::Local => "local",
+    }
 }
 
 #[cfg(test)]
@@ -58,5 +114,53 @@ mod tests {
     #[test]
     fn future_settings_are_preserved_without_speculative_warnings() {
         assert!(validate_claude_settings(&json!({"futureSetting": true})).is_empty());
+    }
+
+    #[test]
+    fn project_scope_warns_only_for_documented_restrictions() {
+        let diagnostics = validate_claude_settings_scope(
+            &json!({
+                "askUserQuestionTimeout": "5m",
+                "autoMode": {"allow": ["$defaults"]},
+                "futureSetting": true
+            }),
+            ClaudeCodeScope::Project,
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().all(|diagnostic| !diagnostic.contains("futureSetting")));
+    }
+
+    #[test]
+    fn managed_only_setting_warns_in_user_scope() {
+        let diagnostics = validate_claude_settings_scope(
+            &json!({"allowManagedHooksOnly": true}),
+            ClaudeCodeScope::User,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics
+            .first()
+            .is_some_and(|diagnostic| diagnostic.contains("managed-only")));
+    }
+
+    #[test]
+    fn documented_scope_settings_are_allowed_in_managed_scope() {
+        let diagnostics = validate_claude_settings_scope(
+            &json!({"autoMode": {}, "claudeMd": "Follow policy"}),
+            ClaudeCodeScope::Managed,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn mcp_allowlist_is_valid_outside_managed_scope() {
+        let diagnostics = validate_claude_settings_scope(
+            &json!({"allowedMcpServers": [{"serverName": "github"}]}),
+            ClaudeCodeScope::User,
+        );
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,7 +194,8 @@ Examples:
       • agents/claude-code/*.md (optional) - Claude Code subagent definitions
 
 Use --agent to validate a specific agent's settings.
-Use --strict to fail on warnings."
+Use --scope with --agent claude-code to check documented scope restrictions.
+Use --strict to fail on warnings and errors; informational diagnostics do not fail."
     )]
     Validate(ConfigValidateArgs),
 
@@ -523,6 +524,10 @@ pub struct ConfigValidateArgs {
     /// Validate a specific agent (defaults to all available source files)
     #[arg(short, long, value_enum)]
     pub agent: Option<crate::app_config::Agent>,
+
+    /// Validate documented Claude Code scope restrictions
+    #[arg(long, value_enum, requires = "agent")]
+    pub scope: Option<crate::app_config::ClaudeCodeScope>,
 
     /// Treat warnings as errors (exit non-zero)
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn load_and_log_config(log_app_config_warnings: bool) -> Result<Option<AppConfig
         }
 
         if log_app_config_warnings {
-            for warning in claudius::validation::validate_app_config(config).warnings {
+            for warning in claudius::validation::validate_app_config(config).diagnostics {
                 warn!("{warning}");
             }
         }
@@ -525,26 +525,34 @@ fn run_config_validate(
     args: cli::ConfigValidateArgs,
     app_config: Option<&AppConfig>,
 ) -> Result<()> {
-    let cli::ConfigValidateArgs { agent, strict } = args;
+    let cli::ConfigValidateArgs { agent, scope, strict } = args;
     let effective_agent =
         agent.or_else(|| app_config.and_then(|cfg| cfg.default.as_ref()).map(|d| d.agent));
 
+    if scope.is_some() && agent != Some(claudius::app_config::Agent::ClaudeCode) {
+        anyhow::bail!("--scope is only supported with --agent claude-code");
+    }
+
     let config_dir =
         Config::get_config_dir().context("Failed to determine Claudius config directory")?;
-    let warnings = collect_config_validation_warnings(&config_dir, effective_agent, app_config)?;
+    let diagnostics = collect_config_diagnostics(&config_dir, effective_agent, scope, app_config)?;
 
-    if warnings.is_empty() {
+    if diagnostics.is_empty() {
         println!("Configuration validation passed");
         return Ok(());
     }
 
-    println!("Configuration validation warnings ({}):", warnings.len());
-    for warning in &warnings {
-        println!("  - {warning}");
+    println!("Configuration diagnostics ({}):", diagnostics.len());
+    for diagnostic in &diagnostics {
+        println!("  - {diagnostic}");
     }
 
-    if strict {
-        anyhow::bail!("Validation failed due to warnings (--strict)");
+    if strict
+        && diagnostics.iter().any(|diagnostic| {
+            diagnostic.severity >= claudius::validation::DiagnosticSeverity::Warning
+        })
+    {
+        anyhow::bail!("Validation failed due to warnings or errors (--strict)");
     }
 
     Ok(())
@@ -594,20 +602,30 @@ fn print_file_migration(file: &claudius::config_migrate::FileMigration, dry_run:
     }
 }
 
-fn collect_config_validation_warnings(
+fn collect_config_diagnostics(
     config_dir: &std::path::Path,
     effective_agent: Option<claudius::app_config::Agent>,
+    claude_scope: Option<claudius::app_config::ClaudeCodeScope>,
     app_config: Option<&AppConfig>,
-) -> Result<Vec<String>> {
-    let mut warnings = app_config
-        .map(|config| claudius::validation::validate_app_config(config).warnings)
+) -> Result<Vec<claudius::validation::Diagnostic>> {
+    let mut diagnostics = app_config
+        .map(|config| claudius::validation::validate_app_config(config).diagnostics)
         .unwrap_or_default();
 
-    warnings.extend(validate_mcp_server_sources(config_dir)?);
-    warnings.extend(validate_agent_sources(config_dir, effective_agent)?);
-    warnings.extend(skills::validate_claudius_skill_sources(config_dir, effective_agent)?.warnings);
+    diagnostics.extend(
+        validate_mcp_server_sources(config_dir)?
+            .into_iter()
+            .map(claudius::validation::Diagnostic::warning),
+    );
+    diagnostics.extend(validate_agent_sources(config_dir, effective_agent, claude_scope)?);
+    diagnostics.extend(
+        skills::validate_claudius_skill_sources(config_dir, effective_agent)?
+            .warnings
+            .into_iter()
+            .map(claudius::validation::Diagnostic::warning),
+    );
 
-    Ok(warnings)
+    Ok(diagnostics)
 }
 
 fn validate_mcp_server_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
@@ -632,21 +650,26 @@ fn validate_mcp_server_sources(config_dir: &std::path::Path) -> Result<Vec<Strin
 fn validate_agent_sources(
     config_dir: &std::path::Path,
     effective_agent: Option<claudius::app_config::Agent>,
-) -> Result<Vec<String>> {
+    claude_scope: Option<claudius::app_config::ClaudeCodeScope>,
+) -> Result<Vec<claudius::validation::Diagnostic>> {
     use claudius::app_config::Agent;
 
     match effective_agent {
-        Some(Agent::Claude) => validate_claude_settings_sources(config_dir),
-        Some(Agent::ClaudeCode) => validate_claude_code_sources(config_dir),
-        Some(Agent::Codex) => validate_codex_sources(config_dir),
-        Some(Agent::Gemini) => validate_gemini_sources(config_dir),
+        Some(Agent::Claude) => validate_claude_settings_sources(config_dir, None),
+        Some(Agent::ClaudeCode) => validate_claude_code_sources(config_dir, claude_scope),
+        Some(Agent::Codex) => validate_codex_sources(config_dir).map(warning_diagnostics),
+        Some(Agent::Gemini) => validate_gemini_sources(config_dir).map(warning_diagnostics),
         None => {
-            let mut warnings = validate_claude_code_sources(config_dir)?;
-            warnings.extend(validate_codex_sources(config_dir)?);
-            warnings.extend(validate_gemini_sources(config_dir)?);
-            Ok(warnings)
+            let mut diagnostics = validate_claude_code_sources(config_dir, None)?;
+            diagnostics.extend(warning_diagnostics(validate_codex_sources(config_dir)?));
+            diagnostics.extend(warning_diagnostics(validate_gemini_sources(config_dir)?));
+            Ok(diagnostics)
         },
     }
+}
+
+fn warning_diagnostics(warnings: Vec<String>) -> Vec<claudius::validation::Diagnostic> {
+    warnings.into_iter().map(claudius::validation::Diagnostic::warning).collect()
 }
 
 fn run_config_doctor(args: cli::ConfigDoctorArgs) -> Result<()> {
@@ -655,13 +678,19 @@ fn run_config_doctor(args: cli::ConfigDoctorArgs) -> Result<()> {
     Ok(())
 }
 
-fn validate_claude_code_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
-    let mut warnings = validate_claude_settings_sources(config_dir)?;
-    warnings.extend(validate_claude_code_subagent_sources(config_dir)?);
-    Ok(warnings)
+fn validate_claude_code_sources(
+    config_dir: &std::path::Path,
+    scope: Option<claudius::app_config::ClaudeCodeScope>,
+) -> Result<Vec<claudius::validation::Diagnostic>> {
+    let mut diagnostics = validate_claude_settings_sources(config_dir, scope)?;
+    diagnostics.extend(warning_diagnostics(validate_claude_code_subagent_sources(config_dir)?));
+    Ok(diagnostics)
 }
 
-fn validate_claude_settings_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
+fn validate_claude_settings_sources(
+    config_dir: &std::path::Path,
+    scope: Option<claudius::app_config::ClaudeCodeScope>,
+) -> Result<Vec<claudius::validation::Diagnostic>> {
     let claude_settings_path = config_dir.join("claude.settings.json");
     let legacy_settings_path = config_dir.join("settings.json");
 
@@ -682,10 +711,18 @@ fn validate_claude_settings_sources(config_dir: &std::path::Path) -> Result<Vec<
     let json_value: serde_json::Value = serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse JSON from {}", settings_path.display()))?;
 
-    let mut warnings = claudius::validation::validate_claude_settings(&json_value)
+    let mut diagnostics = claudius::validation::validate_claude_settings(&json_value)
         .into_iter()
-        .map(|w| format!("{}: {w}", settings_path.display()))
+        .map(|warning| claudius::validation::Diagnostic::warning(warning).with_path(&settings_path))
         .collect::<Vec<_>>();
+
+    if let Some(claude_scope) = scope {
+        diagnostics.extend(
+            claudius::claude_settings::validate_claude_settings_scope(&json_value, claude_scope)
+                .into_iter()
+                .map(|diagnostic| diagnostic.with_path(&settings_path)),
+        );
+    }
 
     // Ensure Settings struct deserialization succeeds (we preserve unknown fields via `extra`).
     let _: claudius::config::Settings = serde_json::from_value(json_value).with_context(|| {
@@ -694,13 +731,15 @@ fn validate_claude_settings_sources(config_dir: &std::path::Path) -> Result<Vec<
 
     // Legacy settings.json is not agent-specific, so annotate which file was used.
     if settings_path.file_name().and_then(|n| n.to_str()) == Some("settings.json") {
-        warnings.push(format!(
-            "{}: Using legacy settings.json (consider migrating to claude.settings.json)",
-            settings_path.display(),
-        ));
+        diagnostics.push(
+            claudius::validation::Diagnostic::info(
+                "Using legacy settings.json (consider migrating to claude.settings.json)",
+            )
+            .with_path(&settings_path),
+        );
     }
 
-    Ok(warnings)
+    Ok(diagnostics)
 }
 
 fn validate_codex_sources(config_dir: &std::path::Path) -> Result<Vec<String>> {
@@ -830,9 +869,9 @@ fn validate_gemini_command_sources(config_dir: &std::path::Path) -> Result<Vec<S
         let result = claudius::validation::validate_gemini_command_file(&command_file)?;
         warnings.extend(
             result
-                .warnings
+                .diagnostics
                 .into_iter()
-                .map(|warning| format!("{}: {warning}", command_file.display())),
+                .map(|diagnostic| format!("{}: {}", command_file.display(), diagnostic.message)),
         );
     }
 
@@ -849,9 +888,9 @@ fn validate_gemini_agent_sources(config_dir: &std::path::Path) -> Result<Vec<Str
         let result = claudius::validation::validate_gemini_agent_file(&agent_file)?;
         warnings.extend(
             result
-                .warnings
+                .diagnostics
                 .into_iter()
-                .map(|warning| format!("{}: {warning}", agent_file.display())),
+                .map(|diagnostic| format!("{}: {}", agent_file.display(), diagnostic.message)),
         );
     }
 
@@ -868,9 +907,9 @@ fn validate_claude_code_subagent_sources(config_dir: &std::path::Path) -> Result
         let result = claudius::validation::validate_claude_code_subagent_file(&agent_file)?;
         warnings.extend(
             result
-                .warnings
+                .diagnostics
                 .into_iter()
-                .map(|warning| format!("{}: {warning}", agent_file.display())),
+                .map(|diagnostic| format!("{}: {}", agent_file.display(), diagnostic.message)),
         );
     }
 

--- a/src/sync_operations.rs
+++ b/src/sync_operations.rs
@@ -179,11 +179,11 @@ fn read_regular_settings(
     let validation_result =
         pre_validate_settings(settings_path).context("Failed to validate settings file")?;
 
-    // Display warnings
-    if !validation_result.warnings.is_empty() {
-        warn!("Configuration validation warnings:");
-        for warning in &validation_result.warnings {
-            warn!("  - {}", warning);
+    // Display validation diagnostics
+    if !validation_result.diagnostics.is_empty() {
+        warn!("Configuration validation diagnostics:");
+        for diagnostic in &validation_result.diagnostics {
+            warn!("  - {}", diagnostic);
         }
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -15,9 +15,96 @@ static YAML_FRONTMATTER_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
         .expect("frontmatter regex should compile")
 });
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+/// Severity assigned to a configuration diagnostic.
+pub enum DiagnosticSeverity {
+    /// Advisory information that does not fail strict validation.
+    Info,
+    /// A compatibility or behavior concern requiring attention.
+    Warning,
+    /// A configuration problem that cannot be safely ignored.
+    Error,
+}
+
+impl std::fmt::Display for DiagnosticSeverity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Info => "info",
+            Self::Warning => "warning",
+            Self::Error => "error",
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Structured finding emitted while validating configuration.
+pub struct Diagnostic {
+    /// Finding severity.
+    pub severity: DiagnosticSeverity,
+    /// Human-readable explanation and remediation guidance.
+    pub message: String,
+    /// Source file associated with the finding, when available.
+    pub path: Option<std::path::PathBuf>,
+}
+
+impl Diagnostic {
+    #[must_use]
+    /// Create an informational diagnostic.
+    pub fn info(message: impl Into<String>) -> Self {
+        Self { severity: DiagnosticSeverity::Info, message: message.into(), path: None }
+    }
+
+    #[must_use]
+    /// Create a warning diagnostic.
+    pub fn warning(message: impl Into<String>) -> Self {
+        Self { severity: DiagnosticSeverity::Warning, message: message.into(), path: None }
+    }
+
+    #[must_use]
+    /// Create an error diagnostic.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self { severity: DiagnosticSeverity::Error, message: message.into(), path: None }
+    }
+
+    #[must_use]
+    /// Associate this diagnostic with a source path.
+    pub fn with_path(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    #[must_use]
+    /// Return whether the message contains the supplied text.
+    pub fn contains(&self, pattern: &str) -> bool {
+        self.message.contains(pattern)
+    }
+}
+
+impl std::fmt::Display for Diagnostic {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "[{}] ", self.severity)?;
+        if let Some(path) = &self.path {
+            write!(formatter, "{}: ", path.display())?;
+        }
+        formatter.write_str(&self.message)
+    }
+}
+
+#[derive(Debug, Default)]
+/// Diagnostics produced by one validation operation.
 pub struct ValidationResult {
-    pub warnings: Vec<String>,
+    /// Structured findings in discovery order.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl ValidationResult {
+    #[must_use]
+    /// Return whether strict validation should fail.
+    pub fn has_actionable_diagnostics(&self) -> bool {
+        self.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity >= DiagnosticSeverity::Warning)
+    }
 }
 
 /// Identifies the settings schema used for semantic JSON validation.
@@ -54,7 +141,7 @@ pub fn validate_app_config(config: &AppConfig) -> ValidationResult {
         }
     }
 
-    ValidationResult { warnings }
+    ValidationResult { diagnostics: warnings.into_iter().map(Diagnostic::warning).collect() }
 }
 
 #[derive(Debug, Deserialize)]
@@ -122,7 +209,10 @@ fn parse_and_validate_json_file<P: AsRef<Path>>(
         None => Vec::new(),
     };
 
-    Ok((json_value, ValidationResult { warnings }))
+    Ok((
+        json_value,
+        ValidationResult { diagnostics: warnings.into_iter().map(Diagnostic::warning).collect() },
+    ))
 }
 
 fn infer_json_config_kind(path: &Path) -> Option<JsonConfigKind> {
@@ -154,7 +244,7 @@ pub fn pre_validate_settings<P: AsRef<Path>>(path: P) -> Result<ValidationResult
 
     if !path_ref.exists() {
         // If file doesn't exist, that's fine - no validation needed
-        return Ok(ValidationResult { warnings: Vec::new() });
+        return Ok(ValidationResult::default());
     }
 
     let (_, validation_result) = validate_json_file_as(path_ref, JsonConfigKind::Claude)?;
@@ -175,7 +265,7 @@ pub fn validate_and_parse_settings<P: AsRef<Path>>(
     let path_ref = path.as_ref();
 
     if !path_ref.exists() {
-        return Ok((None, ValidationResult { warnings: Vec::new() }));
+        return Ok((None, ValidationResult::default()));
     }
 
     let (json_value, validation_result) = validate_json_file_as(path_ref, JsonConfigKind::Claude)?;
@@ -201,7 +291,7 @@ pub fn validate_and_parse_gemini_settings<P: AsRef<Path>>(
     let path_ref = path.as_ref();
 
     if !path_ref.exists() {
-        return Ok((None, ValidationResult { warnings: Vec::new() }));
+        return Ok((None, ValidationResult::default()));
     }
 
     let (json_value, validation_result) = validate_json_file_as(path_ref, JsonConfigKind::Gemini)?;
@@ -242,7 +332,7 @@ pub fn validate_gemini_command_file<P: AsRef<Path>>(path: P) -> Result<Validatio
         warnings.push("Optional field 'description' should not be empty when present".to_string());
     }
 
-    Ok(ValidationResult { warnings })
+    Ok(ValidationResult { diagnostics: warnings.into_iter().map(Diagnostic::warning).collect() })
 }
 
 /// Validates a Claude Code subagent definition file.
@@ -333,7 +423,7 @@ fn validate_markdown_agent_metadata(
         warnings.push("Agent Markdown body should not be empty".to_string());
     }
 
-    ValidationResult { warnings }
+    ValidationResult { diagnostics: warnings.into_iter().map(Diagnostic::warning).collect() }
 }
 
 /// Prompt user to continue after a warning
@@ -367,6 +457,25 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    fn diagnostic_display_includes_severity_and_path() {
+        let diagnostic = Diagnostic::warning("setting is deprecated").with_path("settings.json");
+
+        assert_eq!(diagnostic.to_string(), "[warning] settings.json: setting is deprecated");
+    }
+
+    #[test]
+    fn only_warning_and_error_diagnostics_are_actionable() {
+        let info = ValidationResult { diagnostics: vec![Diagnostic::info("migration available")] };
+        let warning =
+            ValidationResult { diagnostics: vec![Diagnostic::warning("setting is ignored")] };
+        let error = ValidationResult { diagnostics: vec![Diagnostic::error("invalid setting")] };
+
+        assert!(!info.has_actionable_diagnostics());
+        assert!(warning.has_actionable_diagnostics());
+        assert!(error.has_actionable_diagnostics());
+    }
+
+    #[test]
     fn test_validate_app_config_warns_when_onepassword_subtable_is_ignored() {
         let config = AppConfig {
             secret_manager: Some(SecretManagerConfig {
@@ -381,9 +490,9 @@ mod tests {
         };
 
         let result = validate_app_config(&config);
-        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(result.diagnostics.len(), 1);
         assert!(result
-            .warnings
+            .diagnostics
             .first()
             .is_some_and(|warning| warning.contains("[secret-manager.onepassword]")));
     }
@@ -403,7 +512,7 @@ mod tests {
         };
 
         let result = validate_app_config(&config);
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -415,8 +524,11 @@ mod tests {
         };
 
         let result = validate_app_config(&config);
-        assert_eq!(result.warnings.len(), 1);
-        assert!(result.warnings.first().is_some_and(|warning| warning.contains(".codex/skills")));
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result
+            .diagnostics
+            .first()
+            .is_some_and(|warning| warning.contains(".codex/skills")));
     }
 
     #[test]
@@ -487,7 +599,7 @@ mod tests {
         let (value, result) = validate_json_file_as(&file_path, JsonConfigKind::Claude)
             .expect("Failed to validate JSON file");
         assert_eq!(value.get("apiKeyHelper"), Some(&serde_json::json!("/bin/helper")));
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -544,7 +656,7 @@ mod tests {
         fs::write(&file_path, content.to_string()).expect("Failed to write file");
 
         let (_, result) = validate_json_file(&file_path).expect("Failed to validate JSON file");
-        assert!(result.warnings.is_empty()); // Unknown file types don't validate
+        assert!(result.diagnostics.is_empty()); // Unknown file types don't validate
     }
 
     #[test]
@@ -558,13 +670,13 @@ mod tests {
             .expect("Failed to write file");
 
         let (_, result) = validate_json_file(&file_path).expect("Failed to validate JSON file");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
 
         let (_, claude_result) = validate_json_file_as(&file_path, JsonConfigKind::Claude)
             .expect("Failed to validate Claude JSON file");
-        assert_eq!(claude_result.warnings.len(), 1);
+        assert_eq!(claude_result.diagnostics.len(), 1);
         assert!(claude_result
-            .warnings
+            .diagnostics
             .first()
             .is_some_and(|warning| warning.contains("attribution")));
     }
@@ -573,7 +685,7 @@ mod tests {
     fn test_pre_validate_settings_missing_file() {
         let result = pre_validate_settings("/nonexistent/settings.json")
             .expect("Failed to pre-validate settings");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -588,7 +700,7 @@ mod tests {
         fs::write(&file_path, content.to_string()).expect("Failed to write file");
 
         let result = pre_validate_settings(&file_path).expect("Failed to pre-validate settings");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -603,7 +715,7 @@ mod tests {
         fs::write(&file_path, content.to_string()).expect("Failed to write file");
 
         let result = pre_validate_settings(&file_path).expect("Failed to pre-validate settings");
-        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(result.diagnostics.len(), 1);
     }
 
     #[test]
@@ -611,7 +723,7 @@ mod tests {
         let (settings, result) = validate_and_parse_settings("/nonexistent/settings.json")
             .expect("Failed to validate and parse settings");
         assert!(settings.is_none());
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -634,8 +746,11 @@ mod tests {
         assert_eq!(settings.api_key_helper, Some("/bin/helper".to_string()));
         assert_eq!(settings.cleanup_period_days, Some(30));
         assert_eq!(settings.include_co_authored_by, Some(true));
-        assert_eq!(result.warnings.len(), 1);
-        assert!(result.warnings.first().is_some_and(|warning| warning.contains("attribution")));
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result
+            .diagnostics
+            .first()
+            .is_some_and(|warning| warning.contains("attribution")));
     }
 
     #[test]
@@ -658,7 +773,7 @@ mod tests {
         let (settings, result) = validate_and_parse_gemini_settings("/nonexistent/gemini.json")
             .expect("Failed to validate and parse gemini settings");
         assert!(settings.is_none());
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -696,7 +811,7 @@ mod tests {
 
         let (settings_opt, result) = validate_and_parse_gemini_settings(&file_path)
             .expect("Failed to validate and parse gemini settings");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
 
         let settings = settings_opt.expect("Settings should be present");
         assert_eq!(
@@ -725,7 +840,7 @@ mod tests {
 
         let result =
             validate_gemini_command_file(&file_path).expect("Gemini command should validate");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -754,7 +869,7 @@ mod tests {
 
         let result = validate_claude_code_subagent_file(&file_path)
             .expect("Claude Code subagent should validate");
-        assert!(result.warnings.is_empty());
+        assert!(result.diagnostics.is_empty());
     }
 
     #[test]
@@ -779,9 +894,9 @@ mod tests {
 
         let result = validate_claude_code_subagent_file(&file_path)
             .expect("Subagent with empty body should still parse");
-        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(result.diagnostics.len(), 1);
         assert!(result
-            .warnings
+            .diagnostics
             .first()
             .is_some_and(|warning| warning.contains("Markdown body should not be empty")));
     }

--- a/tests/integration/validate_test.rs
+++ b/tests/integration/validate_test.rs
@@ -104,7 +104,9 @@ mod tests {
             .stdout(predicate::str::contains(
                 "Legacy shared skill `shared-review` contains Claude-specific metadata that will be dropped when rendering for Codex.",
             ))
-            .stderr(predicate::str::contains("Validation failed due to warnings (--strict)"));
+            .stderr(predicate::str::contains(
+                "Validation failed due to warnings or errors (--strict)",
+            ));
     }
 
     #[test]
@@ -323,7 +325,9 @@ mod tests {
             .stdout(predicate::str::contains(
                 "mcpServers.aws-docs.autoApprove is not supported by Gemini settings.json; Gemini sync will translate it to `trust`",
             ))
-            .stderr(predicate::str::contains("Validation failed due to warnings (--strict)"));
+            .stderr(predicate::str::contains(
+                "Validation failed due to warnings or errors (--strict)",
+            ));
     }
 
     #[test]
@@ -459,5 +463,89 @@ mode = "service-account"
             .stdout(predicate::str::contains("[secret-manager.onepassword]"))
             .stderr(predicate::str::contains("Validation failed due to warnings"))
             .stderr(predicate::str::contains("[secret-manager.onepassword]").not());
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_reports_documented_claude_scope_mismatch() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_claude_settings(
+                r#"{
+  "askUserQuestionTimeout": "5m",
+  "allowManagedHooksOnly": true,
+  "futureSetting": true
+}"#,
+            )
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "claude-code", "--scope", "project"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("[warning]"))
+            .stdout(predicate::str::contains("askUserQuestionTimeout is ignored"))
+            .stdout(predicate::str::contains("allowManagedHooksOnly is a managed-only"))
+            .stdout(predicate::str::contains("futureSetting").not());
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_allows_mcp_allowlist_in_user_scope() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fixture
+            .with_claude_settings(r#"{"allowedMcpServers": [{"serverName": "github"}]}"#)
+            .unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "claude-code", "--scope", "user", "--strict"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Configuration validation passed"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_strict_does_not_fail_on_info() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+        fixture.with_mcp_servers(r#"{"mcpServers": {}}"#).unwrap();
+        fs::write(fixture.config.join("settings.json"), r#"{"cleanupPeriodDays": 30}"#).unwrap();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "claude-code", "--strict"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("[info]"))
+            .stdout(predicate::str::contains("Using legacy settings.json"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_config_validate_rejects_scope_for_non_claude_agent() {
+        let fixture = TestFixture::new().unwrap();
+        fixture.setup_env();
+
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_claudius"));
+        cmd.current_dir(&fixture.project)
+            .env("XDG_CONFIG_HOME", fixture.config_home())
+            .env("HOME", fixture.home_dir())
+            .args(["config", "validate", "--agent", "codex", "--scope", "user"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--scope is only supported with --agent claude-code"));
     }
 }

--- a/tests/unit/settings_sync_test.rs
+++ b/tests/unit/settings_sync_test.rs
@@ -36,7 +36,7 @@ mod tests {
         let (settings, validation_result) = validate_and_parse_settings(&settings_file).unwrap();
 
         assert!(settings.is_some());
-        assert!(validation_result.warnings.is_empty());
+        assert!(validation_result.diagnostics.is_empty());
 
         let settings_data = settings.unwrap();
         assert_eq!(settings_data.api_key_helper, Some("/path/to/helper".to_string()));
@@ -63,7 +63,7 @@ mod tests {
             validate_json_file_as(&settings_file, JsonConfigKind::Claude).unwrap();
 
         // Future fields must be preserved without speculative warnings.
-        assert!(validation_result.warnings.is_empty());
+        assert!(validation_result.diagnostics.is_empty());
 
         // But the JSON should still be parsed
         assert!(json_value.get("unknownField").is_some());
@@ -106,7 +106,7 @@ mod tests {
             validate_and_parse_gemini_settings(&settings_file).unwrap();
 
         assert!(settings.is_some());
-        assert!(validation_result.warnings.is_empty());
+        assert!(validation_result.diagnostics.is_empty());
 
         let settings_data = settings.unwrap();
         assert_eq!(
@@ -153,10 +153,13 @@ mod tests {
             validate_json_file_as(&settings_file, JsonConfigKind::Gemini).unwrap();
 
         // Should have warnings about unknown fields
-        assert_eq!(validation_result.warnings.len(), 3);
-        assert!(validation_result.warnings.iter().any(|w| w.contains("unknownSetting")));
-        assert!(validation_result.warnings.iter().any(|w| w.contains("unknownMcpField")));
-        assert!(validation_result.warnings.iter().any(|w| w.contains("unknownTelemetryField")));
+        assert_eq!(validation_result.diagnostics.len(), 3);
+        assert!(validation_result.diagnostics.iter().any(|w| w.contains("unknownSetting")));
+        assert!(validation_result.diagnostics.iter().any(|w| w.contains("unknownMcpField")));
+        assert!(validation_result
+            .diagnostics
+            .iter()
+            .any(|w| w.contains("unknownTelemetryField")));
 
         // Unknown fields should still be preserved in the JSON
         assert!(json_value.get("unknownSetting").is_some());
@@ -190,7 +193,7 @@ mod tests {
         assert!(settings_data.extra.contains_key("experimentalFlag"));
 
         // Should have warnings about unknown fields
-        assert_eq!(validation_result.warnings.len(), 2);
+        assert_eq!(validation_result.diagnostics.len(), 2);
     }
 
     #[test]
@@ -201,7 +204,7 @@ mod tests {
         // Should return None without error for nonexistent files
         let (settings, validation_result) = validate_and_parse_settings(&settings_file).unwrap();
         assert!(settings.is_none());
-        assert!(validation_result.warnings.is_empty());
+        assert!(validation_result.diagnostics.is_empty());
     }
 
     #[test]
@@ -214,7 +217,7 @@ mod tests {
         let (settings, validation_result) = validate_and_parse_settings(&settings_file).unwrap();
 
         assert!(settings.is_some());
-        assert!(validation_result.warnings.is_empty());
+        assert!(validation_result.diagnostics.is_empty());
 
         // All fields should be None
         let settings_data = settings.unwrap();


### PR DESCRIPTION
## Summary

- replace string-only `ValidationResult.warnings` with structured diagnostics containing severity, message, and optional source path
- render diagnostics as `info`, `warning`, or `error`
- make `config validate --strict` fail on warnings and errors while leaving informational migration guidance non-blocking
- add `config validate --agent claude-code --scope <scope>`
- detect only Claude Code scope restrictions explicitly documented upstream
- preserve forward compatibility by continuing to ignore unknown settings

## Scope policy

The scope checks intentionally avoid a general field whitelist. They cover documented ignored/managed-only settings such as `askUserQuestionTimeout`, `autoMode`, `claudeMd`, and managed MCP/hook policy fields. Unknown and newly introduced fields remain losslessly accepted.

## Verification

- `nix develop --impure --command cargo test` (186 unit + 292 integration passed; 1 ignored)
- `nix develop --impure --command cargo clippy --all-targets --all-features -- -D warnings -A clippy::struct_excessive_bools`
- `nix develop --impure --command cargo fmt -- --check`
- `git diff --check`

The Clippy allowance is limited to three pre-existing structs affected by Rust 1.97's `struct_excessive_bools` lint and is unrelated to this change.
