### PR TITLE
fix(config): make migrations atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raised the minimum supported Rust version and reproducible Nix toolchain to Rust 1.97.1
 - Updated all Cargo dependencies, including `serial_test` 4.0
 - CPU profiling now writes pprof-compatible protobuf reports instead of SVG flamegraphs, removing a vulnerable transitive XML parser while preserving portable profile analysis
+- Configuration migrations now use same-directory atomic replacement, preserve file modes and source symlinks, and never overwrite an existing timestamped backup
 
 ## [0.2.4] - 2026-05-06
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,8 +270,9 @@ claudius config validate --strict
 Migrate deprecated agent settings in Claudius source files to their documented
 successors. Only transformations with vendor-documented semantics are applied,
 unknown fields are never touched, and re-running on migrated files reports
-nothing to do. A timestamped backup is created before every rewrite; TOML
-comments are preserved.
+nothing to do. A collision-safe timestamped backup is created before every
+atomic rewrite; file permissions, source symlinks, and TOML comments are
+preserved.
 
 Current rules: `includeCoAuthoredBy` → `attribution` and `$schema` addition for
 Claude settings; `background_terminal_timeout` → `background_terminal_max_timeout`

--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ Deprecated settings without a documented mechanical translation (for example
 `shell_environment_policy.exclude` / `include_only` → `filters`) are reported
 by `claudius config validate` but never rewritten automatically.
 
-A timestamped backup is created next to every file before it is rewritten.
+A collision-safe timestamped backup is created next to every file before an
+atomic replacement. File permissions and source symlinks are preserved.
 
 ```bash
 # Preview all pending migrations as unified diffs

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -240,9 +240,9 @@ Deprecated settings without a documented mechanical translation (for
 example shell_environment_policy.exclude / include_only → filters) are
 reported by `claudius config validate` but never rewritten.
 
-A timestamped backup is created next to every file before it is
-rewritten. Re-running the command on migrated files reports nothing to
-do.
+A collision-safe timestamped backup is created next to every file before
+it is atomically replaced with its original permissions preserved.
+Re-running the command on migrated files reports nothing to do.
 
 Examples:
   # Preview all pending migrations as unified diffs

--- a/src/config/writer.rs
+++ b/src/config/writer.rs
@@ -1,8 +1,10 @@
 use super::{ClaudeConfig, McpServersConfig, Settings};
 use crate::codex_settings::CodexSettings;
+use anyhow::Context;
 use chrono::Local;
-use std::fs;
-use std::path::Path;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 
 /// Write Claude configuration to a JSON file
 ///
@@ -39,15 +41,100 @@ pub fn backup_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Option<String>> {
     }
 
     let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-    let backup_path = path_ref.with_file_name(format!(
-        "{}.backup.{}",
-        path_ref.file_name().and_then(|n| n.to_str()).unwrap_or("claude.json"),
-        timestamp
-    ));
+    let file_name = path_ref.file_name().and_then(|name| name.to_str()).unwrap_or("claude.json");
+    let source_metadata = fs::metadata(path_ref)?;
 
-    fs::copy(path_ref, &backup_path)?;
+    let mut suffix = 0_u64;
+    loop {
+        let backup_path = backup_path(path_ref, file_name, &timestamp.to_string(), suffix);
+        match OpenOptions::new().write(true).create_new(true).open(&backup_path) {
+            Ok(mut backup) => {
+                let backup_result = (|| -> anyhow::Result<()> {
+                    let mut source = fs::File::open(path_ref)?;
+                    io::copy(&mut source, &mut backup)?;
+                    backup.flush()?;
+                    backup.set_permissions(source_metadata.permissions())?;
+                    backup.sync_all()?;
+                    Ok(())
+                })();
+                if let Err(error) = backup_result {
+                    drop(backup);
+                    let _ = fs::remove_file(&backup_path);
+                    return Err(error);
+                }
+                return Ok(Some(backup_path.to_string_lossy().to_string()));
+            },
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                suffix = suffix.checked_add(1).ok_or_else(|| {
+                    anyhow::anyhow!("Exhausted backup names for {}", path_ref.display())
+                })?;
+            },
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
 
-    Ok(Some(backup_path.to_string_lossy().to_string()))
+fn backup_path(path: &Path, file_name: &str, timestamp: &str, suffix: u64) -> PathBuf {
+    let suffix_text = if suffix > 0 { format!(".{suffix}") } else { String::new() };
+    path.with_file_name(format!("{file_name}.backup.{timestamp}{suffix_text}"))
+}
+
+/// Atomically replace a file while preserving its permissions.
+///
+/// The temporary file is created beside the destination to keep the final
+/// rename on the same filesystem. If `path` is a symlink, its resolved target
+/// is replaced so the symlink itself remains intact.
+///
+/// # Errors
+///
+/// Returns an error if metadata cannot be read, the temporary file cannot be
+/// written or synchronized, permissions cannot be copied, or the atomic
+/// replacement fails.
+pub fn atomic_write_preserving_permissions(path: &Path, content: &[u8]) -> anyhow::Result<()> {
+    let destination = resolve_write_destination(path)?;
+    let metadata = fs::metadata(&destination)
+        .with_context(|| format!("Failed to read metadata for {}", destination.display()))?;
+    let parent = destination.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Cannot atomically replace path without a parent: {}",
+            destination.display()
+        )
+    })?;
+
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("Failed to create temporary file in {}", parent.display()))?;
+    temporary.write_all(content)?;
+    temporary.flush()?;
+    temporary.as_file().set_permissions(metadata.permissions())?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(&destination)
+        .map_err(|error| error.error)
+        .with_context(|| format!("Failed to atomically replace {}", destination.display()))?;
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+fn resolve_write_destination(path: &Path) -> anyhow::Result<PathBuf> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        fs::canonicalize(path)
+            .with_context(|| format!("Failed to resolve symlink {}", path.display()))
+    } else {
+        Ok(path.to_path_buf())
+    }
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(parent: &Path) -> anyhow::Result<()> {
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_parent: &Path) -> anyhow::Result<()> {
+    Ok(())
 }
 
 /// Write MCP servers configuration to a JSON file
@@ -260,6 +347,72 @@ mod tests {
         let timestamp = parts.last().expect("Parts should have last element");
         assert_eq!(timestamp.len(), 15); // YYYYMMDD_HHMMSS
         assert_eq!(timestamp.chars().nth(8).expect("Timestamp should have 9th character"), '_');
+    }
+
+    #[test]
+    fn test_backup_file_never_overwrites_an_existing_backup() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let file_path = temp_dir.path().join("test.json");
+        fs::write(&file_path, "first version").expect("Failed to write first version");
+        let first = backup_file(&file_path)
+            .expect("First backup should succeed")
+            .expect("First backup should exist");
+
+        fs::write(&file_path, "second version").expect("Failed to write second version");
+        let second = backup_file(&file_path)
+            .expect("Second backup should succeed")
+            .expect("Second backup should exist");
+
+        assert_ne!(first, second);
+        assert_eq!(
+            fs::read_to_string(first).expect("First backup should be readable"),
+            "first version"
+        );
+        assert_eq!(
+            fs::read_to_string(second).expect("Second backup should be readable"),
+            "second version"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let file_path = temp_dir.path().join("settings.json");
+        fs::write(&file_path, "old").expect("Failed to write original file");
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o640))
+            .expect("Failed to set original mode");
+
+        atomic_write_preserving_permissions(&file_path, b"new")
+            .expect("Atomic write should succeed");
+
+        assert_eq!(fs::read_to_string(&file_path).expect("File should be readable"), "new");
+        assert_eq!(
+            fs::metadata(file_path).expect("Metadata should load").permissions().mode() & 0o777,
+            0o640
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_preserves_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+        let target = temp_dir.path().join("source.json");
+        let link = temp_dir.path().join("settings.json");
+        fs::write(&target, "old").expect("Failed to write symlink target");
+        symlink(&target, &link).expect("Failed to create symlink");
+
+        atomic_write_preserving_permissions(&link, b"new").expect("Atomic write should succeed");
+
+        assert!(fs::symlink_metadata(&link)
+            .expect("Symlink metadata should load")
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read_to_string(target).expect("Target should be readable"), "new");
     }
 
     #[test]

--- a/src/config_migrate.rs
+++ b/src/config_migrate.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item, Key};
 
 use crate::app_config::Agent;
-use crate::config::writer::backup_file;
+use crate::config::writer::{atomic_write_preserving_permissions, backup_file};
 
 /// Official JSON schema for Claude Code `settings.json`.
 pub const CLAUDE_SETTINGS_SCHEMA_URL: &str =
@@ -81,8 +81,8 @@ pub fn plan_migration(config_dir: &Path, agent: Option<Agent>) -> Result<Migrati
     Ok(plan)
 }
 
-/// Apply a previously computed plan, creating a timestamped backup of every
-/// file before it is rewritten. Returns the created backup paths.
+/// Apply a previously computed plan, creating a collision-safe timestamped
+/// backup before atomically replacing each file. Returns the backup paths.
 ///
 /// # Errors
 ///
@@ -110,7 +110,7 @@ pub fn apply_migration(plan: &MigrationPlan) -> Result<Vec<String>> {
                 .ok_or_else(|| {
                     anyhow::anyhow!("Refusing to migrate missing file: {}", file.path.display())
                 })?;
-            fs::write(&file.path, &file.migrated)
+            atomic_write_preserving_permissions(&file.path, file.migrated.as_bytes())
                 .with_context(|| format!("Failed to write {}", file.path.display()))?;
             Ok(backup)
         })
@@ -645,6 +645,35 @@ mod tests {
         assert_eq!(
             fs::read_to_string(path).expect("file should remain readable"),
             "changed externally"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_migration_preserves_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::TempDir::new().expect("temp directory should be created");
+        let path = temp_dir.path().join("settings.json");
+        fs::write(&path, "original").expect("original file should be written");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o640))
+            .expect("file mode should be set");
+        let plan = MigrationPlan {
+            files: vec![FileMigration {
+                path: path.clone(),
+                original: "original".to_string(),
+                migrated: "migrated".to_string(),
+                changes: vec!["test migration".to_string()],
+            }],
+            notes: Vec::new(),
+        };
+
+        apply_migration(&plan).expect("migration should succeed");
+
+        assert_eq!(fs::read_to_string(&path).expect("file should be readable"), "migrated");
+        assert_eq!(
+            fs::metadata(path).expect("metadata should load").permissions().mode() & 0o777,
+            0o640
         );
     }
 }


### PR DESCRIPTION
## Summary

- replace migrated configuration files atomically through same-directory temporary files
- preserve existing file modes and source symlinks during migration
- allocate collision-safe timestamped backups without overwriting earlier backups
- document the stronger migration safety guarantees

## Safety properties

- temporary files are created on the destination filesystem to avoid cross-device renames
- file contents and metadata are synchronized before replacement
- the parent directory is synchronized after replacement on Unix
- partial backups are removed if backup creation fails

## Verification

- `nix develop --impure --command cargo fmt -- --check`
- `nix develop --impure --command cargo clippy --all-targets --all-features -- -D warnings -A clippy::struct_excessive_bools`
- `nix develop --impure --command cargo test`
- `nix develop --impure --command cargo test config::writer`
- `git diff --check`

Full suite: 191 unit tests and 293 integration tests passed; 1 integration test ignored.
